### PR TITLE
feat(auth): implement refresh token flow and improve session management

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,11 +5,13 @@
       "url": "https://mcp.notion.com/mcp"
     },
     "supabase": {
-      "type": "http",
-      "url": "https://mcp.supabase.com/mcp?project_ref=getfqjkfsueucoalvtcc",
-      "headers": {
-        "Authorization": "Bearer sbp_02c4c622dc9faa8b26ad8159fb34bc69b819d37e"
-      }
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--project-ref=getfqjkfsueucoalvtcc",
+        "--access-token=sbp_677007ff7a46a71f082382ac56f6375770b47fce"
+      ]
     }
   }
 }

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -5,3 +5,6 @@ SUPABASE_URL=https://<tu-proyecto>.supabase.co
 SUPABASE_ANON_KEY=<tu-anon-key>
 # Secret key de servidor (sb_secret_..., sólo backend; NUNCA exponer al cliente)
 PRIVATE_SUPABASE_SECRET_KEY=<tu-secret-key>
+
+# URL del frontend — usada para restringir CORS en el backend
+FRONTEND_URL=http://localhost:4321

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,3 +1,16 @@
+/**
+ * Express app entry
+ *
+ * Decision Context:
+ * - Why: CORS is restricted to FRONTEND_URL (not open wildcard) because auth cookies are
+ *   HttpOnly and the routes must not be callable from arbitrary origins in production.
+ *   credentials: true is required so browsers send the session when the frontend fetches
+ *   the backend from a cross-origin context (e.g., Astro SSR calling Express locally).
+ * - Previously fixed bugs:
+ *   - cors() was called with no options, allowing all origins. Fixed: restricted to
+ *     FRONTEND_URL env var with a development default of http://localhost:4321.
+ */
+
 import express from 'express';
 import cors from 'cors';
 import 'dotenv/config';
@@ -5,9 +18,11 @@ import 'dotenv/config';
 import { applyApolloMiddleware } from './graphql/server.js';
 import authRoutes from './routes/authRoutes.js';
 
+const FRONTEND_URL = process.env.FRONTEND_URL ?? 'http://localhost:4321';
+
 const app = express();
 
-app.use(cors());
+app.use(cors({ origin: FRONTEND_URL, credentials: true }));
 app.use(express.json());
 app.use('/api/auth', authRoutes);
 

--- a/apps/backend/src/controllers/authController.ts
+++ b/apps/backend/src/controllers/authController.ts
@@ -2,13 +2,18 @@
  * Auth REST controllers
  *
  * Decision Context:
- * - Why: Keep login/session resolution in backend so Astro only talks to the app API.
+ * - Why: Keep login/session/refresh resolution in backend so Astro only talks to the app API.
  * - Pattern: Controllers orchestrate HTTP IO, authService encapsulates Supabase calls.
- * - Previously fixed bugs: none relevant.
+ * - Previously fixed bugs:
+ *   - logout() returned 204 without calling signOut() on Supabase, leaving the JWT valid
+ *     server-side until natural expiry. Fixed: createUserClient(token).auth.signOut() is
+ *     called best-effort before responding. Best-effort means the frontend always clears
+ *     its cookies even if the Supabase call fails (e.g., already-expired token).
  */
 
 import type { Request, Response } from 'express';
 
+import { createUserClient } from '../config/supabase.js';
 import { authService } from '../services/authService.js';
 
 export const authController = {
@@ -49,7 +54,38 @@ export const authController = {
     }
   },
 
-  async logout(_req: Request, res: Response): Promise<void> {
+  // P3: exchanges a refresh token for a new session pair + user payload.
+  async refresh(req: Request, res: Response): Promise<void> {
+    const refreshToken =
+      typeof req.body?.refreshToken === 'string' ? req.body.refreshToken.trim() : '';
+
+    if (!refreshToken) {
+      res.status(400).json({ message: 'Refresh token is required.' });
+      return;
+    }
+
+    try {
+      const result = await authService.refresh(refreshToken);
+      res.status(200).json(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Token refresh failed';
+      res.status(401).json({ message });
+    }
+  },
+
+  // P4: call signOut() so the JWT is invalidated server-side, not just cleared client-side.
+  async logout(req: Request, res: Response): Promise<void> {
+    const authHeader = req.headers.authorization;
+    const accessToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
+
+    if (accessToken) {
+      try {
+        await createUserClient(accessToken).auth.signOut();
+      } catch {
+        // Best-effort: frontend clears cookies regardless of whether signOut succeeds.
+      }
+    }
+
     res.status(204).send();
   },
 };

--- a/apps/backend/src/graphql/server.ts
+++ b/apps/backend/src/graphql/server.ts
@@ -3,8 +3,15 @@
  *
  * Decision Context:
  * - Why: Integrates Apollo Server 5 with Express as per tech stack requirements.
- * - Pattern: Context extracts JWT from Authorization header for user-scoped operations.
- * - Previously fixed bugs: Fixed import path - AS5 uses manual middleware integration.
+ * - Pattern: Context extracts and verifies JWT via Supabase getUser() for user-scoped ops.
+ *   Returns null user for unauthenticated requests (public queries still work; resolvers
+ *   that require auth call requireAuth() which throws if user is null).
+ * - Previously fixed bugs:
+ *   - Fixed import path — AS5 uses manual middleware integration.
+ *   - extractUserFromToken() decoded the JWT with base64 without cryptographic verification,
+ *     allowing any structurally valid but forged token to pass. Fixed: now calls
+ *     createUserClient(token).auth.getUser() which validates the token signature against
+ *     Supabase. Forgeries are rejected with a null user.
  */
 
 import { ApolloServer, HeaderMap } from '@apollo/server';
@@ -16,6 +23,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { resolvers } from './resolvers/index.js';
+import { createUserClient } from '../config/supabase.js';
 import type { GraphQLContext } from '../types/context.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -33,23 +41,24 @@ function loadSchema() {
 }
 
 /**
- * Extract user from JWT token (simplified - production should verify JWT)
+ * Verify the Bearer token against Supabase and return the authenticated user.
+ * Returns null for missing, malformed, or invalid tokens so public resolvers
+ * still work; resolvers that require auth call requireAuth() to gate access.
  */
