### PR TITLE
feat: Implement navigation for joining matches in MatchList component

### DIFF
--- a/apps/frontend/src/components/matches/MatchList.tsx
+++ b/apps/frontend/src/components/matches/MatchList.tsx
@@ -60,10 +60,10 @@ export function MatchList({ initialMatches, isAuthenticated = false }: MatchList
   }, [fetchMatches]);
 
   const handleJoin = (matchId: string) => {
-    // TODO: Implement join match mutation against the backend once the
-    // matchPlayers table + RLS policies are in place (see backend.md rule
-    // "NEVER write to a new table without adding RLS policies").
-    alert(`Próximamente: unirse al partido ${matchId}`);
+    // Navigate to the match detail page where team selection + JoinTeamButton
+    // handle the full join flow (auth, team A/B choice, mutation, reload).
+    // Previously fixed bugs: was a placeholder alert() — replaced with navigation.
+    window.location.href = `/partidos/${matchId}`;
   };
 
   return (

--- a/docs/prompts/b5r2m7qx-prompt-log.md
+++ b/docs/prompts/b5r2m7qx-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-04-26 10:53:00
+- Task ID: b5r2m7qx
+
+## User Prompt
+
+> revisa el boton "SUMARME" que no funciona dentro del branch "unirse-partido"
+
+## Agent Main Actions
+
+- Identified that `handleJoin` in `MatchList.tsx` was a placeholder calling `alert("Próximamente: unirse al partido...")` instead of performing a real action.
+- Fixed `handleJoin` to navigate to `/partidos/${matchId}`, where the complete join flow (team selection, `JoinTeamButton`, GraphQL mutation) is already implemented.
+- Ran `turbo typecheck --force` — passed with 0 errors.


### PR DESCRIPTION
Se pasa nuevamente a desarollo para ajustar la funcionabilidad: El click en "Sumarme" ahora navega a la página de detalle, que ya tiene el flujo completo: selector de equipo (A o B)