### PR TITLE
feat: implement user profile feature with GraphQL support

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,10 +5,14 @@
       "url": "https://mcp.notion.com/mcp"
     },
     "supabase": {
-      "type": "http",
-      "url": "https://mcp.supabase.com/mcp?project_ref=getfqjkfsueucoalvtcc",
-      "headers": {
-        "Authorization": "Bearer sbp_02c4c622dc9faa8b26ad8159fb34bc69b819d37e"
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--project-ref=getfqjkfsueucoalvtcc"
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "sbp_86fd983ce49a8878376c322747ef8e390a766632"
       }
     }
   }

--- a/apps/backend/src/config/redis.ts
+++ b/apps/backend/src/config/redis.ts
@@ -48,6 +48,9 @@ export const CACHE_PREFIX = {
   MATCH_DETAIL: 'match:',
   CLUBS_LIST: 'clubs:list',
   CLUB_DETAIL: 'club:',
+  // `profile:me:<userId>` — scoped to the owner because RLS differs per-user.
+  // Invalidate on profile mutations (updatePosition, stat recompute, etc.).
+  PROFILE_ME: 'profile:me:',
 } as const;
 
 // =====================================================

--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -62,10 +62,31 @@ export enum MatchStatus {
   Open = 'OPEN'
 }
 
+export enum PlayerPosition {
+  Defender = 'DEFENDER',
+  Forward = 'FORWARD',
+  Goalkeeper = 'GOALKEEPER',
+  Midfielder = 'MIDFIELDER'
+}
+
+export type Profile = {
+  __typename?: 'Profile';
+  avatarUrl?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  division: Scalars['Int']['output'];
+  id: Scalars['ID']['output'];
+  matchesPlayed: Scalars['Int']['output'];
+  matchesWon: Scalars['Int']['output'];
+  preferredPosition?: Maybe<PlayerPosition>;
+  role: UserRole;
+  winrate?: Maybe<Scalars['Float']['output']>;
+};
+
 export type Query = {
   __typename?: 'Query';
   match?: Maybe<Match>;
   matches: Array<Match>;
+  myProfile: Profile;
 };
 
 
@@ -77,6 +98,11 @@ export type QueryMatchArgs = {
 export type QueryMatchesArgs = {
   filters?: InputMaybe<MatchFilters>;
 };
+
+export enum UserRole {
+  ClubAdmin = 'CLUB_ADMIN',
+  Player = 'PLAYER'
+}
 
 export type WithIndex<TObject> = TObject & Record<string, any>;
 export type ResolversObject<TObject> = WithIndex<TObject>;
@@ -154,24 +180,30 @@ export type DirectiveResolverFn<TResult = Record<PropertyKey, never>, TParent = 
 export type ResolversTypes = ResolversObject<{
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   Club: ResolverTypeWrapper<Club>;
+  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   Match: ResolverTypeWrapper<Match>;
   MatchFilters: MatchFilters;
   MatchFormat: MatchFormat;
   MatchStatus: MatchStatus;
+  PlayerPosition: PlayerPosition;
+  Profile: ResolverTypeWrapper<Profile>;
   Query: ResolverTypeWrapper<Record<PropertyKey, never>>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
+  UserRole: UserRole;
 }>;
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = ResolversObject<{
   Boolean: Scalars['Boolean']['output'];
   Club: Club;
+  Float: Scalars['Float']['output'];
   ID: Scalars['ID']['output'];
   Int: Scalars['Int']['output'];
   Match: Match;
   MatchFilters: MatchFilters;
+  Profile: Profile;
   Query: Record<PropertyKey, never>;
   String: Scalars['String']['output'];
 }>;
@@ -195,14 +227,28 @@ export type MatchResolvers<ContextType = GraphQLContext, ParentType extends Reso
   totalSlots?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
+export type ProfileResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Profile'] = ResolversParentTypes['Profile']> = ResolversObject<{
+  avatarUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  division?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  matchesPlayed?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  matchesWon?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  preferredPosition?: Resolver<Maybe<ResolversTypes['PlayerPosition']>, ParentType, ContextType>;
+  role?: Resolver<ResolversTypes['UserRole'], ParentType, ContextType>;
+  winrate?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+}>;
+
 export type QueryResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   match?: Resolver<Maybe<ResolversTypes['Match']>, ParentType, ContextType, RequireFields<QueryMatchArgs, 'id'>>;
   matches?: Resolver<Array<ResolversTypes['Match']>, ParentType, ContextType, Partial<QueryMatchesArgs>>;
+  myProfile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
 }>;
 
 export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   Club?: ClubResolvers<ContextType>;
   Match?: MatchResolvers<ContextType>;
+  Profile?: ProfileResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
 }>;
 

--- a/apps/backend/src/graphql/resolvers/domains/profile.ts
+++ b/apps/backend/src/graphql/resolvers/domains/profile.ts
@@ -1,0 +1,38 @@
+/**
+ * Profile Resolver — GraphQL resolvers for Profile queries
+ *
+ * Decision Context:
+ * - Why: Lives under `resolvers/domains/` per backend.md MANDATORY resolver layout.
+ * - Auth: `myProfile` requires auth — we call `requireAuth(context)` which throws a
+ *   clean "Authentication required" error if the JWT was absent/invalid. The frontend
+ *   SSR page catches this and redirects to /login.
+ * - RLS: we build a user-scoped Supabase client from `context.accessToken` and pass it
+ *   through `ServiceContext.supabase`. This lets the RLS policy on `profiles` verify
+ *   `auth.uid()` against the requested row. Using the singleton service client here
+ *   would bypass RLS and break the defense-in-depth posture required by backend.md.
+ * - Thin resolver: no data shaping lives here — service/repo own the DB contract and
+ *   the service owns winrate computation. Keep this file as a 1:1 mapping from GraphQL
+ *   fields to service calls.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { createUserClient } from '../../../config/supabase.js';
+import { profileService } from '../../../services/profileService.js';
+import { requireAuth } from '../../../types/context.js';
+import type { QueryResolvers } from '../../generated/graphql.js';
+
+const Query: QueryResolvers = {
+  myProfile: async (_parent, _args, context) => {
+    const user = requireAuth(context);
+    const userClient = context.accessToken
+      ? createUserClient(context.accessToken)
+      : undefined;
+
+    return profileService.getMyProfile({
+      userId: user.id,
+      supabase: userClient,
+    });
+  },
+};
+
+export const profileResolvers = { Query };

--- a/apps/backend/src/graphql/resolvers/index.ts
+++ b/apps/backend/src/graphql/resolvers/index.ts
@@ -8,9 +8,11 @@
  */
 
 import { matchResolvers } from './domains/match.js';