-function extractUserFromToken(authHeader?: string): { id: string; email: string } | null {
+async function extractUserFromToken(
+  authHeader?: string,
+): Promise<{ id: string; email: string } | null> {
   if (!authHeader?.startsWith('Bearer ')) {
     return null;
   }
-
   const token = authHeader.slice(7);
-
-  // TODO: Verify JWT with Supabase/jsonwebtoken
-  // For now, decode without verification for development
   try {
-    const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
-    return {
-      id: payload.sub,
-      email: payload.email,
-    };
+    const {
+      data: { user },
+      error,
+    } = await createUserClient(token).auth.getUser();
+    if (error || !user) return null;
+    return { id: user.id, email: user.email ?? '' };
   } catch {
     return null;
   }
@@ -85,7 +94,7 @@ export async function applyApolloMiddleware(app: Express): Promise<void> {
   // Manual Express integration for Apollo Server 5
   app.use('/graphql', async (req: Request, res: Response) => {
     const authHeader = req.headers.authorization;
-    const user = extractUserFromToken(authHeader);
+    const user = await extractUserFromToken(authHeader);
 
     const contextValue: GraphQLContext = {
       user,

--- a/apps/backend/src/routes/authRoutes.ts
+++ b/apps/backend/src/routes/authRoutes.ts
@@ -6,6 +6,7 @@ const router = Router();
 
 router.post('/login', authController.login);
 router.get('/session', authController.session);
+router.post('/refresh', authController.refresh);
 router.post('/logout', authController.logout);
 
 export default router;

--- a/apps/backend/src/services/authService.ts
+++ b/apps/backend/src/services/authService.ts
@@ -4,17 +4,28 @@
  * Decision Context:
  * - Why: Frontend must not access Supabase or the database directly. All auth and role
  *   resolution flows are brokered by the backend.
- * - Pattern: Uses anon client for credential login and backend-only clients for verified
- *   session/profile resolution.
- * - Constraints: Errors for invalid credentials remain ambiguous.
- * - Previously fixed bugs: none relevant.
+ * - Pattern: Uses anon client for credential login and user-scoped clients for session
+ *   and profile resolution so RLS policies are enforced on every profiles read.
+ * - Constraints: Errors for invalid credentials remain ambiguous (no email existence leak),
+ *   but email_not_confirmed IS propagated as a distinct message so the frontend can show
+ *   the correct banner without leaking whether the account exists.
+ * - Previously fixed bugs:
+ *   - login() used to throw 'Invalid login credentials' for ALL Supabase errors, including
+ *     email_not_confirmed, so the frontend "confirm your email" banner never appeared.
+ *     Fixed: inspect error.code / error.message before throwing the generic fallback.
+ *   - getUserRole() used the service-role singleton client, bypassing RLS. Fixed: now
+ *     accepts a user-scoped SupabaseClient and enforces RLS on the profiles read.
+ *   - mapAuthenticatedUser() read displayName from user_metadata.nombre instead of
+ *     profiles.displayName. Fixed: getUserProfile() now selects both role and displayName
+ *     from profiles; user_metadata.nombre is kept only as a last-resort fallback.
  */
 
-import type { User } from '@supabase/supabase-js';
+import type { User, SupabaseClient } from '@supabase/supabase-js';
 
 import { createAnonClient, createUserClient, supabase } from '../config/supabase.js';
 
-const PROFILE_ROLE_COLUMNS = 'role';
+// P3: include displayName so mapAuthenticatedUser reads from profiles, not user_metadata.
+const PROFILE_COLUMNS = 'role, displayName';
 
 export type AuthUserRole = 'player' | 'club_admin';
 
@@ -31,30 +42,42 @@ export interface LoginResult {
   user: AuthenticatedUser;
 }
 
-function mapAuthenticatedUser(user: User, role: AuthUserRole): AuthenticatedUser {
+interface UserProfile {
+  role: AuthUserRole;
+  displayName: string;
+}
+
+// P3: profiles.displayName is the authoritative source; user_metadata.nombre is last-resort fallback.
+function mapAuthenticatedUser(user: User, profile: UserProfile): AuthenticatedUser {
   return {
     id: user.id,
     email: user.email ?? '',
     displayName:
-      typeof user.user_metadata?.nombre === 'string'
+      profile.displayName ||
+      (typeof user.user_metadata?.nombre === 'string'
         ? user.user_metadata.nombre
-        : user.email ?? 'Usuario',
-    role,
+        : user.email ?? 'Usuario'),
+    role: profile.role,
   };
 }
 
-async function getUserRole(userId: string): Promise<AuthUserRole> {
-  const { data, error } = await supabase
+// M2: accepts user-scoped client so RLS enforces auth.uid() = id on the profiles read.
+// P3: returns both role and displayName to avoid a second round-trip to profiles.
+async function getUserProfile(userId: string, client: SupabaseClient): Promise<UserProfile> {
+  const { data, error } = await client
     .from('profiles')
-    .select(PROFILE_ROLE_COLUMNS)
+    .select(PROFILE_COLUMNS)
     .eq('id', userId)
     .single();
 
   if (error || !data) {
-    throw new Error(error?.message ?? 'Unable to resolve user role');
+    throw new Error(error?.message ?? 'Unable to resolve user profile');
   }
 
-  return data.role as AuthUserRole;
+  return {
+    role: data.role as AuthUserRole,
+    displayName: data.displayName as string,
+  };
 }
 
 export const authService = {
@@ -62,16 +85,33 @@ export const authService = {
     const authClient = createAnonClient();
     const { data, error } = await authClient.auth.signInWithPassword({ email, password });
 
-    if (error || !data.session || !data.user) {
+    if (error) {
+      // P1: preserve the email_not_confirmed signal so the frontend can show the correct
+      // banner. All other Supabase errors collapse to the ambiguous fallback to avoid
+      // leaking whether an account exists.
+      const code = error.code ?? '';
+      const msg = error.message ?? '';
+      if (
+        code === 'email_not_confirmed' ||
+        msg.toLowerCase().includes('email not confirmed')
+      ) {
+        throw new Error('Email not confirmed');
+      }
       throw new Error('Invalid login credentials');
     }
 
-    const role = await getUserRole(data.user.id);
+    if (!data.session || !data.user) {
+      throw new Error('Invalid login credentials');
+    }
+
+    // M2: use user-scoped client so the profiles SELECT respects RLS.
+    const userClient = createUserClient(data.session.access_token);
+    const profile = await getUserProfile(data.user.id, userClient);
 
     return {
       accessToken: data.session.access_token,
       refreshToken: data.session.refresh_token,
-      user: mapAuthenticatedUser(data.user, role),
+      user: mapAuthenticatedUser(data.user, profile),
     };
   },
 
@@ -86,7 +126,26 @@ export const authService = {
       throw new Error('Invalid or expired token');
     }
 
-    const role = await getUserRole(user.id);
-    return mapAuthenticatedUser(user, role);
+    // M2: pass the existing user-scoped client so profiles read respects RLS.
+    const profile = await getUserProfile(user.id, userClient);
+    return mapAuthenticatedUser(user, profile);
+  },
+
+  // P3: exchanges a refresh token for a new session, returns fresh tokens + resolved profile.
+  async refresh(refreshToken: string): Promise<LoginResult> {
+    const { data, error } = await supabase.auth.refreshSession({ refresh_token: refreshToken });
+
+    if (error || !data.session || !data.user) {
+      throw new Error('Invalid or expired refresh token');
+    }
+
+    const userClient = createUserClient(data.session.access_token);
+    const profile = await getUserProfile(data.user.id, userClient);
+
+    return {
+      accessToken: data.session.access_token,
+      refreshToken: data.session.refresh_token,
+      user: mapAuthenticatedUser(data.user, profile),
+    };
   },
 };

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,2 +1,6 @@
 # Backend app URL para auth SSR y rutas internas del frontend.
 PRIVATE_BACKEND_URL=http://localhost:4000
+
+# Forzar cookies secure=true cuando el servidor está detrás de un proxy TLS (Nginx, Vercel, etc.)
+# Dejar en false (o sin definir) en desarrollo local.
+PRIVATE_IS_PROD=false

--- a/apps/frontend/src/lib/auth.ts
+++ b/apps/frontend/src/lib/auth.ts
@@ -5,11 +5,21 @@
  * - Why: Frontend must not depend on Supabase SDKs or query the database directly.
  *   Astro server code talks only to backend REST auth endpoints.
  * - Pattern: Access token is stored in an HttpOnly cookie and forwarded to the backend
- *   for session validation on SSR requests.
- * - Previously fixed bugs: none relevant.
+ *   for session validation on SSR requests. The refresh token is stored separately with a
+ *   longer maxAge (30 days) so sessions survive browser restarts and access token expiry.
+ * - Previously fixed bugs:
+ *   - getAuthCookieOptions() returned no maxAge, making cookies session-only (cleared on
+ *     browser close). Fixed: access token gets 1 h maxAge, refresh token gets 30 days.
+ *   - refreshFromBackend() did not exist, so expired access tokens always caused a /login
+ *     redirect even when a valid refresh token was present. Fixed: added refresh helpers
+ *     consumed by the middleware to silently renew sessions.
+ *   - isProd was derived from Astro.url.protocol which returns 'http:' behind TLS-terminating
+ *     proxies (Nginx, Vercel, Cloudflare), causing secure:false on production cookies.
+ *     Fixed: isProduction() checks PRIVATE_IS_PROD env var first, then X-Forwarded-Proto,
+ *     then falls back to URL protocol as last resort.
  */
 
-import type { AstroCookies, CookieAttributes } from 'astro';
+import type { AstroCookies, AstroCookieSetOptions } from 'astro';
 
 export type UserRole = 'player' | 'club_admin';
 
@@ -29,19 +39,38 @@ export interface LoginResponse {
 export const ACCESS_TOKEN_COOKIE = 'sumateya-access-token';
 export const REFRESH_TOKEN_COOKIE = 'sumateya-refresh-token';
 
+// P2: separate TTLs — access token is short-lived, refresh token survives 30 days.
+export const ACCESS_TOKEN_MAX_AGE = 60 * 60; // 1 hour (seconds)
+export const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 30; // 30 days (seconds)
+
 const backendUrl =
   import.meta.env.PRIVATE_BACKEND_URL || process.env.PRIVATE_BACKEND_URL || 'http://localhost:4000';
+
+/**
+ * Determines whether the current request is running under HTTPS.
+ * Priority:
+ *  1. PRIVATE_IS_PROD env var (explicit override — reliable behind TLS-terminating proxies)
+ *  2. X-Forwarded-Proto header (set by Nginx, Vercel, Cloudflare, etc.)
+ *  3. URL protocol fallback (accurate only when the app is directly exposed)
+ */
+export function isProduction(request: Request): boolean {
+  if (import.meta.env.PRIVATE_IS_PROD === 'true') return true;
+  if (request.headers.get('x-forwarded-proto') === 'https') return true;
+  return new URL(request.url).protocol === 'https:';
+}
 
 export function getRoleRedirect(role: UserRole | undefined): string {
   return role === 'club_admin' ? '/panel-club' : '/partidos';
 }
 
-export function getAuthCookieOptions(isProd: boolean): CookieAttributes {
+// P2: maxAge param makes the cookie persistent (vs session-only when omitted).
+export function getAuthCookieOptions(isProd: boolean, maxAge?: number): AstroCookieSetOptions {
   return {
     httpOnly: true,
     sameSite: 'lax',
     secure: isProd,
     path: '/',
+    ...(maxAge !== undefined ? { maxAge } : {}),
   };
 }
 
@@ -52,6 +81,11 @@ export function clearAuthCookies(cookies: AstroCookies): void {
 
 export function readAccessToken(cookies: AstroCookies): string | undefined {
   return cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+}
+
+// P3: read the refresh token cookie for silent session renewal.
+export function readRefreshToken(cookies: AstroCookies): string | undefined {
+  return cookies.get(REFRESH_TOKEN_COOKIE)?.value;
 }
 
 export async function loginWithBackend(email: string, password: string): Promise<LoginResponse> {
@@ -91,6 +125,31 @@ export async function getSessionFromBackend(accessToken: string): Promise<AuthUs
 
   const payload = (await response.json()) as { user?: AuthUser };
   return payload.user ?? null;
+}
+
+// P3: exchange a refresh token for a new session; throws if the token is invalid/expired.
+export async function refreshFromBackend(refreshToken: string): Promise<LoginResponse> {
+  const response = await fetch(`${backendUrl}/api/auth/refresh`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  const payload = (await response.json().catch(() => null)) as
+    | { message?: string; accessToken?: string; refreshToken?: string; user?: AuthUser }
+    | null;
+
+  if (!response.ok || !payload?.accessToken || !payload.refreshToken || !payload.user) {
+    throw new Error(payload?.message ?? 'Token refresh failed');
+  }
+
+  return {
+    accessToken: payload.accessToken,
+    refreshToken: payload.refreshToken,
+    user: payload.user,
+  };
 }
 
 export async function logoutFromBackend(accessToken?: string): Promise<void> {

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -5,28 +5,46 @@
  * - Why: Centralizes auth checks so individual pages don't repeat getUser() + redirect logic.
  * - Pattern: Checks PROTECTED_ROUTES first (short-circuit for public paths).
  *   It forwards the access token cookie to backend auth endpoints and never talks to Supabase.
+ * - Refresh flow (P3): if the access token is missing or invalid AND a refresh token cookie
+ *   exists, the middleware silently calls /api/auth/refresh, overwrites both cookies in the
+ *   response, and continues the request. Only if refresh also fails does it redirect to /login.
+ *   This keeps sessions alive past the 1-hour JWT TTL without the user noticing.
  * - Security: Frontend only trusts backend-validated session payloads.
- * - Previously fixed bugs: none relevant.
+ * - TODO (M3 — performance): cache the result of getSessionFromBackend() keyed by access
+ *   token hash with a 30-second TTL to avoid 2 roundtrips (middleware → backend → Supabase
+ *   + DB) on every SSR navigation. Not implemented now to keep complexity low; revisit if
+ *   /partidos shows measurable latency under load.
+ * - Previously fixed bugs:
+ *   - Missing /perfil in PROTECTED_ROUTES (added in M1 — placeholder for future page).
+ *   - No refresh logic: expired tokens always redirected to /login. Fixed in P3 above.
  */
 
 import { defineMiddleware } from 'astro:middleware';
 import {
+  ACCESS_TOKEN_COOKIE,
+  ACCESS_TOKEN_MAX_AGE,
+  REFRESH_TOKEN_COOKIE,
+  REFRESH_TOKEN_MAX_AGE,
   clearAuthCookies,
+  getAuthCookieOptions,
   getRoleRedirect,
   getSessionFromBackend,
+  isProduction,
   readAccessToken,
+  readRefreshToken,
+  refreshFromBackend,
   type UserRole,
 } from './lib/auth';
 
 /** Rutas que requieren autenticación */
-const PROTECTED_ROUTES: string[] = ['/partidos', '/panel-club'];
+const PROTECTED_ROUTES: string[] = ['/partidos', '/panel-club', '/perfil'];
 
 /** Rutas restringidas por rol: sólo accesibles para el rol indicado */
 const ROLE_RESTRICTED: Record<string, UserRole> = {
   '/panel-club': 'club_admin',
 };
 
-export const onRequest = defineMiddleware(async ({ cookies, url, redirect, locals }, next) => {
+export const onRequest = defineMiddleware(async ({ cookies, url, redirect, locals, request }, next) => {
   const pathname = url.pathname;
 
   // Rutas públicas: continuar sin verificar
@@ -35,17 +53,44 @@ export const onRequest = defineMiddleware(async ({ cookies, url, redirect, local
     return next();
   }
 
+  const isProd = isProduction(request);
   const accessToken = readAccessToken(cookies);
 
-  if (!accessToken) {
-    return redirect('/login');
+  let user = null;
+
+  if (accessToken) {
+    user = await getSessionFromBackend(accessToken);
+    if (!user) {
+      // Access token exists but is rejected (invalid or expired) — clear it before trying refresh.
+      cookies.delete(ACCESS_TOKEN_COOKIE, { path: '/' });
+    }
   }
 
-  const user = await getSessionFromBackend(accessToken);
-
+  // P3: if no valid user yet, attempt silent token refresh before giving up.
   if (!user) {
-    clearAuthCookies(cookies);
-    return redirect('/login');
+    const refreshToken = readRefreshToken(cookies);
+
+    if (!refreshToken) {
+      return redirect('/login');
+    }
+
+    try {
+      const result = await refreshFromBackend(refreshToken);
+      cookies.set(
+        ACCESS_TOKEN_COOKIE,
+        result.accessToken,
+        getAuthCookieOptions(isProd, ACCESS_TOKEN_MAX_AGE),
+      );
+      cookies.set(
+        REFRESH_TOKEN_COOKIE,
+        result.refreshToken,
+        getAuthCookieOptions(isProd, REFRESH_TOKEN_MAX_AGE),
+      );
+      user = result.user;
+    } catch {
+      clearAuthCookies(cookies);
+      return redirect('/login');
+    }
   }
 
   // Verificar restricción por rol

--- a/apps/frontend/src/pages/login.astro
+++ b/apps/frontend/src/pages/login.astro
@@ -14,11 +14,14 @@ export const prerender = false;
 import Layout from '../layouts/Layout.astro';
 import {
   ACCESS_TOKEN_COOKIE,
+  ACCESS_TOKEN_MAX_AGE,
   REFRESH_TOKEN_COOKIE,
+  REFRESH_TOKEN_MAX_AGE,
   clearAuthCookies,
   getAuthCookieOptions,
   getRoleRedirect,
   getSessionFromBackend,
+  isProduction,
   loginWithBackend,
   readAccessToken,
 } from '../lib/auth';
@@ -48,10 +51,19 @@ if (Astro.request.method === 'POST') {
   } else {
     try {
       const result = await loginWithBackend(emailValue, password);
-      const cookieOptions = getAuthCookieOptions(Astro.url.protocol === 'https:');
+      const isProd = isProduction(Astro.request);
 
-      Astro.cookies.set(ACCESS_TOKEN_COOKIE, result.accessToken, cookieOptions);
-      Astro.cookies.set(REFRESH_TOKEN_COOKIE, result.refreshToken, cookieOptions);
+      // P2: separate maxAge — short-lived access token, long-lived refresh token.
+      Astro.cookies.set(
+        ACCESS_TOKEN_COOKIE,
+        result.accessToken,
+        getAuthCookieOptions(isProd, ACCESS_TOKEN_MAX_AGE),
+      );
+      Astro.cookies.set(
+        REFRESH_TOKEN_COOKIE,
+        result.refreshToken,
+        getAuthCookieOptions(isProd, REFRESH_TOKEN_MAX_AGE),
+      );
 
       return Astro.redirect(getRoleRedirect(result.user.role));
     } catch (error) {

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,207 @@
+# Testing Manual — User Story: Login y Sesión
+
+> **Estado:** P1–P5 resueltos. Tests T1–T8 desbloqueados. T9–T12 requieren ejecución manual.
+>
+> | Fix | Estado | Descripción |
+> |-----|--------|-------------|
+> | P1 — RLS profiles INSERT/UPDATE | ✅ Aplicado via MCP | Políticas `authenticated` creadas |
+> | P2 — Logout UI + endpoint | ✅ Ya implementado | Botón "Salir" en topbar + `/api/auth/logout` |
+> | P3 — displayName desde profiles | ✅ Corregido | `getUserProfile()` lee `profiles.displayName` |
+> | P4 — isProduction() helper | ✅ Implementado | Respeta `PRIVATE_IS_PROD` y `X-Forwarded-Proto` |
+> | P5 — JWT verification en GraphQL | ✅ Corregido | `createUserClient().auth.getUser()` — firma validada |
+
+> Pasos para verificar manualmente el flujo completo de autenticación
+> después de los fixes P1–P5 + M1–M3.
+
+## Prerequisitos
+
+- Backend corriendo en `http://localhost:4000`
+- Frontend corriendo en `http://localhost:4321`
+- Al menos un usuario con `role = 'player'` en `profiles`
+- Al menos un usuario con `role = 'club_admin'` en `profiles`
+- Un usuario con cuenta creada pero email **sin confirmar**
+
+---
+
+## T1 — Login con credenciales válidas (player) ✅ Desbloqueable
+
+1. Navegar a `http://localhost:4321/login`
+2. Ingresar email y contraseña del usuario con rol `player`
+3. Hacer click en INGRESAR
+
+**Resultado esperado:** Redirect automático a `/partidos`. El topbar muestra el nombre del usuario.
+
+**Falla si:** Se muestra error, o redirige a `/panel-club`.
+
+---
+
+## T2 — Login con credenciales válidas (club_admin) ✅ Desbloqueable
+
+1. Navegar a `http://localhost:4321/login`
+2. Ingresar email y contraseña del usuario con rol `club_admin`
+3. Hacer click en INGRESAR
+
+**Resultado esperado:** Redirect automático a `/panel-club`. El topbar muestra la pill "CLUB".
+
+**Falla si:** Se muestra error, o redirige a `/partidos`.
+
+---
+
+## T3 — Email inexistente ✅ Desbloqueable
+
+1. Navegar a `http://localhost:4321/login`
+2. Ingresar un email que no existe + cualquier contraseña
+3. Hacer click en INGRESAR
+
+**Resultado esperado:** Banner de error con el texto "Email o contraseña incorrectos."
+
+**Falla si:** Aparece un error técnico, o el backend expone si el email existe o no.
+
+---
+
+## T4 — Contraseña incorrecta ✅ Desbloqueable
+
+1. Navegar a `http://localhost:4321/login`
+2. Ingresar un email válido + contraseña incorrecta
+3. Hacer click en INGRESAR
+
+**Resultado esperado:** Banner de error con el texto "Email o contraseña incorrectos."
+
+**Falla si:** Aparece un mensaje diferente al de T3 (no debe haber distinción entre email inexistente y contraseña incorrecta, para no revelar información de cuentas).
+
+---
+
+## T5 — Email no confirmado ✅ Desbloqueable
+
+1. Crear una cuenta nueva sin confirmar el email (o usar cuenta de prueba pre-configurada)
+2. Navegar a `http://localhost:4321/login`
+3. Ingresar las credenciales de esa cuenta
+4. Hacer click en INGRESAR
+
+**Resultado esperado:** Banner de error con el texto "Debés confirmar tu email antes de iniciar sesión. Revisá tu casilla de correo."
+
+**Falla si:** Aparece "Email o contraseña incorrectos." — esto indicaría que P1 no funciona.
+
+---
+
+## T6 — Acceso a /partidos sin sesión ✅ Desbloqueable
+
+1. Asegurarse de no tener cookies de sesión (usar ventana de incógnito o borrar cookies de `localhost`)
+2. Navegar directamente a `http://localhost:4321/partidos`
+
+**Resultado esperado:** Redirect inmediato a `/login`.
+
+**Falla si:** La página de partidos carga sin autenticación.
+
+---
+
+## T7 — Acceso a /panel-club como player ✅ Desbloqueable
+
+1. Iniciar sesión como usuario con rol `player`
+2. Navegar manualmente a `http://localhost:4321/panel-club`
+
+**Resultado esperado:** Redirect a `/partidos` (el middleware redirige al destino por defecto del rol).
+
+**Falla si:** El panel de club carga para un player.
+
+---
+
+## T8 — Acceso a /panel-club como club_admin ✅ Desbloqueable
+
+1. Iniciar sesión como usuario con rol `club_admin`
+2. Navegar a `http://localhost:4321/panel-club`
+
+**Resultado esperado:** El panel carga correctamente con la pill "CLUB" visible.
+
+**Falla si:** Redirect a otro lugar, o error 403/404.
+
+---
+
+## T9 — Sesión persistente al cerrar y abrir el browser 🔍 Test manual requerido
+
+1. Iniciar sesión como cualquier usuario
+2. Cerrar completamente el browser (no solo la pestaña)
+3. Abrir el browser nuevamente
+4. Navegar a `http://localhost:4321/partidos`
+
+**Resultado esperado:** La página carga sin pedirte login nuevamente (la cookie de refresh tiene `maxAge` de 30 días).
+
+**Falla si:** Redirige a `/login` — esto indicaría que P2 no funciona (cookies session-only).
+
+**Verificación adicional en DevTools:**
+- Abrir DevTools → Application → Cookies → `localhost`
+- Verificar que `sumateya-access-token` tiene fecha de expiración ~1 hora desde el login
+- Verificar que `sumateya-refresh-token` tiene fecha de expiración ~30 días desde el login
+
+---
+
+## T10 — Token expirado: refresh silencioso 🔍 Test manual requerido
+
+> Este test requiere manipular el tiempo o expirar el token manualmente.
+
+**Opción A — Borrar solo el access token:**
+1. Iniciar sesión como cualquier usuario
+2. Abrir DevTools → Application → Cookies → `localhost`
+3. Eliminar solo la cookie `sumateya-access-token` (dejar `sumateya-refresh-token`)
+4. Navegar a `http://localhost:4321/partidos`
+
+**Resultado esperado:** La página carga correctamente. El middleware detecta que el access token faltó, usa el refresh token para obtener uno nuevo, y sigue la request sin interrupción. En DevTools se ve que `sumateya-access-token` volvió a aparecer.
+
+**Falla si:** Redirige a `/login` — esto indicaría que P3 no funciona.
+
+---
+
+## T11 — Logout: cookie eliminada e invalidación server-side 🔍 Test manual requerido
+
+1. Iniciar sesión como cualquier usuario
+2. Hacer click en "Salir"
+
+**Resultado esperado:**
+- Redirect a `/login`
+- En DevTools → Application → Cookies: ambas cookies eliminadas
+- Intentar navegar a `/partidos` redirige a `/login` (sesión eliminada)
+
+**Verificación de invalidación server-side (fix P4):**
+
+Antes de hacer logout, copiar el valor del access token desde DevTools. Después del logout, intentar hacer una request manual:
+
+```bash
+curl -H "Authorization: Bearer <token-copiado>" http://localhost:4000/api/auth/session
+```
+
+**Resultado esperado:** `401 Unauthorized` — el token fue revocado en Supabase.
+
+**Falla si:** El endpoint devuelve 200 y datos del usuario — el token sigue activo server-side.
+
+---
+
+## T12 — Verificación de seguridad de cookies 🔍 Test manual requerido
+
+1. Iniciar sesión como cualquier usuario
+2. Abrir DevTools → Application → Cookies → `localhost`
+3. Verificar cada cookie:
+
+| Propiedad | `sumateya-access-token` | `sumateya-refresh-token` |
+|-----------|------------------------|--------------------------|
+| HttpOnly  | ✓ (no editable en JS) | ✓ |
+| SameSite  | Lax                   | Lax |
+| Secure    | false (dev HTTP)      | false (dev HTTP) |
+| MaxAge    | ~3600 s (1 hora)      | ~2592000 s (30 días) |
+
+4. Abrir la consola del browser y verificar que no se puede leer el token:
+
+```javascript
+document.cookie // NO debe mostrar sumateya-access-token ni sumateya-refresh-token
+```
+
+---
+
+## Verificación de RLS en `profiles` ✅ Completado via MCP
+
+Migración aplicada el 2026-04-25 via `mcp__supabase__apply_migration`. Las tres políticas están activas:
+
+| Política | Comando | Condición |
+|---|---|---|
+| Usuario puede leer su propio perfil | SELECT | `USING (auth.uid() = id)` |
+| Usuario puede crear su propio perfil | INSERT | `WITH CHECK (auth.uid() = id)` |
+| Usuario puede actualizar su propio perfil | UPDATE | `USING + WITH CHECK (auth.uid() = id)` |

--- a/docs/prompts/b5m2t9qa-prompt-log.md
+++ b/docs/prompts/b5m2t9qa-prompt-log.md
@@ -1,0 +1,18 @@
+# Prompt Log
+
+- Timestamp: 2026-04-25 00:00:00
+- Task ID: b5m2t9qa
+
+## User Prompt
+
+> Necesito que hagas una auditoría completa y exhaustiva de la User Story "Login y Sesión" en el proyecto sumate-ya. NO hagas cambios al código — solo analizá, testeá y reportá hallazgos.
+>
+> User Story: Como usuario registrado, quiero iniciar sesión con mi email y contraseña para acceder a mis partidos y perfil.
+>
+> Subtareas: pantalla de login, integración Supabase Auth signInWithPassword, persistencia JWT en cookie, redirección por rol, manejo de errores, middleware de auth en backend.
+
+## Agent Main Actions
+
+- Analizó estáticamente todos los archivos del flujo de login: `login.astro`, `middleware.ts`, `lib/auth.ts`, `authService.ts`, `authController.ts`, `authRoutes.ts`, `app.ts`, y `config/supabase.ts`.
+- Identificó 6 problemas críticos: email_not_confirmed silenciado por authService, cookies sin maxAge (sesión no persiste), refresh token sin implementar, logout sin signOut() en Supabase, CORS abierto, y RLS no verificable por falta de autenticación en MCP.
+- Generó un informe con 17 checks pasados, 3 problemas menores, 6 críticos y 11 tests manuales pendientes, con recomendación de no cerrar la User Story hasta resolver P1-P3.

--- a/docs/prompts/c3q7w1nx-prompt-log.md
+++ b/docs/prompts/c3q7w1nx-prompt-log.md
@@ -1,0 +1,16 @@
+# Prompt Log
+
+- Timestamp: 2026-04-25 14:35:00
+- Task ID: c3q7w1nx
+
+## User Prompt
+
+> Estoy en la rama Login-y-sesión y necesito corregir TODOS los problemas críticos detectados en la auditoría de la User Story "Login y Sesión" para poder cerrarla.
+>
+> Problemas críticos: P1 (email_not_confirmed silenciado), P2 (cookies sin maxAge), P3 (refresh token no usado), P4 (logout sin signOut), P5 (CORS abierto), P6 (RLS en profiles sin verificar). Problemas menores: M1 (/perfil faltante en PROTECTED_ROUTES), M2 (getUserRole usa service-role), M3 (costo de requests documentar como TODO). También crear TESTING.md con pasos de tests manuales.
+
+## Agent Main Actions
+
+- Corrigió P1–P5 y M1–M3 en 8 archivos: `authService.ts` (error propagation + user-scoped getUserRole + refresh method), `authController.ts` (refresh endpoint + logout signOut best-effort), `authRoutes.ts` (nueva ruta /refresh), `app.ts` (CORS restringido a FRONTEND_URL), `lib/auth.ts` (maxAge separados + readRefreshToken + refreshFromBackend, fix tipo CookieAttributes→AstroCookieSetOptions), `middleware.ts` (refresh silencioso + /perfil + TODO cache), `login.astro` (cookies con maxAge separados).
+- Documentó P6 como bloqueado (Supabase MCP sin autenticar) con pasos de verificación en TESTING.md, y creó `docs/TESTING.md` con 12 tests manuales paso a paso para todos los escenarios de la User Story.
+- Ejecutó `turbo typecheck --force` (backend 0 errores) y `astro check` (frontend 0 errores, 1 hint falso positivo), confirmando que todos los cambios pasan typecheck antes del cierre.

--- a/docs/prompts/k4v9m2xn-prompt-log.md
+++ b/docs/prompts/k4v9m2xn-prompt-log.md
@@ -1,0 +1,15 @@
+# Prompt Log
+
+- Timestamp: 2026-04-25 00:00:00
+- Task ID: k4v9m2xn
+
+## User Prompt
+
+> Necesito que hagas una auditoría completa y exhaustiva de la User Story "Login y Sesión" en el proyecto sumate-ya. NO hagas cambios al código — solo analizá, testeá y reportá hallazgos.
+> [re-auditoría post-fixes P1–P5]
+
+## Agent Main Actions
+
+- Leyó el estado actual de 6 archivos clave (login.astro, middleware.ts, lib/auth.ts, authService.ts, graphql/server.ts, middleware/auth.ts) y ejecutó 2 queries MCP para verificar políticas RLS y distribución de roles, confirmando que todos los fixes P1–P5 están correctamente aplicados.
+- Verificó que los 29 checks pasan sin problemas críticos: RLS con 3 políticas activas (SELECT/INSERT/UPDATE), JWT verificado criptográficamente en GraphQL via getUser(), isProduction() proxy-aware, displayName desde profiles.displayName, logout funcional.
+- Reportó 1 problema cosmético (comentario decision context desactualizado en login.astro) y 4 tests manuales pendientes (T9-T12: persistencia, refresh silencioso, logout y seguridad de cookies) que no bloquean el cierre de la User Story.

--- a/docs/prompts/p9k3m7vx-prompt-log.md
+++ b/docs/prompts/p9k3m7vx-prompt-log.md
@@ -1,0 +1,15 @@
+# Prompt Log
+
+- Timestamp: 2026-04-25 00:00:00
+- Task ID: p9k3m7vx
+
+## User Prompt
+
+> Necesito que hagas una auditoría completa y exhaustiva de la User Story "Login y Sesión" en el proyecto sumate-ya. NO hagas cambios al código — solo analizá, testeá y reportá hallazgos.
+> [... especificación completa de subtareas 1-6, notas técnicas y formato de respuesta ...]
+
+## Agent Main Actions
+
+- Leyó y analizó 9 archivos de código (login.astro, middleware.ts, lib/auth.ts, authController.ts, authService.ts, authRoutes.ts, app.ts, middleware/auth.ts, config/supabase.ts) y ejecutó 4 queries via Supabase MCP para verificar RLS, schema de profiles y usuarios de test.
+- Identificó 1 problema crítico (faltan políticas RLS INSERT/UPDATE en public.profiles), 5 problemas menores (no hay UI de logout, displayName inconsistente, riesgo secure flag detrás de proxy, authMiddleware no verificado en GraphQL) y 24 checks que pasan correctamente.
+- Produjo informe completo con estado por subtarea, tabla de checks de seguridad, 12 tests manuales recomendados y recomendación de no cerrar la User Story hasta resolver el problema crítico y completar los tests pendientes.

--- a/docs/prompts/r7q3n5wk-prompt-log.md
+++ b/docs/prompts/r7q3n5wk-prompt-log.md
@@ -1,0 +1,17 @@
+# Prompt Log
+
+- Timestamp: 2026-04-25 00:00:00
+- Task ID: r7q3n5wk
+
+## User Prompt
+
+> Ahora que Supabase MCP está autenticado, verificá P6 de la auditoría:
+> revisar la política RLS de SELECT en public.profiles. Debe permitir
+> auth.uid() = id para que cada usuario pueda leer su propio perfil.
+> Si falta o es incorrecta, creá la migración via MCP para corregirla.
+
+## Agent Main Actions
+
+- Diagnosticó y resolvió múltiples problemas de conexión del MCP de Supabase: corrigió el `.vscode/mcp.json` (bloque `mcpServers` anidado incorrectamente), limpió `mcp-needs-auth-cache.json`, y cambió el servidor de HTTP+OAuth a stdio+PAT en `.mcp.json` para evitar el loop de autenticación.
+- Verificó via `execute_sql` las políticas RLS de `public.profiles`: encontró la política "Usuario puede leer su propio perfil" con `USING (auth.uid() = id)` en SELECT, y confirmó que RLS está habilitado (`rls_enabled = true`).
+- Determinó que P6 pasa la auditoría sin cambios — la política SELECT correcta ya existe y no se requiere migración.

--- a/docs/prompts/w8n2k5qr-prompt-log.md
+++ b/docs/prompts/w8n2k5qr-prompt-log.md
@@ -1,0 +1,15 @@
+# Prompt Log
+
+- Timestamp: 2026-04-25 00:00:00
+- Task ID: w8n2k5qr
+
+## User Prompt
+
+> Estoy en la rama Login-y-sesión. Necesito resolver los 6 problemas detectados en la auditoría reciente para poder cerrar la User Story "Login y Sesión".
+> [P1 RLS INSERT/UPDATE, P2 logout UI, P3 displayName, P4 isProduction(), P5 GraphQL JWT, P6 TESTING.md]
+
+## Agent Main Actions
+
+- Aplicó migración RLS via Supabase MCP creando políticas INSERT (`WITH CHECK auth.uid() = id`) y UPDATE (`USING + WITH CHECK auth.uid() = id`) en `public.profiles`; verificó las 3 políticas activas con query de confirmación.
+- Corrigió `authService.ts`: renombró `PROFILE_ROLE_COLUMNS` a `PROFILE_COLUMNS` incluyendo `displayName`, reemplazó `getUserRole()` con `getUserProfile()` que retorna `{ role, displayName }`, actualizó `mapAuthenticatedUser()` para usar `profiles.displayName` como fuente primaria; añadió `isProduction(request)` a `lib/auth.ts` con prioridad PRIVATE_IS_PROD → X-Forwarded-Proto → URL protocol, y usó el helper en `login.astro` y `middleware.ts`.
+- Reemplazó en `graphql/server.ts` el decodificado base64 sin verificación por `createUserClient(token).auth.getUser()` para validar la firma JWT criptográficamente; actualizó `docs/TESTING.md` con el estado de cada test (T1–T8 desbloqueables, T9–T12 pendientes de test manual); typecheck pasó sin errores.


### PR DESCRIPTION
- Added refresh endpoint to authController for exchanging refresh tokens.
- Updated authService to handle refresh token logic and return user profile.
- Enhanced logout functionality to ensure JWT is invalidated server-side.
- Restricted CORS in app.ts to allow only specified frontend URL.
- Improved cookie management in frontend to support separate maxAge for access and refresh tokens.
- Implemented silent refresh logic in middleware to maintain user sessions.
- Created comprehensive testing documentation for login and session flows.
- Verified RLS policies in Supabase to ensure user-specific access to profiles.