### PR TITLE
feat: Implement complete match detail view for players

### DIFF
--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -25,6 +25,7 @@ export type Club = {
   lat?: Maybe<Scalars['Float']['output']>;
   lng?: Maybe<Scalars['Float']['output']>;
   name: Scalars['String']['output'];
+  phone?: Maybe<Scalars['String']['output']>;
   zone?: Maybe<Scalars['String']['output']>;
 };
 
@@ -111,10 +112,12 @@ export type Match = {
   canJoin?: Maybe<Scalars['Boolean']['output']>;
   club?: Maybe<Club>;
   createdAt: Scalars['String']['output'];
+  currentUserTeam?: Maybe<MatchTeam>;
   description?: Maybe<Scalars['String']['output']>;
   format: MatchFormat;
   id: Scalars['ID']['output'];
   isCurrentUserJoined?: Maybe<Scalars['Boolean']['output']>;
+  organizerId?: Maybe<Scalars['ID']['output']>;
   participants?: Maybe<MatchParticipantsData>;
   startTime: Scalars['String']['output'];
   status: MatchStatus;
@@ -234,6 +237,7 @@ export type TeamMember = {
   avatarUrl?: Maybe<Scalars['String']['output']>;
   displayName: Scalars['String']['output'];
   id: Scalars['ID']['output'];
+  preferredPosition?: Maybe<Scalars['String']['output']>;
 };
 
 export enum UserRole {
@@ -378,6 +382,7 @@ export type ClubResolvers<ContextType = GraphQLContext, ParentType extends Resol
   lat?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   lng?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  phone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   zone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
@@ -431,10 +436,12 @@ export type MatchResolvers<ContextType = GraphQLContext, ParentType extends Reso
   canJoin?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   club?: Resolver<Maybe<ResolversTypes['Club']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  currentUserTeam?: Resolver<Maybe<ResolversTypes['MatchTeam']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   format?: Resolver<ResolversTypes['MatchFormat'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   isCurrentUserJoined?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  organizerId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   participants?: Resolver<Maybe<ResolversTypes['MatchParticipantsData']>, ParentType, ContextType>;
   startTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   status?: Resolver<ResolversTypes['MatchStatus'], ParentType, ContextType>;
@@ -482,6 +489,7 @@ export type TeamMemberResolvers<ContextType = GraphQLContext, ParentType extends
   avatarUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  preferredPosition?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{

--- a/apps/backend/src/graphql/resolvers/domains/match.ts
+++ b/apps/backend/src/graphql/resolvers/domains/match.ts
@@ -16,12 +16,16 @@
  * - Previously fixed bugs:
  *   - match(id) used getMatchById which returned no participant data — upgraded to
  *     getMatchDetail so the detail page can show team rosters and join buttons.
+ *   - match(id) had no UUID validation — added UUID_REGEX guard to avoid wasting a
+ *     DB round-trip on obviously invalid IDs (e.g., "abc", "undefined").
  */
 
 import { createUserClient } from '../../../config/supabase.js';
 import { matchService } from '../../../services/matchService.js';
 import { requireAuth } from '../../../types/context.js';
 import type { MutationResolvers, QueryResolvers } from '../../generated/graphql.js';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const Query: QueryResolvers = {
   /**
@@ -35,8 +39,13 @@ const Query: QueryResolvers = {
   /**
    * Get a single match by ID with full participant data.
    * Public endpoint — auth context is optional; if present, populates isCurrentUserJoined.
+   * UUID validation prevents an unnecessary DB round-trip for obviously invalid IDs.
    */
   match: async (_parent, args, ctx) => {
+    if (!UUID_REGEX.test(args.id)) {
+      console.warn(`[matchResolver.match] Invalid UUID format: ${args.id}`);
+      return null;
+    }
     return matchService.getMatchDetail(
       {
         userId: ctx.user?.id,

--- a/apps/backend/src/graphql/schema/match.graphql
+++ b/apps/backend/src/graphql/schema/match.graphql
@@ -11,7 +11,17 @@
 #   without any extra DB round-trips or N+1 joins.
 # - isCurrentUserJoined / canJoin are resolver-computed from the GraphQL context user and
 #   the participant list; they are null when no auth context is present.
-# - Previously fixed bugs: none relevant.
+# - organizerId added for the detail-page US so the frontend can badge the organizer player
+#   without a separate profile query. It is intentionally nullable so list queries can
+#   omit it without any schema change.
+# - currentUserTeam added so the detail page can show "Ya estás anotado en Equipo X"
+#   without having to scan the participant list on the client side.
+# - phone added to Club for the location card on the detail page.
+# - preferredPosition added to TeamMember as a raw String (not the PlayerPosition enum)
+#   so it passes through the DB value without a separate enum-mapping layer in this query
+#   path. Display mapping happens in the frontend PlayerCard component.
+# - Previously fixed bugs:
+#   - Botón "Sumarme" mostraba alert placeholder — replaced by navigation to detail page.
 
 type Club {
   id: ID!
@@ -21,6 +31,7 @@ type Club {
   lat: Float
   lng: Float
   imageUrl: String
+  phone: String
 }
 
 # Minimal player info shown inside a team list
@@ -28,6 +39,7 @@ type TeamMember {
   id: ID!
   displayName: String!
   avatarUrl: String
+  preferredPosition: String
 }
 
 # Participants split by team with counts and available spots
@@ -60,6 +72,10 @@ type Match {
   # Auth-context flags: null when user is not authenticated
   isCurrentUserJoined: Boolean
   canJoin: Boolean
+  # ID of the player who created the match — null on list queries that skip this field
+  organizerId: ID
+  # Team the current user is enrolled in — null when not joined or unauthenticated
+  currentUserTeam: MatchTeam
 }
 
 enum MatchFormat {

--- a/apps/backend/src/repositories/matchRepository.ts
+++ b/apps/backend/src/repositories/matchRepository.ts
@@ -39,8 +39,7 @@ const MATCH_COLUMNS = `
   "clubId"
 `;
 
-// lat/lng/address added for map view — these were intentionally excluded before
-// to save egress; now they are fetched explicitly so the Club type can expose them.
+// Used by list queries (matches, search) — omits phone to keep egress minimal.
 const CLUB_COLUMNS = `
   id,
   name,
@@ -48,6 +47,18 @@ const CLUB_COLUMNS = `
   address,
   lat,
   lng
+`;
+
+// Used only by the detail query — adds phone for the ClubLocationCard.
+// Kept separate so list queries don't pay the phone egress cost.
+const CLUB_DETAIL_COLUMNS = `
+  id,
+  name,
+  zone,
+  address,
+  lat,
+  lng,
+  phone
 `;
 
 // =====================================================
@@ -72,6 +83,11 @@ export interface ClubRow {
   address: string | null;
   lat: number | null;
   lng: number | null;
+}
+
+/** Extended club row used only in detail queries — includes phone. */
+export interface ClubDetailRow extends ClubRow {
+  phone: string | null;
 }
 
 export interface MatchWithClub extends MatchRow {
@@ -332,13 +348,14 @@ const PARTICIPANT_COLUMNS = `
   id,
   team,
   "joinedAt",
-  profiles(id, "displayName", "avatarUrl")
+  profiles(id, "displayName", "avatarUrl", "preferredPosition")
 `;
 
 export interface ParticipantProfileRow {
   id: string;
   displayName: string;
   avatarUrl: string | null;
+  preferredPosition: string | null;
 }
 
 export interface ParticipantRow {
@@ -357,7 +374,7 @@ export interface MatchDetailRow {
   capacity: number;
   status: string;
   createdAt: string;
-  clubs: ClubRow | null;
+  clubs: ClubDetailRow | null;
   matchParticipants: ParticipantRow[];
 }
 
@@ -380,7 +397,7 @@ export async function getMatchWithParticipants(
 ): Promise<MatchDetailRow | null> {
   const { data, error } = await client
     .from('matches')
-    .select(`${MATCH_DETAIL_COLUMNS}, clubs(${CLUB_COLUMNS}), matchParticipants(${PARTICIPANT_COLUMNS})`)
+    .select(`${MATCH_DETAIL_COLUMNS}, clubs(${CLUB_DETAIL_COLUMNS}), matchParticipants(${PARTICIPANT_COLUMNS})`)
     .eq('id', id)
     .single();
 

--- a/apps/backend/src/services/matchService.ts
+++ b/apps/backend/src/services/matchService.ts
@@ -107,6 +107,7 @@ function toMatch(row: MatchWithClub): Match {
           address: row.clubs.address ?? null,
           lat: row.clubs.lat ?? null,
           lng: row.clubs.lng ?? null,
+          // phone is not fetched by CLUB_COLUMNS (list path) — omitted intentionally.
         }
       : null,
   };
@@ -215,22 +216,43 @@ export async function getMatchById(_ctx: ServiceContext, id: string): Promise<Ma
  * - userId is optional — when null (unauthenticated), isCurrentUserJoined = false, canJoin = false.
  * - canJoin does NOT check player role: that check belongs in the joinMatch mutation so the
  *   flag stays accurate even before the user authenticates. The mutation enforces role server-side.
- * - Previously fixed bugs: none relevant.
+ * - canJoin requires !!userId so unauthenticated callers always get false (P2 audit fix).
+ *   Without this, open matches with available spots returned canJoin=true for anonymous users,
+ *   which was semantically incorrect per the field's documented contract.
+ * - Previously fixed bugs:
+ *   - canJoin returned true for unauthenticated users — fixed by adding !!userId guard.
  */
 function toMatchDetail(row: MatchDetailRow, userId?: string): Match {
   const teamA = row.matchParticipants
     .filter((p) => p.team === 'a')
-    .map((p) => ({ id: p.profiles.id, displayName: p.profiles.displayName, avatarUrl: p.profiles.avatarUrl ?? null }));
+    .map((p) => ({
+      id: p.profiles.id,
+      displayName: p.profiles.displayName,
+      avatarUrl: p.profiles.avatarUrl ?? null,
+      preferredPosition: p.profiles.preferredPosition ?? null,
+    }));
 
   const teamB = row.matchParticipants
     .filter((p) => p.team === 'b')
-    .map((p) => ({ id: p.profiles.id, displayName: p.profiles.displayName, avatarUrl: p.profiles.avatarUrl ?? null }));
+    .map((p) => ({
+      id: p.profiles.id,
+      displayName: p.profiles.displayName,
+      avatarUrl: p.profiles.avatarUrl ?? null,
+      preferredPosition: p.profiles.preferredPosition ?? null,
+    }));
 
   const spotsPerTeam = Math.floor(row.capacity / 2);
   const totalCount = teamA.length + teamB.length;
   const isCurrentUserJoined = userId
     ? row.matchParticipants.some((p) => p.profiles.id === userId)
     : false;
+
+  const userParticipant = userId
+    ? row.matchParticipants.find((p) => p.profiles.id === userId)
+    : null;
+  const currentUserTeam = userParticipant
+    ? (userParticipant.team === 'a' ? MatchTeam.A : MatchTeam.B)
+    : null;
 
   return {
     id: row.id,
@@ -242,6 +264,8 @@ function toMatchDetail(row: MatchDetailRow, userId?: string): Match {
     status: DB_TO_STATUS[row.status] ?? MatchStatus.Open,
     createdAt: row.createdAt,
     description: row.description ?? null,
+    organizerId: row.organizerId ?? null,
+    currentUserTeam,
     club: row.clubs
       ? {
           id: row.clubs.id,
@@ -250,6 +274,7 @@ function toMatchDetail(row: MatchDetailRow, userId?: string): Match {
           address: row.clubs.address ?? null,
           lat: row.clubs.lat ?? null,
           lng: row.clubs.lng ?? null,
+          phone: row.clubs.phone ?? null,
         }
       : null,
     participants: {
@@ -262,7 +287,7 @@ function toMatchDetail(row: MatchDetailRow, userId?: string): Match {
       spotsLeftB: Math.max(0, spotsPerTeam - teamB.length),
     },
     isCurrentUserJoined,
-    canJoin: row.status === 'open' && !isCurrentUserJoined && totalCount < row.capacity,
+    canJoin: !!userId && row.status === 'open' && !isCurrentUserJoined && totalCount < row.capacity,
   };
 }
 

--- a/apps/frontend/src/components/matches/ClubLocationCard.astro
+++ b/apps/frontend/src/components/matches/ClubLocationCard.astro
@@ -1,0 +1,184 @@
+---
+/**
+ * ClubLocationCard — Static card showing club location info
+ *
+ * Decision Context:
+ * - Why Astro: purely static — no interactivity needed. The "Ver en mapa" link is a
+ *   plain <a target="_blank"> pointing to Google Maps; no JS required.
+ * - Google Maps URL: uses q=lat,lng format which opens a directions/search view in
+ *   any browser. Prefer this over embed iframes to avoid Google Maps API costs.
+ * - The map link is only rendered when both lat and lng are non-null. Legacy club rows
+ *   may lack geocoded coordinates — callers should not assume they exist.
+ * - phone is shown when present; hidden when null to avoid empty UI elements.
+ * - Previously fixed bugs: none relevant.
+ */
+
+interface ClubLocationProps {
+  id: string;
+  name: string;
+  zone: string | null;
+  address: string | null;
+  lat: number | null;
+  lng: number | null;
+  phone: string | null;
+}
+
+interface Props {
+  club: ClubLocationProps;
+}
+
+const { club } = Astro.props;
+
+const mapsUrl =
+  club.lat != null && club.lng != null
+    ? `https://www.google.com/maps?q=${club.lat},${club.lng}`
+    : null;
+---
+
+<div class="location-card">
+  <div class="location-header">
+    <span class="location-icon">📍</span>
+    <h2 class="club-name">{club.name}</h2>
+  </div>
+
+  <div class="location-details">
+    {club.address && (
+      <div class="detail-row">
+        <span class="detail-label">Dirección</span>
+        <span class="detail-value">{club.address}</span>
+      </div>
+    )}
+    {club.zone && (
+      <div class="detail-row">
+        <span class="detail-label">Zona</span>
+        <span class="detail-value">{club.zone}</span>
+      </div>
+    )}
+    {club.phone && (
+      <div class="detail-row">
+        <span class="detail-label">Teléfono</span>
+        <a href={`tel:${club.phone}`} class="detail-link">{club.phone}</a>
+      </div>
+    )}
+  </div>
+
+  {mapsUrl && (
+    <a
+      href={mapsUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="map-btn"
+      aria-label={`Ver ${club.name} en Google Maps`}
+    >
+      <span class="map-btn-icon">🗺️</span>
+      Ver en mapa
+    </a>
+  )}
+</div>
+
+<style>
+  .location-card {
+    background: hsl(220 55% 11%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 1rem;
+    padding: 1.5rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .location-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .location-icon {
+    font-size: 1.1rem;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+
+  .club-name {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 1.15rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: hsl(210 20% 90%);
+    margin: 0;
+  }
+
+  .location-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .detail-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .detail-label {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: hsl(215 20% 50%);
+    flex-shrink: 0;
+    min-width: 64px;
+  }
+
+  .detail-value {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.875rem;
+    color: hsl(210 20% 80%);
+  }
+
+  .detail-link {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.875rem;
+    color: hsl(216 85% 65%);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+
+  .detail-link:hover {
+    color: hsl(216 85% 75%);
+    text-decoration: underline;
+  }
+
+  .map-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 8px;
+    background: hsl(216 85% 45% / 0.15);
+    border: 1px solid hsl(216 85% 45% / 0.4);
+    color: hsl(216 85% 70%);
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    text-decoration: none;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+    align-self: flex-start;
+  }
+
+  .map-btn:hover {
+    background: hsl(216 85% 45% / 0.28);
+    border-color: hsl(216 85% 55% / 0.6);
+    color: hsl(216 85% 82%);
+  }
+
+  .map-btn-icon {
+    font-size: 1rem;
+    line-height: 1;
+  }
+</style>

--- a/apps/frontend/src/components/matches/MatchInfoCard.astro
+++ b/apps/frontend/src/components/matches/MatchInfoCard.astro
@@ -1,0 +1,309 @@
+---
+/**
+ * MatchInfoCard — Static card showing match metadata
+ *
+ * Decision Context:
+ * - Why Astro: purely static content — format badge, date, description, organizer.
+ *   No interactivity needed; Astro avoids shipping any JS for this component.
+ * - Date formatting uses Intl.DateTimeFormat('es-AR') for correct Spanish locale.
+ *   The format string "sábado 15 de mayo · 18:00" is built by combining the long
+ *   date and time separately so the separator '·' can be styled distinctly.
+ * - organizerName is derived from the participants list in the parent page
+ *   (the participant whose id === match.organizerId). Passed as a separate prop
+ *   to keep this component stateless and not dependent on MatchDetailData shape.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import type { MatchDetailData, MatchFormat } from '../../graphql/operations/matches';
+
+interface Props {
+  match: MatchDetailData;
+  organizerName: string | null;
+  organizerAvatarUrl: string | null;
+  organizerPosition: string | null;
+}
+
+const { match, organizerName, organizerAvatarUrl, organizerPosition } = Astro.props;
+
+const FORMAT_LABEL: Record<MatchFormat, string> = {
+  FIVE_VS_FIVE: '5v5',
+  SEVEN_VS_SEVEN: '7v7',
+  TEN_VS_TEN: '10v10',
+  ELEVEN_VS_ELEVEN: '11v11',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  OPEN: 'Abierto',
+  FULL: 'Completo',
+  IN_PROGRESS: 'En curso',
+  COMPLETED: 'Finalizado',
+  CANCELLED: 'Cancelado',
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  OPEN: 'hsl(142 72% 50%)',
+  FULL: 'hsl(35 100% 55%)',
+  IN_PROGRESS: 'hsl(216 85% 65%)',
+  COMPLETED: 'hsl(215 20% 45%)',
+  CANCELLED: 'hsl(0 72% 65%)',
+};
+
+const POSITION_LABEL: Record<string, string> = {
+  goalkeeper: 'Arquero', GOALKEEPER: 'Arquero',
+  defender: 'Defensor', DEFENDER: 'Defensor',
+  midfielder: 'Mediocampista', MIDFIELDER: 'Mediocampista',
+  forward: 'Delantero', FORWARD: 'Delantero',
+};
+
+const dt = new Date(match.startTime);
+const dateStr = dt.toLocaleDateString('es-AR', {
+  weekday: 'long',
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+const timeStr = dt.toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' });
+
+const statusColor = STATUS_COLOR[match.status] ?? '#fff';
+const statusLabel = STATUS_LABEL[match.status] ?? match.status;
+const formatLabel = FORMAT_LABEL[match.format] ?? match.format;
+
+function initial(name: string) {
+  return name.charAt(0).toUpperCase();
+}
+---
+
+<div class="info-card">
+  <!-- Header row: format + status badges -->
+  <div class="badges-row">
+    <span class="fmt-badge">{formatLabel}</span>
+    <span
+      class="status-badge"
+      style={`color:${statusColor}; border-color:${statusColor}40`}
+    >
+      {statusLabel}
+    </span>
+    {match.status === 'FULL' && (
+      <span class="full-badge">PARTIDO COMPLETO</span>
+    )}
+  </div>
+
+  <!-- Title -->
+  <h1 class="match-title">{match.title}</h1>
+
+  <!-- Date / time -->
+  <div class="stat-row">
+    <span class="stat-icon">📅</span>
+    <div>
+      <span class="stat-label">Fecha y hora</span>
+      <span class="stat-value">{dateStr} · {timeStr}</span>
+    </div>
+  </div>
+
+  <!-- Player count -->
+  <div class="stat-row">
+    <span class="stat-icon">👥</span>
+    <div>
+      <span class="stat-label">Jugadores</span>
+      <span class="stat-value">
+        {match.participants
+          ? `${match.participants.totalCount} / ${match.totalSlots}`
+          : `0 / ${match.totalSlots}`}
+      </span>
+    </div>
+  </div>
+
+  <!-- Description -->
+  {match.description && (
+    <p class="match-desc">{match.description}</p>
+  )}
+
+  <!-- Organizer -->
+  {organizerName && (
+    <div class="organizer-row">
+      <div class="organizer-avatar">
+        {organizerAvatarUrl
+          ? <img src={organizerAvatarUrl} alt={organizerName} class="org-img" loading="lazy" />
+          : <span class="org-initial">{initial(organizerName)}</span>
+        }
+      </div>
+      <div class="organizer-info">
+        <span class="organizer-label">Organizador</span>
+        <span class="organizer-name">{organizerName}</span>
+        {organizerPosition && (
+          <span class="organizer-pos">
+            {POSITION_LABEL[organizerPosition] ?? organizerPosition}
+          </span>
+        )}
+      </div>
+    </div>
+  )}
+</div>
+
+<style>
+  .info-card {
+    background: hsl(220 55% 11%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 1rem;
+    padding: 1.75rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .badges-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .fmt-badge {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1rem;
+    letter-spacing: 0.08em;
+    background: hsl(216 85% 45% / 0.15);
+    color: hsl(216 85% 65%);
+    border: 1px solid hsl(216 85% 45% / 0.3);
+    padding: 0.15rem 0.75rem;
+    border-radius: 4px;
+  }
+
+  .status-badge {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    border: 1px solid;
+    padding: 0.15rem 0.6rem;
+    border-radius: 4px;
+  }
+
+  .full-badge {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    background: hsl(35 100% 48% / 0.15);
+    color: hsl(35 100% 65%);
+    border: 1px solid hsl(35 100% 48% / 0.35);
+    padding: 0.15rem 0.6rem;
+    border-radius: 4px;
+  }
+
+  .match-title {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 2rem;
+    letter-spacing: 0.04em;
+    color: #fff;
+    margin: 0;
+    line-height: 1.1;
+  }
+
+  .stat-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.7rem;
+  }
+
+  .stat-icon {
+    font-size: 1.1rem;
+    line-height: 1;
+    margin-top: 0.15rem;
+    flex-shrink: 0;
+  }
+
+  .stat-label {
+    display: block;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: hsl(215 20% 50%);
+    margin-bottom: 0.1rem;
+  }
+
+  .stat-value {
+    display: block;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.95rem;
+    color: hsl(210 20% 90%);
+    text-transform: capitalize;
+  }
+
+  .match-desc {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.9rem;
+    color: hsl(215 20% 65%);
+    margin: 0;
+    line-height: 1.5;
+    padding-top: 0.5rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .organizer-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .organizer-avatar {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    overflow: hidden;
+    background: hsl(220 30% 20%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border: 1px solid hsl(35 100% 48% / 0.35);
+  }
+
+  .org-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .org-initial {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 1rem;
+    font-weight: 700;
+    color: hsl(35 100% 60%);
+    line-height: 1;
+  }
+
+  .organizer-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  .organizer-label {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: hsl(35 100% 55%);
+  }
+
+  .organizer-name {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: hsl(210 20% 88%);
+  }
+
+  .organizer-pos {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.72rem;
+    color: hsl(215 20% 50%);
+  }
+</style>

--- a/apps/frontend/src/components/matches/PlayerCard.astro
+++ b/apps/frontend/src/components/matches/PlayerCard.astro
@@ -1,0 +1,163 @@
+---
+/**
+ * PlayerCard — Static display of a single team member
+ *
+ * Decision Context:
+ * - Why Astro (not React): purely presentational — no interactivity, no state. Using
+ *   Astro avoids shipping any JS for this component and prevents unnecessary hydration.
+ * - preferredPosition is a raw DB string (e.g. 'goalkeeper') so we map it to Spanish
+ *   labels here. Using String on the GraphQL side avoids a separate enum-mapping layer
+ *   in the service and keeps the contract flexible if positions are extended.
+ * - The "Organizador" badge is shown when isOrganizer=true. The caller derives this by
+ *   comparing player.id against match.organizerId. Text shows the full word "Organizador"
+ *   at all breakpoints — the badge uses a small font (0.6rem) so it fits alongside the
+ *   player name even on narrow screens without truncation.
+ * - Avatar fallback: shows the first letter of displayName when avatarUrl is null.
+ * - Previously fixed bugs: none relevant.
+ */
+
+export interface PlayerCardPlayer {
+  id: string;
+  displayName: string;
+  avatarUrl: string | null;
+  preferredPosition: string | null;
+}
+
+interface Props {
+  player: PlayerCardPlayer;
+  isOrganizer: boolean;
+}
+
+const { player, isOrganizer } = Astro.props;
+
+const POSITION_LABEL: Record<string, string> = {
+  goalkeeper: 'Arquero',
+  defender: 'Defensor',
+  midfielder: 'Mediocampista',
+  forward: 'Delantero',
+  GOALKEEPER: 'Arquero',
+  DEFENDER: 'Defensor',
+  MIDFIELDER: 'Mediocampista',
+  FORWARD: 'Delantero',
+};
+
+const POSITION_ICON: Record<string, string> = {
+  goalkeeper: '🧤',
+  defender: '🛡️',
+  midfielder: '⚡',
+  forward: '⚽',
+  GOALKEEPER: '🧤',
+  DEFENDER: '🛡️',
+  MIDFIELDER: '⚡',
+  FORWARD: '⚽',
+};
+
+const posLabel = player.preferredPosition
+  ? (POSITION_LABEL[player.preferredPosition] ?? player.preferredPosition)
+  : null;
+const posIcon = player.preferredPosition
+  ? (POSITION_ICON[player.preferredPosition] ?? '')
+  : '';
+
+function initial(name: string) {
+  return name.charAt(0).toUpperCase();
+}
+---
+
+<li class="player-card">
+  <div class="player-avatar">
+    {player.avatarUrl
+      ? <img src={player.avatarUrl} alt={player.displayName} class="avatar-img" loading="lazy" />
+      : <span class="avatar-initial">{initial(player.displayName)}</span>
+    }
+  </div>
+  <div class="player-info">
+    <div class="player-name-row">
+      <span class="player-name">{player.displayName}</span>
+      {isOrganizer && <span class="badge-organizer">Organizador</span>}
+    </div>
+    {posLabel && (
+      <span class="player-position">{posIcon} {posLabel}</span>
+    )}
+  </div>
+</li>
+
+<style>
+  .player-card {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.5rem 0;
+  }
+
+  .player-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    overflow: hidden;
+    background: hsl(220 30% 20%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .avatar-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .avatar-initial {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: hsl(210 20% 80%);
+    line-height: 1;
+  }
+
+  .player-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 0;
+  }
+
+  .player-name-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .player-name {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: hsl(210 20% 90%);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .badge-organizer {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: hsl(35 100% 55%);
+    background: hsl(35 100% 48% / 0.15);
+    border: 1px solid hsl(35 100% 48% / 0.35);
+    border-radius: 4px;
+    padding: 0.05rem 0.4rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .player-position {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.72rem;
+    color: hsl(215 20% 50%);
+  }
+</style>

--- a/apps/frontend/src/graphql/operations/matches.graphql
+++ b/apps/frontend/src/graphql/operations/matches.graphql
@@ -54,9 +54,9 @@ query GetMatchById($id: ID!) {
   }
 }
 
-# Full match detail including participant lists, counts and auth-context join flags.
-# Used by /partidos/[id] page. Auth token should be forwarded so isCurrentUserJoined
-# and canJoin are populated correctly.
+# Full match detail including participant lists, counts, organizer and auth-context flags.
+# Used by /partidos/[id] page. Auth token should be forwarded so isCurrentUserJoined,
+# canJoin and currentUserTeam are populated correctly.
 query GetMatchDetail($id: ID!) {
   match(id: $id) {
     id
@@ -68,6 +68,8 @@ query GetMatchDetail($id: ID!) {
     status
     description
     createdAt
+    organizerId
+    currentUserTeam
     club {
       id
       name
@@ -75,17 +77,20 @@ query GetMatchDetail($id: ID!) {
       address
       lat
       lng
+      phone
     }
     participants {
       teamA {
         id
         displayName
         avatarUrl
+        preferredPosition
       }
       teamB {
         id
         displayName
         avatarUrl
+        preferredPosition
       }
       teamACount
       teamBCount

--- a/apps/frontend/src/graphql/operations/matches.ts
+++ b/apps/frontend/src/graphql/operations/matches.ts
@@ -83,6 +83,7 @@ export interface TeamMember {
   id: string;
   displayName: string;
   avatarUrl: string | null;
+  preferredPosition: string | null;
 }
 
 export interface MatchParticipantsData {
@@ -105,6 +106,10 @@ export interface MatchDetailData {
   status: MatchStatus;
   description: string | null;
   createdAt: string;
+  /** ID of the match organizer — used to badge their PlayerCard as "Organizador" */
+  organizerId: string | null;
+  /** Team the current user is enrolled in — null when not joined or not authenticated */
+  currentUserTeam: MatchTeam | null;
   club: {
     id: string;
     name: string;
@@ -112,6 +117,7 @@ export interface MatchDetailData {
     address: string | null;
     lat: number | null;
     lng: number | null;
+    phone: string | null;
   } | null;
   participants: MatchParticipantsData | null;
   isCurrentUserJoined: boolean | null;
@@ -269,6 +275,8 @@ export const GET_MATCH_DETAIL = /* GraphQL */ `
       status
       description
       createdAt
+      organizerId
+      currentUserTeam
       club {
         id
         name
@@ -276,10 +284,11 @@ export const GET_MATCH_DETAIL = /* GraphQL */ `
         address
         lat
         lng
+        phone
       }
       participants {
-        teamA { id displayName avatarUrl }
-        teamB { id displayName avatarUrl }
+        teamA { id displayName avatarUrl preferredPosition }
+        teamB { id displayName avatarUrl preferredPosition }
         teamACount
         teamBCount
         totalCount

--- a/apps/frontend/src/pages/partidos/[id].astro
+++ b/apps/frontend/src/pages/partidos/[id].astro
@@ -1,34 +1,58 @@
 ---
 /**
- * /partidos/[id] — SSR detalle de un partido con equipos y botones de inscripción
+ * /partidos/[id] — Detalle completo de un partido
  *
  * Decision Context:
- * - SSR: el match puede cambiar de estado y sus participantes cambian en tiempo real,
- *   así que no se pre-renderiza. Cache de 3 min en el backend (DYNAMIC_DATA TTL).
- * - Auth: la ruta es pública (cualquiera puede ver el detalle). El botón "Sumarme"
- *   solo aparece para usuarios autenticados con role='player'. El access token se pasa
- *   como prop al JoinTeamButton (React island) para que pueda autorizar la mutation.
- * - GET_MATCH_DETAIL incluye participants, isCurrentUserJoined y canJoin. Si el usuario
- *   no está autenticado, el backend devuelve null para esos flags y el frontend los
- *   interpreta como "no puede sumarse".
- * - JoinTeamButton usa client:load para hidratación inmediata (es la CTA principal).
- * - Después de unirse, el componente hace window.location.reload() para refrescar el SSR.
- * - Realtime: no implementado — se documenta como TODO. El polling podría agregarse como
- *   mejora futura, pero la recarga post-join cubre el caso de uso principal.
+ * - SSR required: participant roster and auth-context flags (isCurrentUserJoined,
+ *   currentUserTeam, canJoin) change in real time. Pre-rendering would serve stale
+ *   data. Backend caches the DB row for 3 min (DYNAMIC_DATA TTL) so SSR load is low.
+ * - UUID guard: non-UUID params are redirected to /partidos immediately to avoid a
+ *   useless DB round-trip. The backend resolver also guards, but doing it here too
+ *   lets Astro issue a proper 302 instead of rendering an empty page.
+ * - Auth: the page is public (unauthenticated users can view the detail). The access
+ *   token is read from the HttpOnly cookie and forwarded to the backend only when
+ *   present, so auth-context flags are null for unauthenticated users.
+ * - Organizer detection: we find the organizer by matching participant.id with
+ *   match.organizerId from the GraphQL response. If the organizer left the match
+ *   they won't appear in participants — organizerName is null in that case.
+ * - JoinTeamButton and LeaveMatchButton use client:load (primary CTAs — must be
+ *   interactive immediately without waiting for scroll).
+ * - Components: MatchInfoCard, ClubLocationCard, PlayerCard are Astro (purely static).
+ * - Banner logic for enrolled users in cancelled matches (P1 audit fix):
+ *   The banner--joined is split into two cases:
+ *   1. isJoined && !matchCancelled → green "Ya estás anotado" + LeaveMatchButton
+ *   2. isJoined && matchCancelled  → gray "Estabas anotado, fue cancelado" (no leave button)
+ *   This prevents showing LeaveMatchButton on cancelled matches, which would always fail
+ *   because leaveMatch blocks changes to cancelled matches server-side.
+ * - Banners for IN_PROGRESS and COMPLETED added (P4 audit fix).
  * - Previously fixed bugs:
- *   - Botón "Sumarme" estaba deshabilitado con "próximamente" — reemplazado con UI de equipos.
- *   - availableSlots estaba hardcodeado a capacity — ahora viene del backend calculado.
+ *   - handleJoin in MatchList was a placeholder alert — fixed to navigate here.
+ *   - "Sumarme" button was disabled with "próximamente" — replaced with full join UI.
+ *   - availableSlots was hardcoded to capacity — now comes from the backend computed value.
+ *   - LeaveMatchButton shown on CANCELLED matches — always produced backend error (P1 fix).
+ *   - IN_PROGRESS / COMPLETED had no status banners — added (P4 fix).
  */
 export const prerender = false;
 
 import Layout from '../../layouts/Layout.astro';
 import JoinTeamButton from '../../components/matches/JoinTeamButton.tsx';
 import LeaveMatchButton from '../../components/matches/LeaveMatchButton.tsx';
+import MatchInfoCard from '../../components/matches/MatchInfoCard.astro';
+import ClubLocationCard from '../../components/matches/ClubLocationCard.astro';
+import PlayerCard from '../../components/matches/PlayerCard.astro';
 import { GET_MATCH_DETAIL } from '../../graphql/operations/matches';
 import type { MatchDetailData } from '../../graphql/operations/matches';
 import { readAccessToken } from '../../lib/auth';
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const { id } = Astro.params;
+
+// Redirect non-UUID params immediately
+if (!id || !UUID_REGEX.test(id)) {
+  return Astro.redirect('/partidos');
+}
+
 const user = Astro.locals.user;
 const isPlayer = user?.role === 'player';
 const accessToken = readAccessToken(Astro.cookies) ?? '';
@@ -50,51 +74,44 @@ try {
     headers,
     body: JSON.stringify({ query: GET_MATCH_DETAIL, variables: { id } }),
   });
+
   const json = await res.json() as {
     data?: { match: MatchDetailData | null };
-    errors?: { message: string }[]
+    errors?: { message: string }[];
   };
+
   if (json.errors?.length) fetchError = json.errors[0].message;
   else match = json.data?.match ?? null;
 } catch {
   fetchError = 'Error de red al cargar el partido.';
 }
 
-const FORMAT_LABEL: Record<string, string> = {
-  FIVE_VS_FIVE: '5v5', SEVEN_VS_SEVEN: '7v7', TEN_VS_TEN: '10v10', ELEVEN_VS_ELEVEN: '11v11',
-};
-const STATUS_LABEL: Record<string, string> = {
-  OPEN: 'Abierto', FULL: 'Completo', IN_PROGRESS: 'En curso',
-  COMPLETED: 'Finalizado', CANCELLED: 'Cancelado',
-};
-const STATUS_COLOR: Record<string, string> = {
-  OPEN: 'hsl(142 72% 50%)', FULL: 'hsl(35 100% 55%)',
-  IN_PROGRESS: 'hsl(216 85% 65%)', COMPLETED: 'hsl(215 20% 45%)',
-  CANCELLED: 'hsl(0 72% 65%)',
-};
-
-function fmtDate(iso: string) {
-  return new Date(iso).toLocaleDateString('es-AR', {
-    weekday: 'long', day: 'numeric', month: 'long', year: 'numeric',
-  });
-}
-function fmtTime(iso: string) {
-  return new Date(iso).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' });
-}
-function initial(name: string) {
-  return name.charAt(0).toUpperCase();
-}
-
 const participants = match?.participants;
+const teamA = participants?.teamA ?? [];
+const teamB = participants?.teamB ?? [];
+const spotsPerTeam = match ? Math.floor(match.totalSlots / 2) : 0;
 const teamAFull = participants ? participants.spotsLeftA === 0 : false;
 const teamBFull = participants ? participants.spotsLeftB === 0 : false;
 const isJoined = match?.isCurrentUserJoined ?? false;
 const canJoin = match?.canJoin ?? false;
 const matchOpen = match?.status === 'OPEN';
+const matchCancelled = match?.status === 'CANCELLED';
+const matchInProgress = match?.status === 'IN_PROGRESS';
+const matchCompleted = match?.status === 'COMPLETED';
+const currentUserTeam = match?.currentUserTeam ?? null;
+
+const allParticipants = [...teamA, ...teamB];
+const organizerParticipant = match?.organizerId
+  ? allParticipants.find((p) => p.id === match!.organizerId)
+  : null;
+const organizerName = organizerParticipant?.displayName ?? null;
+const organizerAvatarUrl = organizerParticipant?.avatarUrl ?? null;
+const organizerPosition = organizerParticipant?.preferredPosition ?? null;
 ---
 
 <Layout title={match ? `${match.title} — Sumate Ya` : 'Partido — Sumate Ya'}>
   <div class="app-shell">
+
     <nav class="topbar">
       <div class="topbar-inner">
         <div class="topbar-brand">
@@ -121,76 +138,43 @@ const matchOpen = match?.status === 'OPEN';
     </nav>
 
     <main class="page-content">
-      {(!match && !fetchError) || (!match && fetchError) ? (
+
+      {(!match || fetchError) && (
         <div class="not-found">
           {fetchError
             ? <><p class="nf-title">Error al cargar</p><p class="nf-sub">{fetchError}</p></>
             : <><p class="nf-title">Partido no encontrado</p><p class="nf-sub">Puede que haya sido cancelado o el enlace es incorrecto.</p></>
           }
-          <a href="/partidos" class="btn-back">← Volver a partidos</a>
+          <a href="/partidos" class="btn-back">← Volver al listado</a>
         </div>
-      ) : match ? (
+      )}
+
+      {match && (
         <div class="match-detail">
           <a href="/partidos" class="link-back">← Volver a partidos</a>
 
-          <!-- Header info card -->
-          <div class="info-card">
-            <div class="match-header">
-              <span class="fmt-badge">{FORMAT_LABEL[match.format] ?? match.format}</span>
-              <span class="status-badge" style={`color:${STATUS_COLOR[match.status] ?? '#fff'};border-color:${STATUS_COLOR[match.status] ?? '#fff'}40`}>
-                {STATUS_LABEL[match.status] ?? match.status}
-              </span>
-              {match.status === 'FULL' && (
-                <span class="full-badge">PARTIDO COMPLETO</span>
-              )}
-            </div>
+          <!-- Section 1: Match info card -->
+          <MatchInfoCard
+            match={match}
+            organizerName={organizerName}
+            organizerAvatarUrl={organizerAvatarUrl}
+            organizerPosition={organizerPosition}
+          />
 
-            <h1 class="match-title">{match.title}</h1>
+          <!-- Section 2: Club location -->
+          {match.club && <ClubLocationCard club={match.club} />}
 
-            {match.club && (
-              <p class="match-club">
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path><circle cx="12" cy="10" r="3"></circle></svg>
-                {match.club.name}
-                {match.club.zone && <span class="club-zone"> · {match.club.zone}</span>}
-                {match.club.address && <span class="club-address"> — {match.club.address}</span>}
-              </p>
-            )}
+          <!-- Section 3: User status banners -->
 
-            {match.description && (
-              <p class="match-desc">{match.description}</p>
-            )}
-
-            <div class="stats-row">
-              <div class="stat">
-                <span class="stat-icon">📅</span>
-                <div class="stat-info">
-                  <span class="stat-label">Fecha</span>
-                  <span class="stat-value">{fmtDate(match.startTime)}</span>
-                </div>
-              </div>
-              <div class="stat">
-                <span class="stat-icon">🕐</span>
-                <div class="stat-info">
-                  <span class="stat-label">Hora</span>
-                  <span class="stat-value">{fmtTime(match.startTime)}</span>
-                </div>
-              </div>
-              <div class="stat">
-                <span class="stat-icon">👥</span>
-                <div class="stat-info">
-                  <span class="stat-label">Cupos</span>
-                  <span class="stat-value">
-                    {participants ? `${participants.totalCount} / ${match.totalSlots}` : `0 / ${match.totalSlots}`}
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            {isJoined && (
-              <div class="already-joined-row">
-                <div class="already-joined-banner" role="status">
-                  ✓ Ya estás inscripto en este partido
-                </div>
+          <!-- P1 fix: split joined banner by match status.
+               CANCELLED matches block leaveMatch server-side — never show the button there. -->
+          {isJoined && !matchCancelled && (
+            <div class="banner banner--joined" role="status">
+              <span class="banner-icon">✓</span>
+              <div class="banner-body">
+                <span class="banner-msg">
+                  Ya estás anotado en Equipo {currentUserTeam === 'A' ? 'A' : 'B'}
+                </span>
                 {isPlayer && (
                   <LeaveMatchButton
                     client:load
@@ -201,52 +185,93 @@ const matchOpen = match?.status === 'OPEN';
                   />
                 )}
               </div>
-            )}
-          </div>
+            </div>
+          )}
 
-          <!-- Teams grid -->
+          {isJoined && matchCancelled && (
+            <div class="banner banner--enrolled-cancelled" role="status">
+              <span class="banner-icon">⚠️</span>
+              <span class="banner-msg">
+                Estabas anotado en Equipo {currentUserTeam === 'A' ? 'A' : 'B'}, pero este partido fue cancelado.
+              </span>
+            </div>
+          )}
+
+          {!isJoined && matchOpen && canJoin && isPlayer && (
+            <div class="banner banner--open" role="status">
+              <span class="banner-icon">⚽</span>
+              <span class="banner-msg">
+                Hay {match.availableSlots} cupo{match.availableSlots !== 1 ? 's' : ''} disponible{match.availableSlots !== 1 ? 's' : ''}.
+                Elegí tu equipo abajo.
+              </span>
+            </div>
+          )}
+
+          {!isJoined && match.status === 'FULL' && (
+            <div class="banner banner--full" role="status">
+              <span class="banner-icon">🔒</span>
+              <span class="banner-msg">Este partido está completo</span>
+            </div>
+          )}
+
+          {!isJoined && matchCancelled && (
+            <div class="banner banner--cancelled" role="alert">
+              <span class="banner-icon">❌</span>
+              <span class="banner-msg">Este partido fue cancelado</span>
+            </div>
+          )}
+
+          <!-- P4 fix: banners para IN_PROGRESS y COMPLETED -->
+          {matchInProgress && (
+            <div class="banner banner--inprogress" role="status">
+              <span class="banner-icon">🟡</span>
+              <span class="banner-msg">Este partido está en curso</span>
+            </div>
+          )}
+
+          {matchCompleted && (
+            <div class="banner banner--completed" role="status">
+              <span class="banner-icon">✅</span>
+              <span class="banner-msg">Este partido ya finalizó</span>
+            </div>
+          )}
+
+          {!user && matchOpen && (
+            <div class="banner banner--auth" role="status">
+              <span class="banner-icon">🔑</span>
+              <span class="banner-msg">
+                <a href="/login" class="banner-link">Iniciá sesión</a> para sumarte a este partido
+              </span>
+            </div>
+          )}
+
+          <!-- Section 4: Teams -->
           {participants ? (
             <div class="teams-grid">
-              <!-- Team A -->
+
               <div class="team-card">
                 <div class="team-header">
                   <span class="team-label team-a">EQUIPO A</span>
-                  <span class="team-count">{participants.teamACount} / {Math.floor(match.totalSlots / 2)}</span>
+                  <span class="team-count">{participants.teamACount} / {spotsPerTeam}</span>
                 </div>
-
-                <ul class="player-list" role="list">
-                  {participants.teamA.map((p) => (
-                    <li class="player-row">
-                      <div class="player-avatar">
-                        {p.avatarUrl
-                          ? <img src={p.avatarUrl} alt={p.displayName} class="avatar-img" loading="lazy" />
-                          : <span class="avatar-initial">{initial(p.displayName)}</span>
-                        }
-                      </div>
-                      <span class="player-name">{p.displayName}</span>
-                    </li>
+                <ul class="player-list" role="list" aria-label="Jugadores Equipo A">
+                  {teamA.map((p) => (
+                    <PlayerCard player={p} isOrganizer={p.id === match!.organizerId} />
                   ))}
                   {participants.spotsLeftA > 0 && Array.from({ length: participants.spotsLeftA }).map((_, i) => (
-                    <li class="player-row player-row--empty">
-                      <div class="player-avatar player-avatar--empty">
-                        <span>+</span>
-                      </div>
-                      <span class="player-name player-name--empty">Lugar disponible</span>
+                    <li class="player-empty">
+                      <div class="empty-avatar"><span>+</span></div>
+                      <span class="empty-label">Lugar disponible</span>
                     </li>
                   ))}
                 </ul>
-
                 <div class="team-cta">
-                  {!user && matchOpen && (
-                    <a href="/login" class="join-link">Iniciá sesión para sumarte</a>
-                  )}
-                  {user && !isPlayer && (
-                    <p class="join-disabled-msg">Solo jugadores pueden sumarse</p>
-                  )}
+                  {!user && matchOpen && <a href="/login" class="cta-link">Iniciá sesión para sumarte</a>}
+                  {user && !isPlayer && <p class="cta-disabled">Solo jugadores pueden sumarse</p>}
                   {isPlayer && isJoined && (
-                    participants.teamA.some((p) => p.id === user?.id)
-                      ? <p class="in-team-msg">✓ Estás en este equipo</p>
-                      : <p class="join-disabled-msg">Ya estás en el Equipo B</p>
+                    teamA.some((p) => p.id === user?.id)
+                      ? <p class="cta-in-team">✓ Estás en este equipo</p>
+                      : <p class="cta-disabled">Ya estás en el Equipo B</p>
                   )}
                   {isPlayer && !isJoined && matchOpen && (
                     <JoinTeamButton
@@ -259,52 +284,33 @@ const matchOpen = match?.status === 'OPEN';
                       accessToken={accessToken}
                     />
                   )}
-                  {!matchOpen && (
-                    <p class="join-disabled-msg">{STATUS_LABEL[match.status] ?? match.status}</p>
-                  )}
+                  {!matchOpen && !isJoined && <p class="cta-disabled">{matchCancelled ? 'Cancelado' : 'Completo'}</p>}
                 </div>
               </div>
 
-              <!-- Team B -->
               <div class="team-card">
                 <div class="team-header">
                   <span class="team-label team-b">EQUIPO B</span>
-                  <span class="team-count">{participants.teamBCount} / {Math.floor(match.totalSlots / 2)}</span>
+                  <span class="team-count">{participants.teamBCount} / {spotsPerTeam}</span>
                 </div>
-
-                <ul class="player-list" role="list">
-                  {participants.teamB.map((p) => (
-                    <li class="player-row">
-                      <div class="player-avatar">
-                        {p.avatarUrl
-                          ? <img src={p.avatarUrl} alt={p.displayName} class="avatar-img" loading="lazy" />
-                          : <span class="avatar-initial">{initial(p.displayName)}</span>
-                        }
-                      </div>
-                      <span class="player-name">{p.displayName}</span>
-                    </li>
+                <ul class="player-list" role="list" aria-label="Jugadores Equipo B">
+                  {teamB.map((p) => (
+                    <PlayerCard player={p} isOrganizer={p.id === match!.organizerId} />
                   ))}
                   {participants.spotsLeftB > 0 && Array.from({ length: participants.spotsLeftB }).map((_, i) => (
-                    <li class="player-row player-row--empty">
-                      <div class="player-avatar player-avatar--empty">
-                        <span>+</span>
-                      </div>
-                      <span class="player-name player-name--empty">Lugar disponible</span>
+                    <li class="player-empty">
+                      <div class="empty-avatar"><span>+</span></div>
+                      <span class="empty-label">Lugar disponible</span>
                     </li>
                   ))}
                 </ul>
-
                 <div class="team-cta">
-                  {!user && matchOpen && (
-                    <a href="/login" class="join-link">Iniciá sesión para sumarte</a>
-                  )}
-                  {user && !isPlayer && (
-                    <p class="join-disabled-msg">Solo jugadores pueden sumarse</p>
-                  )}
+                  {!user && matchOpen && <a href="/login" class="cta-link">Iniciá sesión para sumarte</a>}
+                  {user && !isPlayer && <p class="cta-disabled">Solo jugadores pueden sumarse</p>}
                   {isPlayer && isJoined && (
-                    participants.teamB.some((p) => p.id === user?.id)
-                      ? <p class="in-team-msg">✓ Estás en este equipo</p>
-                      : <p class="join-disabled-msg">Ya estás en el Equipo A</p>
+                    teamB.some((p) => p.id === user?.id)
+                      ? <p class="cta-in-team">✓ Estás en este equipo</p>
+                      : <p class="cta-disabled">Ya estás en el Equipo A</p>
                   )}
                   {isPlayer && !isJoined && matchOpen && (
                     <JoinTeamButton
@@ -317,20 +323,19 @@ const matchOpen = match?.status === 'OPEN';
                       accessToken={accessToken}
                     />
                   )}
-                  {!matchOpen && (
-                    <p class="join-disabled-msg">{STATUS_LABEL[match.status] ?? match.status}</p>
-                  )}
+                  {!matchOpen && !isJoined && <p class="cta-disabled">{matchCancelled ? 'Cancelado' : 'Completo'}</p>}
                 </div>
               </div>
+
             </div>
           ) : (
-            <!-- Fallback: no participant data -->
-            <div class="info-card">
-              <p class="join-disabled-msg">No se pudieron cargar los equipos.</p>
+            <div class="info-card-fallback">
+              <p class="cta-disabled">No se pudieron cargar los equipos.</p>
             </div>
           )}
+
         </div>
-      ) : null}
+      )}
     </main>
   </div>
 </Layout>
@@ -356,8 +361,7 @@ const matchOpen = match?.status === 'OPEN';
   .nav-link {
     font-family: 'Barlow Condensed', sans-serif; font-size: 0.85rem; font-weight: 600;
     letter-spacing: 0.1em; text-transform: uppercase; color: hsl(215 20% 65%);
-    text-decoration: none; padding: 0.3rem 0.6rem; border-radius: 6px;
-    transition: color 0.15s, background 0.15s;
+    text-decoration: none; padding: 0.3rem 0.6rem; border-radius: 6px; transition: color 0.15s, background 0.15s;
   }
   .nav-link:hover { background: rgba(255,255,255,0.06); color: hsl(210 20% 94%); }
   .btn-crear {
@@ -391,134 +395,66 @@ const matchOpen = match?.status === 'OPEN';
   .match-detail { display: flex; flex-direction: column; gap: 1.25rem; }
   .link-back {
     font-family: 'Barlow Condensed', sans-serif; font-size: 0.85rem; font-weight: 600;
-    letter-spacing: 0.08em; text-decoration: none; color: hsl(215 20% 55%);
-    transition: color 0.15s;
+    letter-spacing: 0.08em; text-decoration: none; color: hsl(215 20% 55%); transition: color 0.15s;
   }
   .link-back:hover { color: hsl(210 20% 90%); }
 
-  /* ── Info card ── */
-  .info-card {
-    background: hsl(220 55% 11%); border: 1px solid rgba(255,255,255,0.08);
-    border-radius: 1rem; padding: 1.75rem 2rem;
-    display: flex; flex-direction: column; gap: 1rem;
+  /* Status banners */
+  .banner {
+    display: flex; align-items: flex-start; gap: 0.75rem;
+    border-radius: 10px; padding: 0.9rem 1.25rem;
+    font-family: 'Barlow', sans-serif; font-size: 0.9rem;
   }
-  .match-header { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
-  .fmt-badge {
-    font-family: 'Bebas Neue', sans-serif; font-size: 1rem; letter-spacing: 0.08em;
-    background: hsl(216 85% 45% / 0.15); color: hsl(216 85% 65%);
-    border: 1px solid hsl(216 85% 45% / 0.3); padding: 0.15rem 0.75rem; border-radius: 4px;
-  }
-  .status-badge {
-    font-family: 'Barlow Condensed', sans-serif; font-size: 0.72rem; font-weight: 700;
-    letter-spacing: 0.15em; text-transform: uppercase;
-    border: 1px solid; padding: 0.15rem 0.6rem; border-radius: 4px;
-  }
-  .full-badge {
-    font-family: 'Barlow Condensed', sans-serif; font-size: 0.72rem; font-weight: 700;
-    letter-spacing: 0.15em; text-transform: uppercase;
-    background: hsl(35 100% 48% / 0.15); color: hsl(35 100% 65%);
-    border: 1px solid hsl(35 100% 48% / 0.35); padding: 0.15rem 0.6rem; border-radius: 4px;
-  }
-  .match-title {
-    font-family: 'Bebas Neue', sans-serif; font-size: 1.9rem; letter-spacing: 0.04em;
-    color: #fff; margin: 0; line-height: 1.1;
-  }
-  .match-club {
-    display: flex; align-items: center; flex-wrap: wrap; gap: 0.35rem;
-    font-family: 'Barlow', sans-serif; font-size: 0.875rem; color: hsl(215 20% 60%); margin: 0;
-  }
-  .club-zone { color: hsl(215 20% 45%); }
-  .club-address { color: hsl(215 20% 40%); font-size: 0.825rem; }
-  .match-desc {
-    font-family: 'Barlow', sans-serif; font-size: 0.9rem; color: hsl(215 20% 65%);
-    margin: 0; line-height: 1.5;
-  }
+  .banner-icon { font-size: 1.1rem; line-height: 1.4; flex-shrink: 0; }
+  .banner-body { display: flex; flex-direction: column; gap: 0.65rem; }
+  .banner-msg { color: inherit; }
+  .banner-link { color: inherit; font-weight: 700; text-decoration: underline; }
+  .banner--joined { background: hsl(142 72% 50% / 0.1); border: 1px solid hsl(142 72% 50% / 0.3); color: hsl(142 72% 65%); }
+  .banner--open { background: hsl(216 85% 45% / 0.1); border: 1px solid hsl(216 85% 45% / 0.3); color: hsl(216 85% 70%); }
+  .banner--full { background: hsl(215 20% 20% / 0.5); border: 1px solid rgba(255,255,255,0.1); color: hsl(215 20% 55%); }
+  .banner--cancelled { background: hsl(0 72% 51% / 0.1); border: 1px solid hsl(0 72% 51% / 0.3); color: hsl(0 72% 70%); }
+  .banner--auth { background: hsl(35 100% 48% / 0.08); border: 1px solid hsl(35 100% 48% / 0.25); color: hsl(35 100% 65%); }
+  /* P1: enrolled in a cancelled match — warm muted warning, no action available */
+  .banner--enrolled-cancelled { background: hsl(35 20% 18% / 0.6); border: 1px solid hsl(35 30% 35% / 0.4); color: hsl(35 25% 60%); }
+  /* P4: match in progress — FIFA blue (same family as --open but distinct message) */
+  .banner--inprogress { background: hsl(216 85% 45% / 0.12); border: 1px solid hsl(216 85% 55% / 0.4); color: hsl(216 85% 72%); }
+  /* P4: match completed — neutral gray */
+  .banner--completed { background: hsl(215 15% 18% / 0.6); border: 1px solid rgba(255,255,255,0.1); color: hsl(215 15% 55%); }
 
-  .stats-row {
-    display: flex; gap: 1.5rem; flex-wrap: wrap;
-    padding-top: 1rem; border-top: 1px solid rgba(255,255,255,0.06);
-  }
-  .stat { display: flex; align-items: flex-start; gap: 0.65rem; }
-  .stat-icon { font-size: 1.1rem; line-height: 1; margin-top: 0.1rem; }
-  .stat-info { display: flex; flex-direction: column; gap: 0.1rem; }
-  .stat-label {
-    font-family: 'Barlow Condensed', sans-serif; font-size: 0.65rem;
-    font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; color: hsl(215 20% 50%);
-  }
-  .stat-value { font-family: 'Barlow', sans-serif; font-size: 0.875rem; color: hsl(210 20% 90%); }
-
-  .already-joined-row {
-    display: flex; align-items: center; justify-content: space-between;
-    flex-wrap: wrap; gap: 0.75rem;
-  }
-
-  .already-joined-banner {
-    display: inline-flex; align-items: center; gap: 0.5rem;
-    background: hsl(142 72% 50% / 0.12); border: 1px solid hsl(142 72% 50% / 0.3);
-    color: hsl(142 72% 60%); border-radius: 8px;
-    padding: 0.6rem 1rem; font-size: 0.875rem; font-family: 'Barlow', sans-serif;
-  }
-
-  /* ── Teams grid ── */
-  .teams-grid {
-    display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;
-  }
-  @media (max-width: 640px) {
-    .teams-grid { grid-template-columns: 1fr; }
-  }
+  /* Teams */
+  .teams-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+  @media (max-width: 640px) { .teams-grid { grid-template-columns: 1fr; } }
 
   .team-card {
     background: hsl(220 55% 11%); border: 1px solid rgba(255,255,255,0.08);
     border-radius: 1rem; padding: 1.25rem 1.5rem;
-    display: flex; flex-direction: column; gap: 1rem;
+    display: flex; flex-direction: column; gap: 0.9rem;
   }
   .team-header { display: flex; align-items: center; justify-content: space-between; }
-  .team-label {
-    font-family: 'Bebas Neue', sans-serif; font-size: 1.1rem;
-    letter-spacing: 0.1em;
-  }
+  .team-label { font-family: 'Bebas Neue', sans-serif; font-size: 1.1rem; letter-spacing: 0.1em; }
   .team-a { color: hsl(35 100% 55%); }
   .team-b { color: hsl(216 85% 65%); }
-  .team-count {
-    font-family: 'Barlow Condensed', sans-serif; font-size: 0.8rem; font-weight: 700;
-    letter-spacing: 0.05em; color: hsl(215 20% 50%);
-  }
+  .team-count { font-family: 'Barlow Condensed', sans-serif; font-size: 0.8rem; font-weight: 700; letter-spacing: 0.05em; color: hsl(215 20% 50%); }
 
-  .player-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
-  .player-row { display: flex; align-items: center; gap: 0.75rem; }
-  .player-row--empty { opacity: 0.35; }
-  .player-avatar {
-    width: 32px; height: 32px; border-radius: 50%; overflow: hidden;
-    background: hsl(220 30% 20%); display: flex; align-items: center; justify-content: center;
-    flex-shrink: 0;
-  }
-  .player-avatar--empty {
+  .player-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
+
+  .player-empty { display: flex; align-items: center; gap: 0.65rem; padding: 0.5rem 0; opacity: 0.35; }
+  .empty-avatar {
+    width: 36px; height: 36px; border-radius: 50%;
     border: 1px dashed hsl(215 20% 35%); background: transparent;
-    color: hsl(215 20% 40%); font-size: 0.875rem;
+    display: flex; align-items: center; justify-content: center;
+    color: hsl(215 20% 40%); font-size: 0.875rem; flex-shrink: 0;
   }
-  .avatar-img { width: 100%; height: 100%; object-fit: cover; }
-  .avatar-initial {
-    font-family: 'Barlow Condensed', sans-serif; font-size: 0.875rem;
-    font-weight: 700; color: hsl(210 20% 85%); line-height: 1;
-  }
-  .player-name {
-    font-family: 'Barlow', sans-serif; font-size: 0.875rem; color: hsl(210 20% 85%);
-  }
-  .player-name--empty { color: hsl(215 20% 40%); font-style: italic; }
+  .empty-label { font-family: 'Barlow', sans-serif; font-size: 0.875rem; color: hsl(215 20% 40%); font-style: italic; }
 
   .team-cta { padding-top: 0.5rem; border-top: 1px solid rgba(255,255,255,0.06); }
-  .join-link {
-    font-family: 'Barlow Condensed', sans-serif; font-size: 0.875rem; font-weight: 700;
-    letter-spacing: 0.08em; text-transform: uppercase;
-    color: hsl(35 100% 55%); text-decoration: none;
-  }
-  .join-link:hover { text-decoration: underline; }
-  .join-disabled-msg {
-    font-family: 'Barlow', sans-serif; font-size: 0.825rem;
-    color: hsl(215 20% 45%); margin: 0;
-  }
-  .in-team-msg {
-    font-family: 'Barlow', sans-serif; font-size: 0.825rem;
-    color: hsl(142 72% 55%); margin: 0;
+  .cta-link { font-family: 'Barlow Condensed', sans-serif; font-size: 0.875rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: hsl(35 100% 55%); text-decoration: none; }
+  .cta-link:hover { text-decoration: underline; }
+  .cta-disabled { font-family: 'Barlow', sans-serif; font-size: 0.825rem; color: hsl(215 20% 45%); margin: 0; }
+  .cta-in-team { font-family: 'Barlow', sans-serif; font-size: 0.825rem; color: hsl(142 72% 55%); margin: 0; }
+
+  .info-card-fallback {
+    background: hsl(220 55% 11%); border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 1rem; padding: 1.5rem 2rem;
   }
 </style>

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -550,3 +550,194 @@ Si el partido se volvió open o fue eliminado, también:
 - El otro puede ver `matchDeleted: false` con 1 participante restante, o también `matchDeleted: true` si el match ya fue eliminado
 - No hay error ni duplicado — `deleteMatch` con `DELETE WHERE id=x` sobre fila ya eliminada devuelve 0 filas sin error (idempotente en PostgreSQL)
 - El partido queda eliminado o con 1 participante, nunca inconsistente
+
+---
+
+# Testing Manual — User Story: Detalle completo de un partido
+
+## Contexto
+
+Rama: `detalle-de-partido`  
+Página: `/partidos/[id]` (SSR)  
+Componentes nuevos: `PlayerCard.astro`, `MatchInfoCard.astro`, `ClubLocationCard.astro`  
+Campos nuevos en GraphQL: `organizerId`, `currentUserTeam`, `TeamMember.preferredPosition`, `Club.phone`
+
+Ejecutar tras levantar backend y frontend con `pnpm dev`.
+
+---
+
+## Test 1 — Partido abierto con cupos en ambos equipos (usuario no autenticado)
+
+**Pasos:**
+1. Abrir ventana de incógnito (sin sesión)
+2. Navegar a `/partidos/[id]` de un partido con `status = 'OPEN'` y cupos disponibles
+
+**Resultado esperado:**
+- La página carga con la topbar, `MatchInfoCard`, `ClubLocationCard` (si el club existe), y la grilla de equipos
+- Se muestra la fecha formateada en español (ej: "sábado 5 de abril · 18:00")
+- El formato aparece como badge (ej: "7v7")
+- El badge de estado es verde "Abierto"
+- El banner inferior muestra: "🔑 Iniciá sesión para sumarte a este partido"
+- Los botones "Sumarme al Equipo A/B" no aparecen (solo el link de login en el CTA de cada equipo)
+
+---
+
+## Test 2 — Partido completo (`status = 'FULL'`)
+
+**Pasos:**
+1. Navegar a `/partidos/[id]` de un partido con todos los cupos ocupados
+
+**Resultado esperado:**
+- Badge "Completo" en naranja
+- Badge extra "PARTIDO COMPLETO" visible
+- Banner "🔒 Este partido está completo"
+- Botones "Sumarme" reemplazados por texto "Completo" en cada equipo
+
+---
+
+## Test 3 — Partido cancelado (`status = 'CANCELLED'`)
+
+**Pasos:**
+1. Navegar a `/partidos/[id]` de un partido con `status = 'CANCELLED'`
+
+**Resultado esperado:**
+- Badge "Cancelado" en rojo
+- Banner rojo: "❌ Este partido fue cancelado"
+- Botones de join muestran "Cancelado" en cada equipo
+
+---
+
+## Test 4 — Usuario inscripto ve su estado correcto
+
+**Pasos:**
+1. Iniciar sesión como jugador inscripto en un partido
+2. Navegar al detalle de ese partido
+
+**Resultado esperado:**
+- Banner verde "✓ Ya estás anotado en Equipo A" (o B según corresponda)
+- El botón "Salirme del partido" aparece dentro del banner
+- En el equipo correspondiente aparece "✓ Estás en este equipo"
+- En el otro equipo aparece "Ya estás en el Equipo A" (o B)
+- NO aparecen botones "Sumarme" en ningún equipo
+
+---
+
+## Test 5 — Usuario player no inscripto ve botones de "Sumarme"
+
+**Pasos:**
+1. Iniciar sesión como jugador sin inscripción en el partido
+2. Navegar al detalle de un partido abierto con cupos
+
+**Resultado esperado:**
+- Banner azul: "⚽ Hay X cupos disponibles. Elegí tu equipo abajo."
+- Botones "Sumarme al Equipo A" y "Sumarme al Equipo B" visibles y activos
+- Al hacer click en "Sumarme al Equipo A" → el botón muestra spinner → si exitoso, la página recarga mostrando el jugador en el Equipo A
+
+---
+
+## Test 6 — Badge "Organizador" en la tarjeta del organizador
+
+**Pasos:**
+1. Navegar al detalle de un partido como cualquier usuario
+2. Observar la lista de jugadores en el equipo donde está el organizador
+
+**Resultado esperado:**
+- El jugador que creó el partido tiene el badge naranja "Org." junto a su nombre
+- Los demás jugadores NO tienen ese badge
+
+---
+
+## Test 7 — Botón "Ver en mapa" abre Google Maps
+
+**Pasos:**
+1. Navegar al detalle de un partido cuyo club tiene `lat` y `lng` configurados
+2. Click en el botón "🗺️ Ver en mapa" en la card de ubicación
+
+**Resultado esperado:**
+- Se abre una nueva pestaña apuntando a `https://www.google.com/maps?q=<lat>,<lng>`
+- Las coordenadas son las del club (verificar que coincidan con las de la DB)
+
+---
+
+## Test 8 — Club sin coordenadas: ocultar botón de mapa
+
+**Pasos:**
+1. Navegar al detalle de un partido cuyo club tiene `lat = null` o `lng = null`
+
+**Resultado esperado:**
+- La `ClubLocationCard` muestra nombre, dirección y zona del club
+- El botón "Ver en mapa" NO aparece
+- No hay errores ni elementos vacíos
+
+---
+
+## Test 9 — ID inválido (no UUID) redirige a /partidos
+
+**Pasos:**
+1. Navegar a `/partidos/abc-no-es-uuid`
+2. Navegar a `/partidos/undefined`
+3. Navegar a `/partidos/12345`
+
+**Resultado esperado:**
+- En todos los casos: redirect inmediato a `/partidos` (sin un 404 o página en blanco)
+
+---
+
+## Test 10 — Fecha y hora en español
+
+**Pasos:**
+1. Navegar al detalle de un partido con fecha conocida (ej: 2026-05-16T18:00:00)
+
+**Resultado esperado:**
+- En la `MatchInfoCard` se muestra la fecha capitalizada y en español: "sábado 16 de mayo de 2026 · 18:00"
+- No aparece el mes o día en inglés
+- La hora usa formato de 24 horas con 2 dígitos (ej: "08:00", no "8:00 AM")
+
+---
+
+## Test 11 — Posición preferida de los jugadores
+
+**Pasos:**
+1. Navegar al detalle de un partido donde algún jugador tiene `preferredPosition` configurado
+
+**Resultado esperado:**
+- Bajo el nombre del jugador se muestra su posición en español con ícono:
+  - `goalkeeper` → "🧤 Arquero"
+  - `defender` → "🛡️ Defensor"
+  - `midfielder` → "⚡ Mediocampista"
+  - `forward` → "⚽ Delantero"
+- Jugadores sin posición configurada no muestran esa línea
+
+---
+
+## Test 12 — Responsive mobile (equipos en una columna)
+
+**Pasos:**
+1. Abrir el detalle de un partido en un viewport de 375px de ancho (DevTools → Device Toolbar)
+
+**Resultado esperado:**
+- Los dos equipos aparecen uno abajo del otro (una sola columna)
+- Todos los elementos son legibles y no se cortan
+- Los botones de join son de ancho completo
+
+---
+
+## Test 13 — club_admin ve el detalle sin botones de join
+
+**Pasos:**
+1. Iniciar sesión como usuario con `role = 'club_admin'`
+2. Navegar al detalle de cualquier partido abierto
+
+**Resultado esperado:**
+- La página carga correctamente con todos los datos del partido
+- En el CTA de cada equipo aparece "Solo jugadores pueden sumarse"
+- No aparece el banner de "Hay X cupos disponibles"
+- No aparece el botón "Salirme del partido"
+
+---
+
+## Notas de implementación
+
+- **Organizer FK sin participante**: Si el organizador se salió del partido, `match.organizerId` apunta a un usuario que ya no está en `matchParticipants`. El badge "Org." no aparecerá en ningún jugador en ese caso. Esto es correcto e intencional (ver Decision Context de `matchService.leaveMatch`).
+- **preferredPosition raw**: El backend retorna el valor literal de la DB (ej: `'goalkeeper'`). El componente `PlayerCard.astro` mapea tanto mayúsculas como minúsculas para mayor robustez.
+- **phone en clubs legacy**: Clubs sin teléfono configurado simplemente no muestran esa fila en `ClubLocationCard`.

--- a/docs/prompts/m3k7p2nw-prompt-log.md
+++ b/docs/prompts/m3k7p2nw-prompt-log.md
@@ -1,0 +1,19 @@
+# Prompt Log
+
+- Timestamp: 2026-04-26 11:20:00
+- Task ID: m3k7p2nw
+
+## User Prompt
+
+> Sos un desarrollador senior fullstack especializado en Astro 6, GraphQL y Supabase. Necesito que implementes la siguiente User Story completa en el proyecto sumate-ya.
+>
+> ## User Story
+> Como jugador, quiero ver el detalle completo de un partido para decidir si me sumo.
+>
+> [Stack, context, tasks 1-10, restricciones y resultado esperado — ver mensaje original completo]
+
+## Agent Main Actions
+
+- Extendió el schema GraphQL (`match.graphql`) con `organizerId` y `currentUserTeam` en `Match`, `preferredPosition` en `TeamMember` y `phone` en `Club`; actualizó `matchRepository.ts` y `matchService.toMatchDetail()` para mapear los nuevos campos; corrió codegen y sincronizó los tipos de frontend en `matches.ts` y `matches.graphql`.
+- Creó tres componentes Astro reutilizables: `PlayerCard.astro` (jugador con badge Organizador, posición e ícono), `MatchInfoCard.astro` (fecha localizada, formato, organizador) y `ClubLocationCard.astro` (club, dirección, teléfono y botón "Ver en mapa" con Google Maps); reescribió `/partidos/[id].astro` con validación UUID, banners de estado por situación del usuario, grilla de equipos y CTAs para join/leave.
+- Añadió validación UUID en el resolver `match(id)` del backend para evitar round-trips innecesarios; documentó 13 casos de prueba en `docs/TESTING.md`; corrió `turbo typecheck --force` con resultado 0 errores, 0 warnings.

--- a/docs/prompts/q9r4v6xt-prompt-log.md
+++ b/docs/prompts/q9r4v6xt-prompt-log.md
@@ -1,0 +1,15 @@
+# Prompt Log
+
+- Timestamp: 2026-04-26 11:35:00
+- Task ID: q9r4v6xt
+
+## User Prompt
+
+> Estoy en la rama detalle-de-partido. Necesito resolver los problemas P1 (crítico), P2, P3, P4 y P5 detectados en la auditoría reciente para poder cerrar la User Story "Detalle completo de un partido".
+> [P1: LeaveMatchButton visible en CANCELLED, P2: canJoin true para no autenticados, P3: CLUB_COLUMNS incluye phone en lista, P4: sin banners para IN_PROGRESS/COMPLETED, P5: badge "Org." en lugar de "Organizador"]
+
+## Agent Main Actions
+
+- **P1 (crítico)**: Dividió el banner `banner--joined` en dos ramas en `[id].astro`: `isJoined && !matchCancelled` muestra el banner verde con `LeaveMatchButton`; `isJoined && matchCancelled` muestra un banner ámbar/gris "Estabas anotado, fue cancelado" sin botón de salida, evitando el error garantizado del backend.
+- **P2 + P3**: En `matchService.ts` agregó `!!userId &&` al cálculo de `canJoin`; en `matchRepository.ts` separó `CLUB_COLUMNS` (sin `phone`, para queries de lista) de `CLUB_DETAIL_COLUMNS` (con `phone`, solo para `getMatchWithParticipants`), creó `ClubDetailRow extends ClubRow`, actualizó `MatchDetailRow.clubs` y eliminó `phone` de `toMatch` en el service.
+- **P4 + P5**: Agregó variables `matchInProgress` y `matchCompleted` al frontmatter de `[id].astro` y sus banners correspondientes (`banner--inprogress` en azul FIFA, `banner--completed` en gris neutro); también corrigió la condición del banner CANCELLED para que solo aparezca cuando `!isJoined` (el caso joined+cancelled tiene su propio banner); cambió el texto del badge en `PlayerCard.astro` de "Org." a "Organizador". Typecheck: 0 errores, 0 warnings.


### PR DESCRIPTION
- Added new components: PlayerCard, MatchInfoCard, and ClubLocationCard for displaying match details.
- Extended GraphQL schema with new fields: organizerId, currentUserTeam, preferredPosition, and phone.
- Documented 13 test cases in TESTING.md to validate the new functionality.
- Implemented user story for viewing match details, including handling various match statuses and user states.
- Improved UI responsiveness and ensured proper display of player positions and organizer badges.