### PR TITLE
feat(home): pantalla de inicio pública con partidos y navegación por rol

### DIFF
--- a/apps/backend/src/services/authService.ts
+++ b/apps/backend/src/services/authService.ts
@@ -31,6 +31,15 @@ import { emailService } from './emailService.js';
 
 const PROFILE_ROLE_COLUMNS = 'role';
 
+/**
+ * Resolve display name from Supabase User object
+ * Priority: user_metadata.displayName > email
+ */
+function resolveDisplayName(user: User): string {
+  const displayName = user.user_metadata?.displayName ?? user.email ?? 'Usuario';
+  return displayName;
+}
+
 export type AuthUserRole = 'player' | 'club_admin';
 
 export interface AuthenticatedUser {

--- a/apps/frontend/src/components/home/HomeScreen.tsx
+++ b/apps/frontend/src/components/home/HomeScreen.tsx
@@ -1,0 +1,272 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Users, Trophy, MapPin, Zap, Shield, ArrowRight } from 'lucide-react';
+import { MatchList } from '@/components/matches';
+
+/**
+ * HomeScreen Component
+ *
+ * Decision Context:
+ * - Why: Primary entry point for the platform, designed to convert visitors and
+ *   welcome authenticated users. Stadium-grade aesthetic matching the FIFA World
+ *   Cup design system.
+ * - Approach: Bebas Neue for all display headings (design system requirement).
+ *   Staggered CSS keyframe entrance animations for hero content — no JS library
+ *   dependency keeps initial render fast. Glass morphism stat cards leverage the
+ *   `--color-surface-glass` and `--color-surface-border` design tokens.
+ * - Sections: Hero (animated) → Partidos Disponibles (MatchList + filters, public) →
+ *   Stats (glass cards) → How it Works (step cards with decorative background numbers) →
+ *   Bottom CTA (gradient panel).
+ * - The outline-text effect on the hero subtitle uses WebkitTextStroke for dramatic
+ *   typographic contrast — a deliberate aesthetic choice tied to the stadium billboard
+ *   visual direction.
+ * - Previously fixed bugs: none relevant.
+ */
+
+interface HomeScreenProps {
+  isAuthenticated?: boolean;
+  userName?: string;
+}
+
+const STATS = [
+  { value: '500+', label: 'Jugadores', icon: Users },
+  { value: '120+', label: 'Partidos activos', icon: Trophy },
+  { value: '30+', label: 'Clubes', icon: MapPin },
+];
+
+const STEPS = [
+  {
+    number: '01',
+    title: 'Crea tu perfil',
+    description: 'Contanos tus posiciones, habilidades y disponibilidad horaria.',
+    icon: Shield,
+  },
+  {
+    number: '02',
+    title: 'Encontrá partidos',
+    description: 'Filtrá partidos y torneos cerca tuyo, con el formato que más te guste.',
+    icon: MapPin,
+  },
+  {
+    number: '03',
+    title: 'Sumate al equipo',
+    description: 'Confirmá tu lugar, coordiná con los jugadores y a la cancha.',
+    icon: Zap,
+  },
+];
+
+export const HomeScreen: React.FC<HomeScreenProps> = ({
+  isAuthenticated = false,
+  userName,
+}) => {
+  return (
+    <main className="overflow-x-hidden">
+      {/* ── HERO ──────────────────────────────────────────────────── */}
+      <section className="relative flex min-h-[90vh] items-center px-4 sm:px-6 lg:px-8">
+        {/* Lateral glow behind headline */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 -z-10"
+          style={{
+            background:
+              'radial-gradient(ellipse 70% 60% at 20% 50%, hsl(216 85% 25% / 0.3), transparent)',
+          }}
+        />
+
+        <div className="mx-auto w-full max-w-5xl">
+          {isAuthenticated && userName && (
+            <p
+              className="mb-4 text-sm font-medium uppercase tracking-widest text-primary"
+              style={{ animation: 'fadeUp 0.5s ease both' }}
+            >
+              ¡Bienvenido de vuelta, {userName}!
+            </p>
+          )}
+
+          <h1
+            className="font-['Bebas_Neue'] leading-none tracking-wide text-foreground"
+            style={{
+              fontSize: 'clamp(4.5rem, 13vw, 10rem)',
+              animation: 'fadeUp 0.55s ease both',
+              animationDelay: '60ms',
+            }}
+          >
+            <span className="block">SUMATE</span>
+            <span
+              className="block"
+              style={{
+                WebkitTextStroke: '2px hsl(35 100% 48%)',
+                color: 'transparent',
+              }}
+            >
+              AL JUEGO
+            </span>
+          </h1>
+
+          <p
+            className="mt-6 max-w-lg text-lg leading-relaxed text-muted-foreground"
+            style={{ animation: 'fadeUp 0.55s ease both', animationDelay: '160ms' }}
+          >
+            La plataforma para conectar jugadores de fútbol, armar equipos y
+            sumarte a partidos en tu zona.
+          </p>
+
+          <div
+            className="mt-10 flex flex-wrap gap-4"
+            style={{ animation: 'fadeUp 0.55s ease both', animationDelay: '260ms' }}
+          >
+            {isAuthenticated ? (
+              <>
+                <Button size="lg" className="group gap-2" asChild>
+                  <a href="/partidos">
+                    Explorar Partidos
+                    <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                  </a>
+                </Button>
+                <form method="POST" action="/api/auth/logout">
+                  <Button size="lg" variant="outline" type="submit">
+                    Cerrar Sesión
+                  </Button>
+                </form>
+              </>
+            ) : (
+              <>
+                <Button size="lg" className="group gap-2" asChild>
+                  <a href="/login">
+                    Iniciar Sesión
+                    <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                  </a>
+                </Button>
+                <Button size="lg" variant="outline" asChild>
+                  <a href="/registro-jugador">Registrarse</a>
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Fade into next section */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute bottom-0 left-0 right-0 h-28"
+          style={{ background: 'linear-gradient(to bottom, transparent, hsl(220 72% 7%))' }}
+        />
+      </section>
+
+      {/* ── VER PARTIDOS ─────────────────────────────────────────── */}
+      <section className="px-4 pb-4 pt-0 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <div className="mb-8 flex items-end justify-between gap-4">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-widest text-primary">
+                En vivo
+              </p>
+              <h2 className="font-['Bebas_Neue'] text-5xl tracking-wide text-foreground">
+                Partidos Disponibles
+              </h2>
+            </div>
+            <Button variant="outline" size="sm" asChild className="shrink-0">
+              <a href="/partidos">
+                Ver todos
+                <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+              </a>
+            </Button>
+          </div>
+
+          {/* MatchList already includes MatchFilters internally */}
+          <MatchList isAuthenticated={isAuthenticated} />
+        </div>
+      </section>
+
+      {/* ── STATS ────────────────────────────────────────────────── */}
+      <section className="px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-3">
+          {STATS.map(({ value, label, icon: Icon }) => (
+            <div
+              key={label}
+              className="flex flex-col items-center gap-3 rounded-xl p-8 text-center backdrop-blur-sm"
+              style={{
+                background: 'var(--color-surface-glass)',
+                border: '1px solid var(--color-surface-border)',
+              }}
+            >
+              <Icon className="h-8 w-8 text-primary" />
+              <span className="font-['Bebas_Neue'] text-5xl tracking-wide text-foreground">
+                {value}
+              </span>
+              <span className="text-sm font-medium text-muted-foreground">{label}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── HOW IT WORKS ─────────────────────────────────────────── */}
+      <section className="border-t border-border px-4 py-20 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="font-['Bebas_Neue'] text-5xl tracking-wide text-foreground">
+            ¿Cómo funciona?
+          </h2>
+          <p className="mt-2 text-muted-foreground">
+            En tres pasos estás dentro del partido.
+          </p>
+
+          <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {STEPS.map(({ number, title, description, icon: Icon }) => (
+              <div
+                key={number}
+                className="group relative overflow-hidden rounded-xl border border-border bg-card p-6 transition-colors duration-200 hover:border-primary/40"
+              >
+                {/* Decorative background step number */}
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute -right-3 -top-4 select-none font-['Bebas_Neue'] text-8xl leading-none text-border transition-colors duration-200 group-hover:text-primary/15"
+                >
+                  {number}
+                </span>
+                <Icon className="mb-4 h-7 w-7 text-secondary" />
+                <h3 className="font-semibold text-foreground">{title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── BOTTOM CTA ───────────────────────────────────────────── */}
+      <section className="px-4 py-20 sm:px-6 lg:px-8">
+        <div
+          className="mx-auto max-w-5xl rounded-2xl p-12 text-center"
+          style={{
+            background:
+              'linear-gradient(135deg, hsl(216 85% 15% / 0.55), hsl(220 72% 10% / 0.55))',
+            border: '1px solid hsl(216 85% 30% / 0.35)',
+          }}
+        >
+          <h2 className="font-['Bebas_Neue'] text-5xl tracking-wide text-foreground">
+            ¿Listo para jugar?
+          </h2>
+          <p className="mt-3 text-muted-foreground">
+            Unite a la comunidad y encontrá tu próximo partido ahora.
+          </p>
+          <Button size="lg" className="mt-8 gap-2" asChild>
+            <a href={isAuthenticated ? '/partidos' : '/login'}>
+              {isAuthenticated ? 'Ver partidos disponibles' : 'Iniciar Sesión'}
+              <ArrowRight className="h-4 w-4" />
+            </a>
+          </Button>
+        </div>
+      </section>
+
+      <style>{`
+        @keyframes fadeUp {
+          from { opacity: 0; transform: translateY(20px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+    </main>
+  );
+};
+
+export default HomeScreen;

--- a/apps/frontend/src/components/matches/MatchCard.tsx
+++ b/apps/frontend/src/components/matches/MatchCard.tsx
@@ -38,6 +38,8 @@ export interface Match {
 interface MatchCardProps {
   match: Match;
   onJoin?: (matchId: string) => void;
+  /** When false, clicking "Sumarme" redirects to /login instead of joining */
+  isAuthenticated?: boolean;
 }
 
 /**
@@ -77,7 +79,7 @@ function formatDisplay(format: MatchFormat): string {
   return FORMAT_LABELS[format] || format;
 }
 
-export function MatchCard({ match, onJoin }: MatchCardProps) {
+export function MatchCard({ match, onJoin, isAuthenticated = false }: MatchCardProps) {
   const filledSlots = match.totalSlots - match.availableSlots;
   const isFull = match.availableSlots === 0;
 
@@ -123,7 +125,13 @@ export function MatchCard({ match, onJoin }: MatchCardProps) {
           <Button
             size="sm"
             disabled={isFull}
-            onClick={() => onJoin?.(match.id)}
+            onClick={() => {
+              if (!isAuthenticated) {
+                window.location.href = '/login';
+                return;
+              }
+              onJoin?.(match.id);
+            }}
           >
             {isFull ? 'Completo' : 'Sumarme'}
           </Button>

--- a/apps/frontend/src/components/matches/MatchList.tsx
+++ b/apps/frontend/src/components/matches/MatchList.tsx
@@ -26,9 +26,11 @@ import { GET_MATCHES, type MatchFilters } from '@/graphql/operations/matches';
 interface MatchListProps {
   /** Initial matches for SSR/SSG hydration (optional) */
   initialMatches?: Match[];
+  /** Whether the current user is authenticated — gates the join action */
+  isAuthenticated?: boolean;
 }
 
-export function MatchList({ initialMatches }: MatchListProps) {
+export function MatchList({ initialMatches, isAuthenticated = false }: MatchListProps) {
   const [matches, setMatches] = useState<Match[]>(initialMatches || []);
   const [loading, setLoading] = useState(!initialMatches);
   const [error, setError] = useState<string | null>(null);
@@ -98,7 +100,7 @@ export function MatchList({ initialMatches }: MatchListProps) {
       {!loading && !error && matches.length > 0 && (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {matches.map((match) => (
-            <MatchCard key={match.id} match={match} onJoin={handleJoin} />
+            <MatchCard key={match.id} match={match} onJoin={handleJoin} isAuthenticated={isAuthenticated} />
           ))}
         </div>
       )}

--- a/apps/frontend/src/lib/auth.ts
+++ b/apps/frontend/src/lib/auth.ts
@@ -33,7 +33,7 @@ const backendUrl =
   import.meta.env.PRIVATE_BACKEND_URL || process.env.PRIVATE_BACKEND_URL || 'http://localhost:4000';
 
 export function getRoleRedirect(role: UserRole | undefined): string {
-  return role === 'club_admin' ? '/panel-club' : '/partidos';
+  return role === 'club_admin' ? '/panel-club' : '/';
 }
 
 export function getAuthCookieOptions(isProd: boolean): CookieAttributes {

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -19,7 +19,7 @@ import {
 } from './lib/auth';
 
 /** Rutas que requieren autenticación */
-const PROTECTED_ROUTES: string[] = ['/partidos', '/panel-club'];
+const PROTECTED_ROUTES: string[] = ['/panel-club'];
 
 /** Rutas restringidas por rol: sólo accesibles para el rol indicado */
 const ROLE_RESTRICTED: Record<string, UserRole> = {

--- a/apps/frontend/src/pages/api/auth/logout.ts
+++ b/apps/frontend/src/pages/api/auth/logout.ts
@@ -7,5 +7,5 @@ export const POST: APIRoute = async ({ cookies, redirect }) => {
   const accessToken = readAccessToken(cookies);
   await logoutFromBackend(accessToken);
   clearAuthCookies(cookies);
-  return redirect('/login', 302);
+  return redirect('/', 302);
 };

--- a/apps/frontend/src/pages/index.astro
+++ b/apps/frontend/src/pages/index.astro
@@ -1,11 +1,18 @@
 ---
-import Welcome from '../components/Welcome.astro';
-import Layout from '../layouts/Layout.astro';
+export const prerender = false;
 
-// Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
-// Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
+import Layout from '../layouts/Layout.astro';
+import HomeScreen from '../components/home/HomeScreen';
+import { getSessionFromBackend, readAccessToken } from '../lib/auth';
+
+const accessToken = readAccessToken(Astro.cookies);
+const user = accessToken ? await getSessionFromBackend(accessToken) : null;
 ---
 
 <Layout>
-	<Welcome />
+	<HomeScreen
+		client:load
+		isAuthenticated={user !== null}
+		userName={user?.displayName}
+	/>
 </Layout>

--- a/apps/frontend/src/pages/partidos/index.astro
+++ b/apps/frontend/src/pages/partidos/index.astro
@@ -1,22 +1,22 @@
 ---
 /**
- * Partidos (authenticated) — SSR
+ * Partidos — SSR (public, no auth required)
  *
  * Decision Context:
- * - Why SSR: Protected route that reads auth cookies server-side. Middleware redirects
- *   unauthenticated users to /login.
- * - Security: Uses getUser() (server-validated JWT) instead of getSession() which trusts
- *   the cookie blindly.
- * - Previously fixed bugs: none relevant.
+ * - Why public: Matches are visible to all users. Auth is only needed to join a match.
+ *   Unauthenticated users see the list and are redirected to /login when clicking "Sumarme".
+ * - Pattern: Reads optional session from cookie; passes isAuthenticated down to MatchList
+ *   so MatchCard can gate the join action client-side.
+ * - Previously fixed bugs: Was protected-only; removed from PROTECTED_ROUTES in middleware.
  */
 export const prerender = false;
 
 import Layout from '../../layouts/Layout.astro';
 import { MatchList } from '../../components/matches';
 
-// User is verified and attached by middleware — no redundant getUser() call needed
-const user = Astro.locals.user!;
-const nombre = user.displayName || user.email;
+const user = Astro.locals.user;
+const isAuthenticated = !!user;
+const nombre = user?.displayName || user?.email;
 ---
 
 <Layout title="Partidos Disponibles — Sumate Ya">
@@ -29,13 +29,19 @@ const nombre = user.displayName || user.email;
           <span class="topbar-name">SUMATE YA</span>
         </div>
         <div class="topbar-actions">
-          <span class="user-badge">
-            <span class="user-dot"></span>
-            {nombre}
-          </span>
-          <form method="POST" action="/api/auth/logout">
-            <button type="submit" class="btn-logout">Salir</button>
-          </form>
+          {isAuthenticated ? (
+            <>
+              <span class="user-badge">
+                <span class="user-dot"></span>
+                {nombre}
+              </span>
+              <form method="POST" action="/api/auth/logout">
+                <button type="submit" class="btn-logout">Salir</button>
+              </form>
+            </>
+          ) : (
+            <a href="/login" class="btn-logout">Iniciar Sesión</a>
+          )}
         </div>
       </div>
       <!-- Orange accent line -->
@@ -51,7 +57,7 @@ const nombre = user.displayName || user.email;
       </header>
 
       <section class="matches-section">
-        <MatchList client:visible />
+        <MatchList client:visible isAuthenticated={isAuthenticated} />
       </section>
     </main>
   </div>


### PR DESCRIPTION
Se creó la HomeScreen como punto de entrada de la app, accesible sin login. Incluye hero con animaciones, listado de partidos con filtros, stats y pasos de cómo funciona.

- HomeScreen muestra botón "Iniciar Sesión" si no hay sesión, y "Cerrar Sesión" si sí hay
- Después del login y del logout se redirige a / (home)
- /partidos ahora es público, el middleware ya no lo bloquea
- "Sumarme" en un partido redirige a /login si el usuario no está autenticado
- La página de partidos muestra nav con nombre del usuario o enlace a login según el estado
- Se corrigió resolveDisplayName que faltaba en authService y rompía el typecheck