+import { profileResolvers } from './domains/profile.js';
 
 export const resolvers = {
   Query: {
     ...matchResolvers.Query,
+    ...profileResolvers.Query,
   },
 };

--- a/apps/backend/src/graphql/schema/profile.graphql
+++ b/apps/backend/src/graphql/schema/profile.graphql
@@ -1,0 +1,43 @@
+# GraphQL Schema: Profile type and myProfile query
+#
+# Decision Context:
+# - Why: Player-facing profile page needs a self-scoped query (`myProfile`) instead of a
+#   public `profile(id)` so the resolver can enforce auth + RLS via the caller's JWT.
+# - Why Int for `division`: DB column is smallint; keeping it as Int here avoids exposing
+#   a made-up enum that would drift from the DB default (1) without a migration.
+# - `winrate` is Float? and nullable: a player with 0 matches has no meaningful winrate,
+#   so we surface `null` instead of a misleading 0.0.
+# - Previously fixed bugs: none relevant.
+
+# User role enum (mirrors DB enum "userRole": player | club_admin)
+enum UserRole {
+  PLAYER
+  CLUB_ADMIN
+}
+
+# On-pitch preferred position (mirrors DB enum "playerPosition")
+enum PlayerPosition {
+  GOALKEEPER
+  DEFENDER
+  MIDFIELDER
+  FORWARD
+}
+
+# A player or club-admin profile linked to auth.users
+type Profile {
+  id: ID!
+  displayName: String!
+  avatarUrl: String
+  role: UserRole!
+  preferredPosition: PlayerPosition
+  division: Int!
+  matchesPlayed: Int!
+  matchesWon: Int!
+  # Win percentage 0-100 with 2 decimals, or null when matchesPlayed = 0
+  winrate: Float
+}
+
+extend type Query {
+  # Returns the authenticated user's profile. Auth required.
+  myProfile: Profile!
+}

--- a/apps/backend/src/repositories/profileRepository.ts
+++ b/apps/backend/src/repositories/profileRepository.ts
@@ -1,0 +1,80 @@
+/**
+ * Profile Repository — DB access for the `profiles` table
+ *
+ * Decision Context:
+ * - Why: Explicit column list (PROFILE_COLUMNS) enforces backend.md egress-prevention rule
+ *   "NEVER use select('*')". Future additions to the DB schema won't silently grow the
+ *   response size until a field is added here intentionally.
+ * - Accepts an optional `client` argument so the myProfile resolver can pass a user-scoped
+ *   Supabase client — RLS policies on `profiles` must be able to verify auth.uid().
+ * - camelCase identifiers are quoted because the DB uses quoted-camelCase naming (backend.md
+ *   "Database (Supabase)" rule). Unquoted identifiers would be lowercased by Postgres and
+ *   fail to match columns like "displayName".
+ * - PGRST116 is Supabase's not-found code on `.single()`; we translate to `null` so the
+ *   service can decide whether missing profile is a real error or an edge case.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { supabase, type SupabaseClient } from '../config/supabase.js';
+
+// =====================================================
+// Column Definitions (NEVER use select('*'))
+// =====================================================
+
+const PROFILE_COLUMNS = `
+  id,
+  "displayName",
+  "avatarUrl",
+  role,
+  "preferredPosition",
+  division,
+  "matchesPlayed",
+  "matchesWon"
+`;
+
+// =====================================================
+// Types
+// =====================================================
+
+export interface ProfileRow {
+  id: string;
+  displayName: string;
+  avatarUrl: string | null;
+  role: string;
+  preferredPosition: string | null;
+  division: number;
+  matchesPlayed: number;
+  matchesWon: number;
+}
+
+// =====================================================
+// Repository Functions
+// =====================================================
+
+export async function getProfileById(
+  id: string,
+  client: SupabaseClient = supabase,
+): Promise<ProfileRow | null> {
+  const { data, error } = await client
+    .from('profiles')
+    .select(PROFILE_COLUMNS)
+    .eq('id', id)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    console.error(
+      `[profileRepository.getProfileById] Supabase error for profileId=${id}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return data as unknown as ProfileRow;
+}
+
+export const profileRepository = {
+  getProfileById,
+};

--- a/apps/backend/src/services/profileService.ts
+++ b/apps/backend/src/services/profileService.ts
@@ -1,0 +1,116 @@
+/**
+ * Profile Service — business logic for player profiles
+ *
+ * Decision Context:
+ * - Why: Services return data only (backend.md). Winrate is computed here, not in the DB,
+ *   because `matchesWon` / `matchesPlayed` counters already live on the row and a DB
+ *   generated column would not gracefully represent the null-when-zero case.
+ * - Caching: TTL = USER_DATA (5 min) matches backend.md guidance "player profiles 5m".
+ *   Cache key is scoped per user (`profile:me:<userId>`) so each JWT gets its own entry.
+ *   When a mutation lands that updates stats (join match, record result), it MUST call
+ *   `cacheDelete(${CACHE_PREFIX.PROFILE_ME}${userId})` to avoid stale stats.
+ * - RLS: the service uses `ctx.supabase ?? supabase` so the user-scoped client (created in
+ *   the resolver from the caller's JWT) is used for DB reads. The fallback to the singleton
+ *   is defensive — `myProfile` always requires auth and the resolver always passes
+ *   `ctx.supabase`, but backend.md mandates the pattern for consistency with future services.
+ * - Winrate formula: (won / played) * 100, rounded to 2 decimals, or null when played = 0.
+ *   Rounding uses Number(fixed(2)) so GraphQL Float stays numeric instead of a string.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { cacheGetOrSet, CACHE_PREFIX, CACHE_TTL } from '../config/redis.js';
+import { supabase } from '../config/supabase.js';
+import {
+  PlayerPosition,
+  UserRole,
+  type Profile,
+} from '../graphql/generated/graphql.js';
+import { profileRepository, type ProfileRow } from '../repositories/profileRepository.js';
+import type { ServiceContext } from '../types/context.js';
+
+// =====================================================
+// Enum Mapping (DB -> GraphQL)
+// =====================================================
+
+const DB_TO_ROLE: Record<string, UserRole> = {
+  player: UserRole.Player,
+  club_admin: UserRole.ClubAdmin,
+};
+
+const DB_TO_POSITION: Record<string, PlayerPosition> = {
+  goalkeeper: PlayerPosition.Goalkeeper,
+  defender: PlayerPosition.Defender,
+  midfielder: PlayerPosition.Midfielder,
+  forward: PlayerPosition.Forward,
+};
+
+// =====================================================
+// Data Transformation
+// =====================================================
+
+function computeWinrate(matchesWon: number, matchesPlayed: number): number | null {
+  if (matchesPlayed <= 0) return null;
+  const rate = (matchesWon / matchesPlayed) * 100;
+  return Number(rate.toFixed(2));
+}
+
+function toProfile(row: ProfileRow): Profile {
+  return {
+    id: row.id,
+    displayName: row.displayName,
+    avatarUrl: row.avatarUrl,
+    role: DB_TO_ROLE[row.role] ?? UserRole.Player,
+    preferredPosition: row.preferredPosition
+      ? (DB_TO_POSITION[row.preferredPosition] ?? null)
+      : null,
+    division: row.division,
+    matchesPlayed: row.matchesPlayed,
+    matchesWon: row.matchesWon,
+    winrate: computeWinrate(row.matchesWon, row.matchesPlayed),
+  };
+}
+
+// =====================================================
+// Service Functions
+// =====================================================
+
+/**
+ * Returns the authenticated user's profile. Requires `ctx.userId` and should be called
+ * with a user-scoped Supabase client for RLS enforcement.
+ */
+export async function getMyProfile(ctx: ServiceContext): Promise<Profile> {
+  if (!ctx.userId) {
+    console.warn('[profileService.getMyProfile] Called without userId');
+    throw new Error('Authentication required');
+  }
+
+  const db = ctx.supabase ?? supabase;
+  const cacheKey = `${CACHE_PREFIX.PROFILE_ME}${ctx.userId}`;
+
+  try {
+    const row = await cacheGetOrSet<ProfileRow | null>(
+      cacheKey,
+      () => profileRepository.getProfileById(ctx.userId as string, db),
+      CACHE_TTL.USER_DATA,
+    );
+
+    if (!row) {
+      console.warn(
+        `[profileService.getMyProfile] Profile not found for userId=${ctx.userId}`,
+      );
+      throw new Error('Profile not found');
+    }
+
+    return toProfile(row);
+  } catch (error) {
+    console.error(
+      `[profileService.getMyProfile] Failed for userId=${ctx.userId}:`,
+      error,
+    );
+    throw error instanceof Error ? error : new Error('Failed to fetch profile');
+  }
+}
+
+export const profileService = {
+  getMyProfile,
+};

--- a/apps/frontend/src/components/home/HomeScreen.tsx
+++ b/apps/frontend/src/components/home/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { Users, Trophy, MapPin, Zap, Shield, ArrowRight } from 'lucide-react';
+import { Users, Trophy, MapPin, Zap, Shield, ArrowRight, UserCircle } from 'lucide-react';
 import { MatchList } from '@/components/matches';
 
 /**
@@ -20,6 +20,10 @@ import { MatchList } from '@/components/matches';
  * - The outline-text effect on the hero subtitle uses WebkitTextStroke for dramatic
  *   typographic contrast — a deliberate aesthetic choice tied to the stadium billboard
  *   visual direction.
+ * - Authenticated CTA cluster: "Explorar Partidos" (primary, FIFA orange) →
+ *   "Mi Perfil" (secondary, FIFA blue) → "Cerrar Sesión" (outline). The profile
+ *   link lives here because the home page has no topbar — without it, signed-in users
+ *   had no discoverable entry point to /perfil from the landing.
  * - Previously fixed bugs: none relevant.
  */
 
@@ -121,6 +125,12 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
                   <a href="/partidos">
                     Explorar Partidos
                     <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                  </a>
+                </Button>
+                <Button size="lg" variant="secondary" className="gap-2" asChild>
+                  <a href="/perfil">
+                    <UserCircle className="h-4 w-4" />
+                    Mi Perfil
                   </a>
                 </Button>
                 <form method="POST" action="/api/auth/logout">

--- a/apps/frontend/src/components/profile/ProfileCard.astro
+++ b/apps/frontend/src/components/profile/ProfileCard.astro
@@ -1,0 +1,359 @@
+---
+/**
+ * ProfileCard — player profile summary (Astro island, no interactivity required)
+ *
+ * Decision Context:
+ * - Why Astro and not React: the card is fully static server-rendered data (name, avatar,
+ *   stats). frontend.md: "Prefer Astro for static content and use React islands only for
+ *   interactivity." No client JS shipped.
+ * - Design: FIFA dark stadium aesthetic (design-system.md) — Bebas Neue title, Barlow
+ *   body, FIFA orange/blue/gold tokens via CSS vars. No hardcoded hex/hsl values outside
+ *   the globals theme; inline hsl() references reuse the exact tokens documented in
+ *   globals.css so a future palette change only touches one file.
+ * - Avatar: falls back to the user's initials when `avatarUrl` is null/empty. Initials
+ *   are derived from `displayName` on the server — zero client cost and always aligned
+ *   with what the user sees in /partidos.
+ * - Division: rendered as a bold pill because the value space is small (1..N) and a
+ *   numeric badge reads better than a free-form label. Color ramps by tier so higher
+ *   divisions "pop" more — tie-break favors the orange primary for division 1.
+ * - Position: maps backend enum to a Spanish label + emoji for readability. Handles the
+ *   null case explicitly (new players with no preferred position set).
+ * - Winrate: progress bar + numeric label. `null` renders as "—" (not 0%) so zero-match
+ *   players aren't shown as losers. The bar color ramps through destructive/primary/gold
+ *   at 40/70 thresholds — purely visual, keeps the card scannable without a legend.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import type { PlayerPosition, Profile } from '@/graphql/operations/profile';
+
+interface Props {
+  profile: Profile;
+}
+
+const { profile } = Astro.props;
+
+// ----- Initials fallback for empty avatar -----
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).slice(0, 2);
+  return parts
+    .map((p) => p.charAt(0).toUpperCase())
+    .join('')
+    .slice(0, 2);
+}
+
+const hasAvatar = !!profile.avatarUrl && profile.avatarUrl.length > 0;
+const initials = getInitials(profile.displayName);
+
+// ----- Position label + emoji -----
+const POSITION_LABEL: Record<PlayerPosition, { label: string; emoji: string }> = {
+  GOALKEEPER: { label: 'Arquero', emoji: '🧤' },
+  DEFENDER: { label: 'Defensor', emoji: '🛡️' },
+  MIDFIELDER: { label: 'Mediocampista', emoji: '🎯' },
+  FORWARD: { label: 'Delantero', emoji: '⚽' },
+};
+
+const positionInfo = profile.preferredPosition
+  ? POSITION_LABEL[profile.preferredPosition]
+  : null;
+
+// ----- Division badge tone -----
+// Division 1 is the strongest tier in this data model → most prominent treatment.
+function divisionTone(division: number): 'gold' | 'orange' | 'blue' {
+  if (division <= 1) return 'gold';
+  if (division <= 3) return 'orange';
+  return 'blue';
+}
+const tone = divisionTone(profile.division);
+
+// ----- Winrate display -----
+const winratePercent = profile.winrate ?? 0;
+const winrateLabel =
+  profile.winrate === null ? '—' : `${profile.winrate.toFixed(2)}%`;
+
+function winrateTone(rate: number | null): 'low' | 'mid' | 'high' {
+  if (rate === null) return 'low';
+  if (rate >= 70) return 'high';
+  if (rate >= 40) return 'mid';
+  return 'low';
+}
+const wrTone = winrateTone(profile.winrate);
+---
+
+<article class="profile-card">
+  <header class="profile-header">
+    <div class={`avatar avatar--${hasAvatar ? 'img' : 'initials'}`}>
+      {hasAvatar ? (
+        <img src={profile.avatarUrl!} alt={`Avatar de ${profile.displayName}`} />
+      ) : (
+        <span>{initials}</span>
+      )}
+      <span class="avatar-ring"></span>
+    </div>
+
+    <div class="identity">
+      <p class="eyebrow">JUGADOR · SUMATE YA</p>
+      <h2 class="name">{profile.displayName}</h2>
+      {positionInfo && (
+        <p class="position">
+          <span class="position-emoji" aria-hidden="true">{positionInfo.emoji}</span>
+          <span>{positionInfo.label}</span>
+        </p>
+      )}
+    </div>
+  </header>
+
+  <div class="stats">
+    <div class={`stat stat--division stat--${tone}`}>
+      <span class="stat-label">División</span>
+      <span class="stat-value">{profile.division}</span>
+    </div>
+
+    <div class="stat">
+      <span class="stat-label">Partidos jugados</span>
+      <span class="stat-value">{profile.matchesPlayed}</span>
+    </div>
+
+    <div class="stat">
+      <span class="stat-label">Partidos ganados</span>
+      <span class="stat-value">{profile.matchesWon}</span>
+    </div>
+
+    <div class={`stat stat--winrate stat--wr-${wrTone}`}>
+      <span class="stat-label">Winrate</span>
+      <span class="stat-value">{winrateLabel}</span>
+      <div class="wr-bar" aria-hidden="true">
+        <div class="wr-bar-fill" style={`width:${winratePercent}%`}></div>
+      </div>
+    </div>
+  </div>
+</article>
+
+<style>
+  .profile-card {
+    max-width: 720px;
+    margin: 0 auto;
+    border-radius: 1rem;
+    background: linear-gradient(
+      180deg,
+      hsl(220 55% 13%) 0%,
+      hsl(220 60% 9%) 100%
+    );
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow:
+      0 0 0 1px rgba(246, 164, 0, 0.05),
+      0 30px 60px -20px rgba(0, 0, 0, 0.6);
+    overflow: hidden;
+  }
+
+  /* ---- Header (avatar + identity) ---- */
+  .profile-header {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 2rem 2rem 1.5rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    background: radial-gradient(
+      ellipse at top left,
+      hsl(216 85% 18% / 0.35),
+      transparent 60%
+    );
+  }
+
+  .avatar {
+    position: relative;
+    width: 108px;
+    height: 108px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    overflow: hidden;
+    background: hsl(220 40% 16%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .avatar--initials span {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 2.5rem;
+    letter-spacing: 0.04em;
+    color: hsl(35 100% 55%);
+  }
+
+  .avatar-ring {
+    position: absolute;
+    inset: -3px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    background:
+      linear-gradient(hsl(220 55% 11%), hsl(220 55% 11%)) padding-box,
+      linear-gradient(135deg, hsl(35 100% 48%), hsl(216 85% 45%)) border-box;
+    pointer-events: none;
+  }
+
+  .identity {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+  }
+
+  .eyebrow {
+    margin: 0;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    color: hsl(35 100% 55%);
+    text-transform: uppercase;
+  }
+
+  .name {
+    margin: 0;
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 2.25rem;
+    line-height: 1;
+    letter-spacing: 0.03em;
+    color: hsl(210 20% 96%);
+    word-break: break-word;
+  }
+
+  .position {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0.25rem 0 0;
+    padding: 0.2rem 0.6rem;
+    width: fit-content;
+    border-radius: 999px;
+    background: hsl(216 85% 45% / 0.12);
+    border: 1px solid hsl(216 85% 45% / 0.3);
+    color: hsl(216 85% 75%);
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.82rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+  }
+
+  .position-emoji {
+    font-size: 0.95rem;
+    line-height: 1;
+  }
+
+  /* ---- Stats grid ---- */
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1px;
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .stat {
+    padding: 1.25rem 1.5rem;
+    background: hsl(220 55% 10%);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .stat-label {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: hsl(215 20% 55%);
+  }
+
+  .stat-value {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.85rem;
+    line-height: 1;
+    letter-spacing: 0.04em;
+    color: hsl(210 20% 94%);
+  }
+
+  /* ---- Division tones ---- */
+  .stat--division .stat-value {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 3.5rem;
+    padding: 0.35rem 0.7rem;
+    border-radius: 0.5rem;
+    font-size: 1.75rem;
+    width: fit-content;
+  }
+
+  .stat--gold .stat-value {
+    background: linear-gradient(135deg, hsl(42 100% 55%), hsl(35 100% 48%));
+    color: hsl(220 72% 7%);
+    box-shadow: 0 4px 14px hsl(42 100% 55% / 0.25);
+  }
+
+  .stat--orange .stat-value {
+    background: hsl(35 100% 48% / 0.18);
+    color: hsl(35 100% 65%);
+    border: 1px solid hsl(35 100% 48% / 0.4);
+  }
+
+  .stat--blue .stat-value {
+    background: hsl(216 85% 45% / 0.18);
+    color: hsl(216 85% 70%);
+    border: 1px solid hsl(216 85% 45% / 0.4);
+  }
+
+  /* ---- Winrate (full width row) ---- */
+  .stat--winrate {
+    grid-column: 1 / -1;
+  }
+
+  .wr-bar {
+    margin-top: 0.55rem;
+    height: 8px;
+    width: 100%;
+    background: hsl(220 40% 16%);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+
+  .wr-bar-fill {
+    height: 100%;
+    border-radius: 999px;
+    transition: width 0.4s ease;
+  }
+
+  .stat--wr-low .wr-bar-fill {
+    background: linear-gradient(90deg, hsl(0 72% 51%), hsl(35 100% 48%));
+  }
+
+  .stat--wr-mid .wr-bar-fill {
+    background: linear-gradient(90deg, hsl(35 100% 48%), hsl(42 100% 55%));
+  }
+
+  .stat--wr-high .wr-bar-fill {
+    background: linear-gradient(90deg, hsl(42 100% 55%), hsl(216 85% 55%));
+  }
+
+  @media (max-width: 560px) {
+    .profile-header {
+      flex-direction: column;
+      align-items: flex-start;
+      padding: 1.5rem 1.25rem;
+    }
+
+    .stats {
+      grid-template-columns: 1fr;
+    }
+
+    .name {
+      font-size: 1.85rem;
+    }
+  }
+</style>

--- a/apps/frontend/src/graphql/operations/profile.graphql
+++ b/apps/frontend/src/graphql/operations/profile.graphql
@@ -1,0 +1,15 @@
+# Profile operations — GraphQL source of truth (see matches.graphql pattern)
+
+query GetMyProfile {
+  myProfile {
+    id
+    displayName
+    avatarUrl
+    role
+    preferredPosition
+    division
+    matchesPlayed
+    matchesWon
+    winrate
+  }
+}

--- a/apps/frontend/src/graphql/operations/profile.ts
+++ b/apps/frontend/src/graphql/operations/profile.ts
@@ -1,0 +1,51 @@
+/**
+ * Profile GraphQL operations (TypeScript companion to profile.graphql).
+ *
+ * Decision Context:
+ * - Why: frontend.md forbids inline GraphQL inside UI components — operations live here.
+ *   Frontend codegen isn't wired up yet, so we keep a hand-typed mirror of the schema
+ *   until it is. If you edit the query, update BOTH `profile.graphql` and this file.
+ * - Enums mirror the backend schema exactly (`player` → `PLAYER`, etc.) so the frontend
+ *   can compare without a runtime mapping layer.
+ * - Previously fixed bugs: none relevant.
+ */
+
+// =====================================================
+// Types (mirror backend GraphQL schema)
+// =====================================================
+
+export type UserRole = 'PLAYER' | 'CLUB_ADMIN';
+
+export type PlayerPosition = 'GOALKEEPER' | 'DEFENDER' | 'MIDFIELDER' | 'FORWARD';
+
+export interface Profile {
+  id: string;
+  displayName: string;
+  avatarUrl: string | null;
+  role: UserRole;
+  preferredPosition: PlayerPosition | null;
+  division: number;
+  matchesPlayed: number;
+  matchesWon: number;
+  winrate: number | null;
+}
+
+// =====================================================
+// GraphQL Operations
+// =====================================================
+
+export const GET_MY_PROFILE = /* GraphQL */ `
+  query GetMyProfile {
+    myProfile {
+      id
+      displayName
+      avatarUrl
+      role
+      preferredPosition
+      division
+      matchesPlayed
+      matchesWon
+      winrate
+    }
+  }
+`;

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -2,11 +2,18 @@
  * Astro SSR middleware — auth guard + role-based routing.
  *
  * Decision Context:
- * - Why: Centralizes auth checks so individual pages don't repeat getUser() + redirect logic.
- * - Pattern: Checks PROTECTED_ROUTES first (short-circuit for public paths).
- *   It forwards the access token cookie to backend auth endpoints and never talks to Supabase.
- * - Security: Frontend only trusts backend-validated session payloads.
- * - Previously fixed bugs: none relevant.
+ * - Why: Centralizes auth checks so individual pages don't repeat getUser() + redirect logic,
+ *   and ensures Astro.locals.user is populated consistently for both public and protected
+ *   routes so navbars can show authenticated-user affordances (e.g., "Mi Perfil").
+ * - Pattern: Always attempt to resolve the session if an access token is present, then apply
+ *   auth/role enforcement only for PROTECTED_ROUTES. Public routes still get locals.user when
+ *   a valid cookie is attached — this is what powers the authenticated navbar on /partidos.
+ * - Security: Frontend only trusts backend-validated session payloads. Tokens are forwarded
+ *   to the backend /api/auth/session endpoint; we never call Supabase directly from here.
+ * - Previously fixed bugs:
+ *   - /partidos navbar showed "Iniciar Sesión" for logged-in users because the middleware
+ *     short-circuited on non-protected routes and never populated locals.user. Fixed by
+ *     splitting session resolution from route enforcement.
  */
 
 import { defineMiddleware } from 'astro:middleware';
@@ -19,7 +26,7 @@ import {
 } from './lib/auth';
 
 /** Rutas que requieren autenticación */
-const PROTECTED_ROUTES: string[] = ['/panel-club'];
+const PROTECTED_ROUTES: string[] = ['/panel-club', '/perfil'];
 
 /** Rutas restringidas por rol: sólo accesibles para el rol indicado */
 const ROLE_RESTRICTED: Record<string, UserRole> = {
@@ -28,27 +35,32 @@ const ROLE_RESTRICTED: Record<string, UserRole> = {
 
 export const onRequest = defineMiddleware(async ({ cookies, url, redirect, locals }, next) => {
   const pathname = url.pathname;
-
-  // Rutas públicas: continuar sin verificar
   const isProtected = PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
+
+  const accessToken = readAccessToken(cookies);
+
+  // Intentar resolver la sesión para cualquier ruta que tenga cookie — así las páginas
+  // públicas (ej: /partidos) pueden renderizar el navbar autenticado.
+  const user = accessToken ? await getSessionFromBackend(accessToken) : null;
+
+  if (accessToken && !user) {
+    // Cookie presente pero inválida: limpiar para forzar re-login
+    clearAuthCookies(cookies);
+  }
+
+  if (user) {
+    locals.user = user;
+  }
+
   if (!isProtected) {
     return next();
   }
 
-  const accessToken = readAccessToken(cookies);
-
-  if (!accessToken) {
-    return redirect('/login');
-  }
-
-  const user = await getSessionFromBackend(accessToken);
-
+  // A partir de acá: ruta protegida
   if (!user) {
-    clearAuthCookies(cookies);
     return redirect('/login');
   }
 
-  // Verificar restricción por rol
   const requiredRole = Object.entries(ROLE_RESTRICTED).find(([route]) =>
     pathname.startsWith(route),
   )?.[1];
@@ -59,8 +71,6 @@ export const onRequest = defineMiddleware(async ({ cookies, url, redirect, local
       return redirect(getRoleRedirect(userRole));
     }
   }
-
-  locals.user = user;
 
   return next();
 });

--- a/apps/frontend/src/pages/partidos/index.astro
+++ b/apps/frontend/src/pages/partidos/index.astro
@@ -31,6 +31,7 @@ const nombre = user?.displayName || user?.email;
         <div class="topbar-actions">
           {isAuthenticated ? (
             <>
+              <a href="/perfil" class="nav-link">Mi Perfil</a>
               <span class="user-badge">
                 <span class="user-dot"></span>
                 {nombre}
@@ -119,6 +120,25 @@ const nombre = user?.displayName || user?.email;
   .topbar-accent {
     height: 2px;
     background: linear-gradient(90deg, hsl(35 100% 48%), hsl(216 85% 45%), transparent);
+  }
+
+  /* ---- Nav link (to /perfil etc.) ---- */
+  .nav-link {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: hsl(215 20% 65%);
+    text-decoration: none;
+    padding: 0.3rem 0.6rem;
+    border-radius: 6px;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .nav-link:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: hsl(210 20% 94%);
   }
 
   /* ---- User badge ---- */

--- a/apps/frontend/src/pages/perfil.astro
+++ b/apps/frontend/src/pages/perfil.astro
@@ -1,0 +1,352 @@
+---
+/**
+ * Perfil — SSR (auth required)
+ *
+ * Decision Context:
+ * - Why SSR: the profile is scoped to the caller (myProfile) and requires a JWT to
+ *   satisfy RLS. Static pre-rendering would need a client-side fetch that duplicates
+ *   auth plumbing already handled by the middleware.
+ * - Auth: middleware (PROTECTED_ROUTES) redirects unauthenticated users before this
+ *   file runs, so the accessToken cookie is guaranteed to be present. We re-read the
+ *   cookie here only to forward it to the backend GraphQL endpoint.
+ * - Fetch: native fetch instead of urqlClient because urql-client.ts reads the token
+ *   from localStorage (client-side only). The user asked us not to modify lib/supabase.ts
+ *   — we intentionally also leave urql-client.ts untouched and use fetch directly so the
+ *   SSR token flow stays isolated to this page.
+ * - Error UX: any GraphQL error is rendered inline instead of throwing a 500. The most
+ *   common case is an expired token; the page still renders the navbar so the user can
+ *   hit "Salir" and re-login without losing the session hint.
+ * - Previously fixed bugs: none relevant.
+ */
+export const prerender = false;
+
+import Layout from '../layouts/Layout.astro';
+import ProfileCard from '../components/profile/ProfileCard.astro';
+import { ACCESS_TOKEN_COOKIE } from '../lib/auth';
+import { GET_MY_PROFILE, type Profile } from '../graphql/operations/profile';
+
+const backendUrl =
+  import.meta.env.PRIVATE_BACKEND_URL ||
+  process.env.PRIVATE_BACKEND_URL ||
+  'http://localhost:4000';
+const graphqlUrl =
+  import.meta.env.PUBLIC_GRAPHQL_URL ||
+  process.env.PUBLIC_GRAPHQL_URL ||
+  `${backendUrl}/graphql`;
+
+const user = Astro.locals.user;
+const accessToken = Astro.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+const displayName = user?.displayName || user?.email || 'Jugador';
+
+let profile: Profile | null = null;
+let errorMessage: string | null = null;
+
+if (!accessToken) {
+  // Middleware already redirects on this path, but we keep a defensive guard.
+  errorMessage = 'Sesión inválida. Iniciá sesión nuevamente.';
+} else {
+  try {
+    const response = await fetch(graphqlUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ query: GET_MY_PROFILE }),
+    });
+
+    const result = (await response.json().catch(() => null)) as
+      | { data?: { myProfile: Profile | null }; errors?: Array<{ message: string }> }
+      | null;
+
+    if (!response.ok || !result) {
+      errorMessage = 'No pudimos cargar tu perfil. Intentá de nuevo en unos segundos.';
+    } else if (result.errors?.length) {
+      errorMessage = result.errors[0]?.message || 'Error al cargar tu perfil.';
+    } else if (result.data?.myProfile) {
+      profile = result.data.myProfile;
+    } else {
+      errorMessage = 'Tu perfil no está disponible todavía.';
+    }
+  } catch (e) {
+    errorMessage = e instanceof Error ? e.message : 'Error de red al cargar el perfil';
+  }
+}
+---
+
+<Layout title="Mi Perfil — Sumate Ya">
+  <div class="app-shell">
+    <!-- Top navigation bar -->
+    <nav class="topbar">
+      <div class="topbar-inner">
+        <div class="topbar-brand">
+          <span class="topbar-ball">⚽</span>
+          <span class="topbar-name">SUMATE YA</span>
+        </div>
+        <div class="topbar-actions">
+          <a href="/partidos" class="nav-link">Partidos</a>
+          <span class="user-badge">
+            <span class="user-dot"></span>
+            {displayName}
+          </span>
+          <form method="POST" action="/api/auth/logout">
+            <button type="submit" class="btn-logout">Salir</button>
+          </form>
+        </div>
+      </div>
+      <div class="topbar-accent"></div>
+    </nav>
+
+    <!-- Page content -->
+    <main class="page-content">
+      <header class="section-header">
+        <div class="section-label">TU FICHA</div>
+        <h1 class="section-title">Mi Perfil</h1>
+        <p class="section-sub">Resumen de tu actividad en la cancha</p>
+      </header>
+
+      <section class="profile-section">
+        {profile ? (
+          <ProfileCard profile={profile} />
+        ) : (
+          <div class="error-card" role="alert">
+            <p class="error-title">No pudimos mostrar tu perfil</p>
+            <p class="error-body">{errorMessage}</p>
+            <div class="error-actions">
+              <a href="/partidos" class="btn-ghost">Ir a partidos</a>
+              <a href="/login" class="btn-primary">Iniciar sesión</a>
+            </div>
+          </div>
+        )}
+      </section>
+    </main>
+  </div>
+</Layout>
+
+<style>
+  .app-shell {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ---- Top navbar (matches /partidos pattern) ---- */
+  .topbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: rgba(7, 15, 31, 0.85);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .topbar-inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.25rem;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .topbar-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .topbar-ball {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  .topbar-name {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.35rem;
+    letter-spacing: 0.1em;
+    color: #ffffff;
+  }
+
+  .topbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .topbar-accent {
+    height: 2px;
+    background: linear-gradient(90deg, hsl(35 100% 48%), hsl(216 85% 45%), transparent);
+  }
+
+  .nav-link {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: hsl(215 20% 65%);
+    text-decoration: none;
+    padding: 0.3rem 0.6rem;
+    border-radius: 6px;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .nav-link:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: hsl(210 20% 94%);
+  }
+
+  .user-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(246, 164, 0, 0.12);
+    border: 1px solid rgba(246, 164, 0, 0.25);
+    color: hsl(35 100% 65%);
+    border-radius: 20px;
+    padding: 0.25rem 0.875rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    font-family: 'Barlow Condensed', sans-serif;
+    letter-spacing: 0.03em;
+  }
+
+  .user-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: hsl(35 100% 55%);
+    box-shadow: 0 0 4px hsl(35 100% 55%);
+  }
+
+  .btn-logout {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 6px;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.8125rem;
+    font-family: 'Barlow', sans-serif;
+    font-weight: 500;
+    cursor: pointer;
+    color: hsl(215 20% 60%);
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+
+  .btn-logout:hover {
+    background: rgba(255, 255, 255, 0.07);
+    color: hsl(210 20% 90%);
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+
+  /* ---- Page content ---- */
+  .page-content {
+    flex: 1;
+    max-width: 1100px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 2.5rem 1.25rem;
+  }
+
+  .section-header {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .section-label {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    color: hsl(35 100% 55%);
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+  }
+
+  .section-title {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 2.5rem;
+    font-weight: 400;
+    letter-spacing: 0.04em;
+    color: #ffffff;
+    margin: 0 0 0.375rem;
+    line-height: 1;
+  }
+
+  .section-sub {
+    margin: 0;
+    color: hsl(215 20% 50%);
+    font-size: 0.9rem;
+    font-family: 'Barlow', sans-serif;
+  }
+
+  .profile-section {
+    padding: 0;
+  }
+
+  /* ---- Error state ---- */
+  .error-card {
+    max-width: 560px;
+    margin: 0 auto;
+    text-align: center;
+    padding: 2rem 1.5rem;
+    border-radius: 0.75rem;
+    background: hsl(220 55% 11%);
+    border: 1px solid hsl(0 72% 51% / 0.35);
+  }
+
+  .error-title {
+    margin: 0 0 0.5rem;
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.5rem;
+    letter-spacing: 0.04em;
+    color: hsl(0 72% 70%);
+  }
+
+  .error-body {
+    margin: 0 0 1.25rem;
+    color: hsl(215 20% 60%);
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.95rem;
+  }
+
+  .error-actions {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .btn-primary,
+  .btn-ghost {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 6px;
+    text-decoration: none;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+
+  .btn-primary {
+    background: hsl(35 100% 48%);
+    color: hsl(220 72% 7%);
+  }
+  .btn-primary:hover {
+    background: hsl(35 100% 55%);
+  }
+
+  .btn-ghost {
+    background: transparent;
+    color: hsl(215 20% 70%);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+  }
+  .btn-ghost:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: hsl(210 20% 94%);
+  }
+</style>

--- a/docs/prompts/h9r4k8nt-prompt-log.md
+++ b/docs/prompts/h9r4k8nt-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-04-24 13:55:00
+- Task ID: h9r4k8nt
+
+## User Prompt
+
+> agregar "Mi Perfil" entre "Explorar Partido" y "Cerrar sesion"
+
+## Agent Main Actions
+
+- Insertado botón "Mi Perfil" (`variant="secondary"`, ícono `UserCircle` de lucide-react) entre "Explorar Partidos" y "Cerrar Sesión" en el branch autenticado del hero de `HomeScreen.tsx`, usando `<a href="/perfil">` para mantener el patrón SSR-friendly del resto de los CTAs.
+- Importado `UserCircle` de lucide-react y actualizado el bloque Decision Context del componente para documentar el cluster de CTAs (primary → secondary → outline) y por qué el link a `/perfil` vive acá (la home no tiene topbar, sin este botón los usuarios logueados no tenían cómo llegar a su perfil).
+- Validado con `pnpm run typecheck` (turbo typecheck --force) verde. El frontend hot-reloadea automáticamente si el dev server está corriendo.

--- a/docs/prompts/k8p3m2xn-prompt-log.md
+++ b/docs/prompts/k8p3m2xn-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-04-24 13:22:00
+- Task ID: k8p3m2xn
+
+## User Prompt
+
+> cheq si el perfil de usuario funciona
+
+## Agent Main Actions
+
+- Backend smoke: con el backend corriendo, registré un jugador (`/api/auth/register-player`), validé introspección y ejecuté `myProfile` con JWT — devolvió los 9 campos esperados con `winrate: null` para 0 partidos y `role: PLAYER`. Sin JWT, el resolver responde `Authentication required`.
+- Frontend E2E: levanté `pnpm --filter @sumate-ya/frontend dev`, confirmé que `/perfil` sin cookies redirige a `/login` (middleware OK), logueé vía POST al `/login` Astro con Origin/Referer correctos (cookies `sumateya-access-token`/`sumateya-refresh-token` HttpOnly seteadas) y la segunda request a `/perfil` devolvió HTML 200 con el `ProfileCard` renderizado: nombre "Perfil Verify", División 1, Partidos jugados 0, Partidos ganados 0, Winrate "—".
+- Limpieza: borré los dos usuarios de prueba en `auth.users` vía Supabase MCP (`perfil-test-...` y `perfil-verify-...`), detuve los procesos backend/frontend de background y limpié archivos temporales de cookies.

--- a/docs/prompts/m4t7q2rb-prompt-log.md
+++ b/docs/prompts/m4t7q2rb-prompt-log.md
@@ -1,0 +1,18 @@
+# Prompt Log
+
+- Timestamp: 2026-04-24 13:45:00
+- Task ID: m4t7q2rb
+
+## User Prompt
+
+> dime la direcion para ver perfil de usuario
+> [screenshot home autenticada]
+> no viuaizo "Mi Perfil" ni tampoco una navbar
+> [screenshot /partidos logueado mostrando "Iniciar Sesión" en lugar de "Mi Perfil"]
+> no no aparece
+
+## Agent Main Actions
+
+- Diagnóstico: en `/partidos` aparecía el botón "Iniciar Sesión" a pesar de tener sesión válida. Causa raíz: `middleware.ts` hacía `return next()` temprano para rutas no incluidas en `PROTECTED_ROUTES` (como `/partidos`), por lo que `Astro.locals.user` quedaba `undefined` y el topbar caía al branch anónimo.
+- Fix en `apps/frontend/src/middleware.ts`: separé resolución de sesión (ahora se ejecuta siempre que haya access token, poblando `locals.user` para rutas públicas) de la aplicación de la guardia (redirect a `/login` solo para `PROTECTED_ROUTES`, role gate intacto). Limpieza de cookies inválidas en cualquier ruta. Actualicé el bloque Decision Context con el bug previo.
+- Validación: `pnpm run typecheck` (turbo typecheck --force) verde en backend + codegen. Expliqué al usuario que refrescando `/partidos` debería ver ahora el link "Mi Perfil", el badge del usuario y el botón "Salir".

--- a/docs/prompts/q9t4n7xb-prompt-log.md
+++ b/docs/prompts/q9t4n7xb-prompt-log.md
@@ -1,0 +1,16 @@
+# Prompt Log
+
+- Timestamp: 2026-04-20 00:00:00
+- Task ID: q9t4n7xb
+
+## User Prompt
+
+> Podés listar las tablas de la base de datos de Supabase?
+>
+> como lo hago ?
+
+## Agent Main Actions
+
+- Detectó que el MCP de Supabase no estaba disponible en la primera vuelta y pidió al usuario autenticarlo antes de ejecutar operaciones DB.
+- Tras cargarse el MCP, usó `ToolSearch` para traer el schema de `mcp__supabase__list_tables` y lo invocó sobre el schema `public`.
+- Reportó las 13 tablas del schema `public` con su conteo de filas y confirmación de RLS habilitado.

--- a/docs/prompts/r3p9n7bk-prompt-log.md
+++ b/docs/prompts/r3p9n7bk-prompt-log.md
@@ -1,0 +1,40 @@
+# Prompt Log
+
+- Timestamp: 2026-04-24 00:00:00
+- Task ID: r3p9n7bk
+
+## User Prompt
+
+> Sos un desarrollador senior fullstack especializado en Astro 6, Supabase y GraphQL. Necesito que implementes la siguiente User Story completa en el proyecto "sumate-ya".
+>
+> ## User Story
+> Como jugador, quiero ver mi perfil con mi nombre, división, partidos jugados y foto para tener un resumen de mi actividad.
+>
+> ## Stack del proyecto
+> - Frontend: Astro 6 con SSR, Tailwind CSS
+> - Auth y base de datos: Supabase
+> - GraphQL en el backend (existe estructura en `apps/backend/src/graphql/`)
+> - UI: shadcn/ui (Avatar + Card)
+>
+> ## Contexto importante del proyecto
+> - El login ya está implementado, autentica via cookies con `getUser()`
+> - Los perfiles viven en `public.profiles` con campos: id, displayName, avatarUrl, role, preferredPosition, division, matchesPlayed (y posiblemente matchesWon)
+> - El middleware protege rutas, redirige a `/login` si no hay sesión
+> - Ya existe la ruta `/partidos` como ejemplo de página protegida
+> - Usar SSR (no client-side), ya que requiere datos del usuario autenticado
+>
+> ## Tareas a implementar
+> (revisar schema; Query GraphQL myProfile; página /perfil SSR; componente ProfileCard; middleware; navegación)
+>
+> ## Restricciones
+> - No modificar `lib/supabase.ts`
+> - Mantener consistencia visual con el estilo FIFA ya aplicado
+> - Usar GraphQL para la obtención de datos, no consulta directa a Supabase desde el frontend
+> - Respetar RLS: el resolver debe crear client user-scoped
+> - No romper las rutas existentes
+
+## Agent Main Actions
+
+- Inspeccionó la tabla `public.profiles` vía Supabase MCP (confirmó `matchesWon`, enums de role/preferredPosition, y RLS), agregó el schema `profile.graphql` con enums `UserRole` y `PlayerPosition` y la query `myProfile`, y creó `profileRepository` + `profileService` (con cache Redis scopeado por usuario) y el resolver `myProfile` que usa `createUserClient(accessToken)` para respetar RLS. Corrió el codegen del backend.
+- En el frontend creó las operations `profile.graphql` y `profile.ts`, el componente `ProfileCard.astro` con estética FIFA (avatar con anillo degradado, pill de división por tier, posición con ícono, winrate con progress bar y null handling) y la página SSR `/perfil.astro` que hace fetch GraphQL directo al backend con el JWT de la cookie y maneja estado de error inline.
+- Agregó `/perfil` a `PROTECTED_ROUTES` en `middleware.ts`, insertó link de navegación recíproco entre `/partidos` y `/perfil`, y validó la implementación con `pnpm run typecheck` (turbo typecheck --force) exitoso (backend + codegen).


### PR DESCRIPTION
- Added GraphQL schema for user profile with `myProfile` query.
- Created `profileRepository` for database access to the `profiles` table.
- Developed `profileService` to handle business logic and winrate calculation.
- Introduced `ProfileCard` component for displaying user profile information.
- Implemented SSR page `/perfil` to fetch and render user profile data.
- Added GraphQL operations for fetching user profile data.
- Updated middleware to protect the `/perfil` route and ensure user authentication.
- Enhanced UI with FIFA-themed design elements for profile display.