### PR TITLE
feat: implement player match history feature

### DIFF
--- a/apps/backend/src/config/redis.ts
+++ b/apps/backend/src/config/redis.ts
@@ -54,6 +54,9 @@ export const CACHE_PREFIX = {
   // `profile:me:<userId>` — scoped to the owner because RLS differs per-user.
   // Invalidate on profile mutations (updatePosition, stat recompute, etc.).
   PROFILE_ME: 'profile:me:',
+  // `user:matches:<userId>:page:<page>:size:<pageSize>` — per-user history pagination.
+  // Invalidate when a match this user participated in transitions to 'completed'.
+  USER_MATCHES: 'user:matches:',
 } as const;
 
 // =====================================================

--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -141,6 +141,29 @@ export enum MatchFormat {
   TenVsTen = 'TEN_VS_TEN'
 }
 
+export type MatchHistoryConnection = {
+  __typename?: 'MatchHistoryConnection';
+  hasMore: Scalars['Boolean']['output'];
+  items: Array<MatchHistoryItem>;
+  page: Scalars['Int']['output'];
+  pageSize: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type MatchHistoryItem = {
+  __typename?: 'MatchHistoryItem';
+  club?: Maybe<Club>;
+  format: MatchFormat;
+  id: Scalars['ID']['output'];
+  isOrganizer: Scalars['Boolean']['output'];
+  scoreA?: Maybe<Scalars['Int']['output']>;
+  scoreB?: Maybe<Scalars['Int']['output']>;
+  startTime: Scalars['String']['output'];
+  title: Scalars['String']['output'];
+  userResult: MatchUserResult;
+  userTeam: Scalars['String']['output'];
+};
+
 export type MatchParticipantsData = {
   __typename?: 'MatchParticipantsData';
   spotsLeftA: Scalars['Int']['output'];
@@ -163,6 +186,13 @@ export enum MatchStatus {
 export enum MatchTeam {
   A = 'A',
   B = 'B'
+}
+
+export enum MatchUserResult {
+  Draw = 'DRAW',
+  Lost = 'LOST',
+  Pending = 'PENDING',
+  Won = 'WON'
 }
 
 export type Mutation = {
@@ -213,6 +243,7 @@ export type Query = {
   clubs: Array<ClubDetail>;
   match?: Maybe<Match>;
   matches: Array<Match>;
+  myMatches: MatchHistoryConnection;
   myProfile: Profile;
 };
 
@@ -230,6 +261,12 @@ export type QueryMatchArgs = {
 
 export type QueryMatchesArgs = {
   filters?: InputMaybe<MatchFilters>;
+};
+
+
+export type QueryMyMatchesArgs = {
+  page?: InputMaybe<Scalars['Int']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type TeamMember = {
@@ -337,9 +374,12 @@ export type ResolversTypes = ResolversObject<{
   Match: ResolverTypeWrapper<Match>;
   MatchFilters: MatchFilters;
   MatchFormat: MatchFormat;
+  MatchHistoryConnection: ResolverTypeWrapper<MatchHistoryConnection>;
+  MatchHistoryItem: ResolverTypeWrapper<MatchHistoryItem>;
   MatchParticipantsData: ResolverTypeWrapper<MatchParticipantsData>;
   MatchStatus: MatchStatus;
   MatchTeam: MatchTeam;
+  MatchUserResult: MatchUserResult;
   Mutation: ResolverTypeWrapper<Record<PropertyKey, never>>;
   PlayerPosition: PlayerPosition;
   Profile: ResolverTypeWrapper<Profile>;
@@ -367,6 +407,8 @@ export type ResolversParentTypes = ResolversObject<{
   LeaveMatchResult: LeaveMatchResult;
   Match: Match;
   MatchFilters: MatchFilters;
+  MatchHistoryConnection: MatchHistoryConnection;
+  MatchHistoryItem: MatchHistoryItem;
   MatchParticipantsData: MatchParticipantsData;
   Mutation: Record<PropertyKey, never>;
   Profile: Profile;
@@ -449,6 +491,27 @@ export type MatchResolvers<ContextType = GraphQLContext, ParentType extends Reso
   totalSlots?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
+export type MatchHistoryConnectionResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['MatchHistoryConnection'] = ResolversParentTypes['MatchHistoryConnection']> = ResolversObject<{
+  hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  items?: Resolver<Array<ResolversTypes['MatchHistoryItem']>, ParentType, ContextType>;
+  page?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  pageSize?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type MatchHistoryItemResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['MatchHistoryItem'] = ResolversParentTypes['MatchHistoryItem']> = ResolversObject<{
+  club?: Resolver<Maybe<ResolversTypes['Club']>, ParentType, ContextType>;
+  format?: Resolver<ResolversTypes['MatchFormat'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  isOrganizer?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  scoreA?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  scoreB?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  startTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  userResult?: Resolver<ResolversTypes['MatchUserResult'], ParentType, ContextType>;
+  userTeam?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
 export type MatchParticipantsDataResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['MatchParticipantsData'] = ResolversParentTypes['MatchParticipantsData']> = ResolversObject<{
   spotsLeftA?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   spotsLeftB?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -482,6 +545,7 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   clubs?: Resolver<Array<ResolversTypes['ClubDetail']>, ParentType, ContextType>;
   match?: Resolver<Maybe<ResolversTypes['Match']>, ParentType, ContextType, RequireFields<QueryMatchArgs, 'id'>>;
   matches?: Resolver<Array<ResolversTypes['Match']>, ParentType, ContextType, Partial<QueryMatchesArgs>>;
+  myMatches?: Resolver<ResolversTypes['MatchHistoryConnection'], ParentType, ContextType, Partial<QueryMyMatchesArgs>>;
   myProfile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
 }>;
 
@@ -501,6 +565,8 @@ export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   JoinMatchResult?: JoinMatchResultResolvers<ContextType>;
   LeaveMatchResult?: LeaveMatchResultResolvers<ContextType>;
   Match?: MatchResolvers<ContextType>;
+  MatchHistoryConnection?: MatchHistoryConnectionResolvers<ContextType>;
+  MatchHistoryItem?: MatchHistoryItemResolvers<ContextType>;
   MatchParticipantsData?: MatchParticipantsDataResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Profile?: ProfileResolvers<ContextType>;

--- a/apps/backend/src/graphql/resolvers/domains/match.ts
+++ b/apps/backend/src/graphql/resolvers/domains/match.ts
@@ -13,6 +13,7 @@
  *   (thrown from the service) so the client receives a clean Spanish message. The result
  *   type always has matchDeleted to tell the frontend whether to redirect or reload.
  * - createMatch: unchanged from previous implementation.
+ * - myMatches: auth-required, Zod-validated pagination, delegates to getMyMatches service.
  * - Previously fixed bugs:
  *   - match(id) used getMatchById which returned no participant data — upgraded to
  *     getMatchDetail so the detail page can show team rosters and join buttons.
@@ -20,12 +21,23 @@
  *     DB round-trip on obviously invalid IDs (e.g., "abc", "undefined").
  */
 
+import { z } from 'zod';
 import { createUserClient } from '../../../config/supabase.js';
 import { matchService } from '../../../services/matchService.js';
 import { requireAuth } from '../../../types/context.js';
 import type { MutationResolvers, QueryResolvers } from '../../generated/graphql.js';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const myMatchesArgsSchema = z.object({
+  page: z.number().int().min(1, { message: 'La página debe ser 1 o mayor' }).default(1),
+  pageSize: z
+    .number()
+    .int()
+    .min(1, { message: 'El tamaño de página debe ser al menos 1' })
+    .max(50, { message: 'El tamaño de página no puede superar 50' })
+    .default(10),
+});
 
 const Query: QueryResolvers = {
   /**
@@ -34,6 +46,26 @@ const Query: QueryResolvers = {
    */
   matches: async (_parent, args, _ctx) => {
     return matchService.listMatches({}, args.filters);
+  },
+
+  /**
+   * Returns the authenticated player's completed match history.
+   *
+   * Decision Context:
+   * - requireAuth: history is personal — unauthenticated requests must not leak any data.
+   * - Zod validation: page and pageSize default to 1 and 10 respectively so the query is
+   *   always well-formed even if the client omits them. Max pageSize = 50 caps egress.
+   * - User-scoped client not needed for reads (no RLS on SELECT for completed matches in
+   *   the current policy set), but we keep the pattern consistent by passing userId.
+   * - Previously fixed bugs: none relevant.
+   */
+  myMatches: async (_parent, args, ctx) => {
+    const user = requireAuth(ctx);
+    const { page, pageSize } = myMatchesArgsSchema.parse({
+      page: args.page ?? 1,
+      pageSize: args.pageSize ?? 10,
+    });
+    return matchService.getMyMatches({ userId: user.id }, page, pageSize);
   },
 
   /**

--- a/apps/backend/src/graphql/schema/match-history.graphql
+++ b/apps/backend/src/graphql/schema/match-history.graphql
@@ -1,0 +1,59 @@
+# GraphQL Schema: Match history for the authenticated player
+#
+# Decision Context:
+# - Why separate file: keeps the public match queries (match.graphql) isolated from
+#   the auth-required personal history endpoint. Apollo merges all .graphql files.
+# - userResult is computed in the service (not the DB) by comparing the participant's
+#   team against the match's winnerTeam column.
+# - scoreA / scoreB / winnerTeam: these DB columns DO NOT EXIST YET.
+#   The "registrar resultado" User Story is out of scope for this sprint.
+#   Until that US is implemented, userResult is always PENDING and scoreA/scoreB are null.
+#   TODO: When "registrar resultado" is merged, wire up:
+#     - WON:  winnerTeam === userTeam (lowercase)
+#     - LOST: winnerTeam !== userTeam && winnerTeam !== 'draw'
+#     - DRAW: winnerTeam === 'draw'
+# - MatchHistoryConnection uses page/pageSize (offset pagination) instead of cursor
+#   pagination because the history list is not expected to change during a user session
+#   (completed matches are immutable), so offset drift is not a concern.
+# - myMatches is auth-required (requireAuth in resolver). Unauthenticated callers get
+#   an Apollo authentication error.
+# - Previously fixed bugs: none relevant.
+
+enum MatchUserResult {
+  WON
+  LOST
+  DRAW
+  PENDING
+}
+
+# A single completed match as seen from the authenticated player's perspective
+type MatchHistoryItem {
+  id: ID!
+  title: String!
+  startTime: String!
+  format: MatchFormat!
+  club: Club
+  # The team (A or B) the player was on
+  userTeam: String!
+  # Computed from winnerTeam vs userTeam — always PENDING until result fields are added
+  userResult: MatchUserResult!
+  # Nullable until "registrar resultado" US is implemented
+  scoreA: Int
+  scoreB: Int
+  isOrganizer: Boolean!
+}
+
+# Offset-paginated response for myMatches
+type MatchHistoryConnection {
+  items: [MatchHistoryItem!]!
+  total: Int!
+  page: Int!
+  pageSize: Int!
+  hasMore: Boolean!
+}
+
+extend type Query {
+  # Returns the authenticated player's completed match history, newest first.
+  # Requires authentication. page defaults to 1, pageSize defaults to 10 (max 50).
+  myMatches(page: Int, pageSize: Int): MatchHistoryConnection!
+}

--- a/apps/backend/src/repositories/matchRepository.ts
+++ b/apps/backend/src/repositories/matchRepository.ts
@@ -643,6 +643,105 @@ export async function deleteMatch(matchId: string): Promise<void> {
   }
 }
 
+// =====================================================
+// Match History — completed matches for a specific player
+// =====================================================
+
+// Minimal columns selected for the history card — no capacity/createdAt/clubSlotId needed.
+const MATCH_HISTORY_COLUMNS = `
+  id,
+  description,
+  "scheduledAt",
+  format,
+  "organizerId"
+`;
+
+// Club columns for history — no lat/lng/phone, only display fields needed.
+const CLUB_HISTORY_COLUMNS = `
+  id,
+  name,
+  zone
+`;
+
+export interface HistoryClubRow {
+  id: string;
+  name: string;
+  zone: string | null;
+}
+
+export interface HistoryParticipantRow {
+  team: 'a' | 'b';
+}
+
+export interface CompletedMatchRow {
+  id: string;
+  description: string | null;
+  scheduledAt: string;
+  format: string;
+  organizerId: string;
+  clubs: HistoryClubRow | null;
+  matchParticipants: HistoryParticipantRow[];
+}
+
+export interface CompletedMatchesResult {
+  rows: CompletedMatchRow[];
+  total: number;
+}
+
+/**
+ * Get paginated completed matches for a specific player.
+ * Queries from the `matches` side so we can order by scheduledAt DESC.
+ * The !inner join on matchParticipants filters to only matches where the player participated.
+ *
+ * Decision Context:
+ * - Why from `matches` (not `matchParticipants`): querying from the `matches` side lets us
+ *   ORDER BY "scheduledAt" DESC directly, which gives the user their history newest-first.
+ *   Querying from `matchParticipants` would only allow ordering by `joinedAt`, which is a
+ *   proxy for scheduledAt but not exact.
+ * - !inner on matchParticipants: ensures the outer WHERE clause (status = 'completed') and
+ *   the join filter (matchParticipants.playerId = userId) are both applied as INNER JOIN
+ *   conditions, so only matches the player participated in appear.
+ * - matchParticipants result array: with the !inner + playerId filter, PostgREST returns
+ *   only the participant row for this specific player — exactly one item per match.
+ * - count: 'exact' adds a Content-Range header with the total rows (pre-pagination).
+ *   Used by the service to compute hasMore.
+ * - Service-role client: reads are safe with service-role since match history is auth-gated
+ *   at the resolver layer. The user-scoped client could also be used but is not required.
+ * - Previously fixed bugs: none relevant.
+ */
+export async function getCompletedMatchesByUser(
+  userId: string,
+  page: number,
+  pageSize: number,
+  client: SupabaseClient = supabase,
+): Promise<CompletedMatchesResult> {
+  const offset = (page - 1) * pageSize;
+
+  const { data, error, count } = await client
+    .from('matches')
+    .select(
+      `${MATCH_HISTORY_COLUMNS}, clubs(${CLUB_HISTORY_COLUMNS}), matchParticipants!inner(team)`,
+      { count: 'exact' },
+    )
+    .eq('status', 'completed')
+    .eq('matchParticipants.playerId', userId)
+    .order('scheduledAt', { ascending: false })
+    .range(offset, offset + pageSize - 1);
+
+  if (error) {
+    console.error(
+      `[matchRepository.getCompletedMatchesByUser] Supabase error userId=${userId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return {
+    rows: (data as unknown as CompletedMatchRow[]) ?? [],
+    total: count ?? 0,
+  };
+}
+
 // Export repository as object for consistency
 export const matchRepository = {
   getMatchesWithFilters,
@@ -656,4 +755,5 @@ export const matchRepository = {
   deleteMatch,
   createMatch,
   createMatchParticipant,
+  getCompletedMatchesByUser,
 };

--- a/apps/backend/src/services/matchService.ts
+++ b/apps/backend/src/services/matchService.ts
@@ -26,6 +26,7 @@ import {
   MatchFormat,
   MatchStatus,
   MatchTeam,
+  MatchUserResult,
   type CreateMatchInput,
   type CreateMatchResult,
   type JoinMatchInput,
@@ -34,12 +35,15 @@ import {
   type LeaveMatchResult,
   type Match,
   type MatchFilters,
+  type MatchHistoryConnection,
+  type MatchHistoryItem,
 } from '../graphql/generated/graphql.js';
 import {
   matchRepository,
   type MatchDetailRow,
   type MatchWithClub,
   type MatchFilterOptions,
+  type CompletedMatchRow,
 } from '../repositories/matchRepository.js';
 import { clubSlotRepository } from '../repositories/clubSlotRepository.js';
 import { profileRepository } from '../repositories/profileRepository.js';
@@ -652,6 +656,86 @@ export async function createMatch(
   return { success: true, matchId: newMatch.id, message: null };
 }
 
+// =====================================================
+// Match History
+// =====================================================
+
+/**
+ * Convert a completed-match DB row into a MatchHistoryItem GraphQL type.
+ *
+ * Decision Context:
+ * - userResult is always PENDING because scoreA/scoreB/winnerTeam do not exist in the DB yet.
+ *   TODO: When "registrar resultado" US is implemented, replace PENDING with:
+ *     WON  → winnerTeam && winnerTeam === userTeam.toLowerCase()
+ *     LOST → winnerTeam && winnerTeam !== userTeam.toLowerCase() && winnerTeam !== 'draw'
+ *     DRAW → winnerTeam === 'draw'
+ *   At that point, add scoreA/scoreB/winnerTeam to MATCH_HISTORY_COLUMNS in the repo.
+ * - isOrganizer is derived from `row.organizerId === userId` (no extra DB round-trip).
+ * - matchParticipants[0] always exists because getCompletedMatchesByUser uses !inner
+ *   join filtered by playerId — guarantees exactly one participant entry per row.
+ * - Previously fixed bugs: none relevant.
+ */
+function toMatchHistoryItem(row: CompletedMatchRow, userId: string): MatchHistoryItem {
+  const userTeam = row.matchParticipants[0]?.team === 'a' ? 'A' : 'B';
+
+  return {
+    id: row.id,
+    title: row.description ?? 'Partido sin título',
+    startTime: row.scheduledAt,
+    format: DB_TO_FORMAT[row.format] ?? MatchFormat.FiveVsFive,
+    club: row.clubs
+      ? { id: row.clubs.id, name: row.clubs.name, zone: row.clubs.zone ?? null }
+      : null,
+    userTeam,
+    userResult: MatchUserResult.Pending,
+    scoreA: null,
+    scoreB: null,
+    isOrganizer: row.organizerId === userId,
+  };
+}
+
+/**
+ * Return the authenticated player's completed match history, paginated.
+ *
+ * Decision Context:
+ * - Caching: keyed by userId + page + pageSize with USER_DATA TTL (5 min).
+ *   Per-user key prevents cross-user cache pollution. The 5-min TTL balances
+ *   freshness (match completions happen infrequently) against repeated queries.
+ * - Cache invalidation: currently not wired to the "completed" transition because
+ *   there is no explicit "mark completed" mutation yet. When that mutation is added,
+ *   invalidate `${CACHE_PREFIX.USER_MATCHES}${userId}*` for all participants.
+ * - hasMore: computed as offset + pageSize < total, which is the total count of
+ *   ALL matching rows returned by the count query (pre-pagination).
+ * - Previously fixed bugs: none relevant.
+ */
+export async function getMyMatches(
+  ctx: ServiceContext,
+  page: number,
+  pageSize: number,
+): Promise<MatchHistoryConnection> {
+  if (!ctx.userId) throw new Error('Authentication required');
+
+  const offset = (page - 1) * pageSize;
+  const cacheKey = `${CACHE_PREFIX.USER_MATCHES}${ctx.userId}:page:${page}:size:${pageSize}`;
+  const userId = ctx.userId;
+
+  return cacheGetOrSet(
+    cacheKey,
+    async () => {
+      const result = await matchRepository.getCompletedMatchesByUser(userId, page, pageSize);
+      const items = result.rows.map((row) => toMatchHistoryItem(row, userId));
+      return {
+        items,
+        total: result.total,
+        page,
+        pageSize,
+        hasMore: offset + pageSize < result.total,
+      };
+    },
+    CACHE_TTL.USER_DATA,
+  );
+}
+
 export const matchService = {
   listMatches,
   listOpenMatches,
@@ -661,4 +745,5 @@ export const matchService = {
   joinMatch,
   leaveMatch,
   createMatch,
+  getMyMatches,
 };

--- a/apps/frontend/src/components/profile/MatchHistoryCard.tsx
+++ b/apps/frontend/src/components/profile/MatchHistoryCard.tsx
@@ -1,0 +1,226 @@
+/**
+ * MatchHistoryCard — Single match card for the player's history list.
+ *
+ * Decision Context:
+ * - Why React (.tsx, not .astro): this component is imported and rendered inside
+ *   MatchHistoryList.tsx (a React island). Astro components cannot be imported inside
+ *   React components, so .tsx is the only viable choice.
+ * - Result badge colors follow FIFA design tokens: green → WON, red → LOST,
+ *   amber → DRAW, muted gray → PENDING. These are inline styles (not Tailwind classes)
+ *   to avoid Tailwind purge issues inside a React island that isn't part of the Astro
+ *   build graph.
+ * - scoreA/scoreB are null until "registrar resultado" is implemented — the score
+ *   section is hidden when both are null.
+ * - Date formatting uses Intl.DateTimeFormat('es-AR') to match MatchInfoCard.astro.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import type { MatchHistoryItem, MatchUserResult } from '../../graphql/operations/profile';
+
+interface MatchHistoryCardProps {
+  item: MatchHistoryItem;
+}
+
+const FORMAT_LABEL: Record<string, string> = {
+  FIVE_VS_FIVE: '5v5',
+  SEVEN_VS_SEVEN: '7v7',
+  TEN_VS_TEN: '10v10',
+  ELEVEN_VS_ELEVEN: '11v11',
+};
+
+const RESULT_CONFIG: Record<
+  MatchUserResult,
+  { label: string; bg: string; color: string; border: string }
+> = {
+  WON:     { label: 'Ganado',       bg: 'hsl(142 72% 50% / 0.12)', color: 'hsl(142 72% 60%)', border: 'hsl(142 72% 50% / 0.35)' },
+  LOST:    { label: 'Perdido',      bg: 'hsl(0 72% 51% / 0.12)',   color: 'hsl(0 72% 65%)',   border: 'hsl(0 72% 51% / 0.35)' },
+  DRAW:    { label: 'Empate',       bg: 'hsl(35 100% 48% / 0.12)', color: 'hsl(35 100% 60%)', border: 'hsl(35 100% 48% / 0.35)' },
+  PENDING: { label: 'Sin resultado',bg: 'hsl(215 20% 20% / 0.4)',  color: 'hsl(215 20% 55%)', border: 'rgba(255,255,255,0.1)' },
+};
+
+function formatDate(iso: string): string {
+  const dt = new Date(iso);
+  const date = dt.toLocaleDateString('es-AR', { weekday: 'long', day: 'numeric', month: 'long' });
+  const time = dt.toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' });
+  return `${date} · ${time}`;
+}
+
+export function MatchHistoryCard({ item }: MatchHistoryCardProps) {
+  const result = RESULT_CONFIG[item.userResult];
+  const formatLabel = FORMAT_LABEL[item.format] ?? item.format;
+  const hasScore = item.scoreA != null && item.scoreB != null;
+
+  return (
+    <article style={cardStyle}>
+      {/* Top row: date + format badge */}
+      <div style={topRowStyle}>
+        <span style={dateStyle}>{formatDate(item.startTime)}</span>
+        <span style={formatBadgeStyle}>{formatLabel}</span>
+      </div>
+
+      {/* Club info */}
+      {item.club && (
+        <div style={clubRowStyle}>
+          <span style={clubIconStyle}>📍</span>
+          <span style={clubNameStyle}>{item.club.name}</span>
+          {item.club.zone && <span style={clubZoneStyle}>· {item.club.zone}</span>}
+        </div>
+      )}
+
+      {/* Team + organizer */}
+      <div style={metaRowStyle}>
+        <span style={teamBadgeStyle(item.userTeam)}>
+          Equipo {item.userTeam}
+        </span>
+        {item.isOrganizer && <span style={orgBadgeStyle}>Organizador</span>}
+      </div>
+
+      {/* Result + score */}
+      <div style={resultRowStyle}>
+        <span
+          style={{
+            ...resultBadgeBase,
+            background: result.bg,
+            color: result.color,
+            border: `1px solid ${result.border}`,
+          }}
+        >
+          {result.label}
+        </span>
+        {hasScore && (
+          <span style={scoreStyle}>
+            {item.scoreA} — {item.scoreB}
+          </span>
+        )}
+      </div>
+    </article>
+  );
+}
+
+// =====================================================
+// Inline styles — FIFA design tokens
+// =====================================================
+
+const cardStyle: React.CSSProperties = {
+  background: 'hsl(220 55% 11%)',
+  border: '1px solid rgba(255,255,255,0.08)',
+  borderRadius: '0.75rem',
+  padding: '1rem 1.25rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.6rem',
+};
+
+const topRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '0.5rem',
+  flexWrap: 'wrap',
+};
+
+const dateStyle: React.CSSProperties = {
+  fontFamily: "'Barlow', sans-serif",
+  fontSize: '0.8rem',
+  color: 'hsl(215 20% 55%)',
+  textTransform: 'capitalize',
+};
+
+const formatBadgeStyle: React.CSSProperties = {
+  fontFamily: "'Bebas Neue', sans-serif",
+  fontSize: '0.85rem',
+  letterSpacing: '0.08em',
+  background: 'hsl(216 85% 45% / 0.15)',
+  color: 'hsl(216 85% 65%)',
+  border: '1px solid hsl(216 85% 45% / 0.3)',
+  padding: '0.1rem 0.6rem',
+  borderRadius: '4px',
+  flexShrink: 0,
+};
+
+const clubRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.35rem',
+};
+
+const clubIconStyle: React.CSSProperties = {
+  fontSize: '0.75rem',
+  lineHeight: 1,
+};
+
+const clubNameStyle: React.CSSProperties = {
+  fontFamily: "'Barlow Condensed', sans-serif",
+  fontSize: '0.875rem',
+  fontWeight: 700,
+  color: 'hsl(210 20% 85%)',
+  letterSpacing: '0.02em',
+};
+
+const clubZoneStyle: React.CSSProperties = {
+  fontFamily: "'Barlow', sans-serif",
+  fontSize: '0.8rem',
+  color: 'hsl(215 20% 50%)',
+};
+
+const metaRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  flexWrap: 'wrap',
+};
+
+function teamBadgeStyle(team: string): React.CSSProperties {
+  const isA = team === 'A';
+  return {
+    fontFamily: "'Barlow Condensed', sans-serif",
+    fontSize: '0.7rem',
+    fontWeight: 700,
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase',
+    color: isA ? 'hsl(35 100% 55%)' : 'hsl(216 85% 65%)',
+    background: isA ? 'hsl(35 100% 48% / 0.12)' : 'hsl(216 85% 45% / 0.12)',
+    border: `1px solid ${isA ? 'hsl(35 100% 48% / 0.3)' : 'hsl(216 85% 45% / 0.3)'}`,
+    padding: '0.1rem 0.5rem',
+    borderRadius: '4px',
+  };
+}
+
+const orgBadgeStyle: React.CSSProperties = {
+  fontFamily: "'Barlow Condensed', sans-serif",
+  fontSize: '0.6rem',
+  fontWeight: 700,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  color: 'hsl(35 100% 55%)',
+  background: 'hsl(35 100% 48% / 0.15)',
+  border: '1px solid hsl(35 100% 48% / 0.35)',
+  padding: '0.1rem 0.45rem',
+  borderRadius: '4px',
+};
+
+const resultRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+  flexWrap: 'wrap',
+  paddingTop: '0.5rem',
+  borderTop: '1px solid rgba(255,255,255,0.06)',
+};
+
+const resultBadgeBase: React.CSSProperties = {
+  fontFamily: "'Barlow Condensed', sans-serif",
+  fontSize: '0.72rem',
+  fontWeight: 700,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  padding: '0.15rem 0.65rem',
+  borderRadius: '4px',
+};
+
+const scoreStyle: React.CSSProperties = {
+  fontFamily: "'Bebas Neue', sans-serif",
+  fontSize: '1rem',
+  letterSpacing: '0.06em',
+  color: 'hsl(210 20% 90%)',
+};

--- a/apps/frontend/src/components/profile/MatchHistoryList.tsx
+++ b/apps/frontend/src/components/profile/MatchHistoryList.tsx
@@ -1,0 +1,221 @@
+/**
+ * MatchHistoryList — React island for the player's completed match history.
+ *
+ * Decision Context:
+ * - Why React island (not Astro): needs client-side state for "Cargar más" pagination.
+ *   The initial page is rendered server-side via Astro (initialData prop), subsequent
+ *   pages are fetched on-demand when the user clicks "Cargar más".
+ * - client:visible: hydrated only when the section scrolls into the viewport, keeping
+ *   the initial page load fast (the above-the-fold ProfileCard loads first).
+ * - Data fetching: uses raw fetch (not urql) like JoinTeamButton — backendUrl and
+ *   accessToken are passed as props from the SSR Astro page where they're available.
+ * - Page accumulation: clicking "Cargar más" appends items to the existing list (no
+ *   replace). This matches the "infinite scroll" mental model for a history feed.
+ * - Empty state: shown when initialData.items.length === 0, not when items is empty
+ *   after loading (which would flicker on hydration).
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { useState } from 'react';
+import { MatchHistoryCard } from './MatchHistoryCard';
+import {
+  GET_MY_MATCHES,
+  type MatchHistoryConnection,
+  type MatchHistoryItem,
+} from '../../graphql/operations/profile';
+
+interface MatchHistoryListProps {
+  initialData: MatchHistoryConnection;
+  backendUrl: string;
+  accessToken: string;
+}
+
+export function MatchHistoryList({ initialData, backendUrl, accessToken }: MatchHistoryListProps) {
+  const [items, setItems] = useState<MatchHistoryItem[]>(initialData.items);
+  const [currentPage, setCurrentPage] = useState(initialData.page);
+  const [hasMore, setHasMore] = useState(initialData.hasMore);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadMore() {
+    if (loading) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const nextPage = currentPage + 1;
+      const res = await fetch(`${backendUrl}/graphql`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          query: GET_MY_MATCHES,
+          variables: { page: nextPage, pageSize: initialData.pageSize },
+        }),
+      });
+
+      const json = (await res.json()) as {
+        data?: { myMatches?: MatchHistoryConnection };
+        errors?: { message: string }[];
+      };
+
+      if (json.errors?.length) {
+        setError(json.errors[0].message);
+        return;
+      }
+
+      const result = json.data?.myMatches;
+      if (result) {
+        setItems((prev) => [...prev, ...result.items]);
+        setCurrentPage(nextPage);
+        setHasMore(result.hasMore);
+      }
+    } catch {
+      setError('Error de red al cargar más partidos.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (initialData.items.length === 0) {
+    return (
+      <div style={emptyStyle}>
+        <span style={emptyIconStyle}>🏟️</span>
+        <p style={emptyTitleStyle}>Aún no tenés partidos jugados</p>
+        <p style={emptySubStyle}>
+          Tus partidos completados aparecerán aquí con el resultado y el puntaje.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={containerStyle}>
+      <div style={listStyle}>
+        {items.map((item) => (
+          <MatchHistoryCard key={item.id} item={item} />
+        ))}
+      </div>
+
+      {hasMore && (
+        <div style={footerStyle}>
+          <button
+            onClick={loadMore}
+            disabled={loading}
+            style={loading ? loadMoreBtnLoadingStyle : loadMoreBtnStyle}
+            aria-busy={loading}
+          >
+            {loading ? 'Cargando…' : 'Cargar más'}
+          </button>
+        </div>
+      )}
+
+      {!hasMore && items.length > 0 && (
+        <p style={endLabelStyle}>Mostrando todos tus partidos ({items.length})</p>
+      )}
+
+      {error && (
+        <p style={errorStyle} role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// =====================================================
+// Inline styles — FIFA design tokens
+// =====================================================
+
+const containerStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+};
+
+const listStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+  gap: '0.75rem',
+};
+
+const footerStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'center',
+  paddingTop: '0.5rem',
+};
+
+const loadMoreBtnBase: React.CSSProperties = {
+  fontFamily: "'Barlow Condensed', sans-serif",
+  fontSize: '0.875rem',
+  fontWeight: 700,
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  padding: '0.6rem 1.5rem',
+  borderRadius: '8px',
+  border: '1px solid hsl(35 100% 48% / 0.4)',
+  background: 'transparent',
+  color: 'hsl(35 100% 55%)',
+  cursor: 'pointer',
+  transition: 'background 0.15s, color 0.15s',
+};
+
+const loadMoreBtnStyle: React.CSSProperties = loadMoreBtnBase;
+
+const loadMoreBtnLoadingStyle: React.CSSProperties = {
+  ...loadMoreBtnBase,
+  opacity: 0.5,
+  cursor: 'wait',
+};
+
+const endLabelStyle: React.CSSProperties = {
+  fontFamily: "'Barlow', sans-serif",
+  fontSize: '0.8rem',
+  color: 'hsl(215 20% 45%)',
+  textAlign: 'center',
+  margin: 0,
+};
+
+const errorStyle: React.CSSProperties = {
+  fontFamily: "'Barlow', sans-serif",
+  fontSize: '0.85rem',
+  color: 'hsl(0 72% 65%)',
+  textAlign: 'center',
+  margin: 0,
+};
+
+const emptyStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '0.5rem',
+  padding: '2.5rem 1rem',
+  background: 'hsl(220 55% 11%)',
+  border: '1px solid rgba(255,255,255,0.08)',
+  borderRadius: '1rem',
+  textAlign: 'center',
+};
+
+const emptyIconStyle: React.CSSProperties = {
+  fontSize: '2rem',
+  lineHeight: 1,
+  marginBottom: '0.25rem',
+};
+
+const emptyTitleStyle: React.CSSProperties = {
+  fontFamily: "'Bebas Neue', sans-serif",
+  fontSize: '1.4rem',
+  letterSpacing: '0.04em',
+  color: '#fff',
+  margin: 0,
+};
+
+const emptySubStyle: React.CSSProperties = {
+  fontFamily: "'Barlow', sans-serif",
+  fontSize: '0.875rem',
+  color: 'hsl(215 20% 50%)',
+  margin: 0,
+  maxWidth: '320px',
+};

--- a/apps/frontend/src/graphql/operations/profile.graphql
+++ b/apps/frontend/src/graphql/operations/profile.graphql
@@ -13,3 +13,30 @@ query GetMyProfile {
     winrate
   }
 }
+
+# Paginated match history for the authenticated player.
+# scoreA/scoreB are always null until "registrar resultado" US is implemented.
+query GetMyMatches($page: Int, $pageSize: Int) {
+  myMatches(page: $page, pageSize: $pageSize) {
+    items {
+      id
+      title
+      startTime
+      format
+      userTeam
+      userResult
+      scoreA
+      scoreB
+      isOrganizer
+      club {
+        id
+        name
+        zone
+      }
+    }
+    total
+    page
+    pageSize
+    hasMore
+  }
+}

--- a/apps/frontend/src/graphql/operations/profile.ts
+++ b/apps/frontend/src/graphql/operations/profile.ts
@@ -7,6 +7,9 @@
  *   until it is. If you edit the query, update BOTH `profile.graphql` and this file.
  * - Enums mirror the backend schema exactly (`player` → `PLAYER`, etc.) so the frontend
  *   can compare without a runtime mapping layer.
+ * - MatchHistoryItem.scoreA/scoreB are always null until "registrar resultado" US is merged.
+ *   The types include them as nullable so the UI can conditionally render scores when
+ *   that US is eventually implemented.
  * - Previously fixed bugs: none relevant.
  */
 
@@ -18,6 +21,8 @@ export type UserRole = 'PLAYER' | 'CLUB_ADMIN';
 
 export type PlayerPosition = 'GOALKEEPER' | 'DEFENDER' | 'MIDFIELDER' | 'FORWARD';
 
+export type MatchUserResult = 'WON' | 'LOST' | 'DRAW' | 'PENDING';
+
 export interface Profile {
   id: string;
   displayName: string;
@@ -28,6 +33,35 @@ export interface Profile {
   matchesPlayed: number;
   matchesWon: number;
   winrate: number | null;
+}
+
+export interface MatchHistoryClub {
+  id: string;
+  name: string;
+  zone: string | null;
+}
+
+export interface MatchHistoryItem {
+  id: string;
+  title: string;
+  startTime: string;
+  format: string;
+  userTeam: string;
+  userResult: MatchUserResult;
+  /** Null until "registrar resultado" US is implemented */
+  scoreA: number | null;
+  /** Null until "registrar resultado" US is implemented */
+  scoreB: number | null;
+  isOrganizer: boolean;
+  club: MatchHistoryClub | null;
+}
+
+export interface MatchHistoryConnection {
+  items: MatchHistoryItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
 }
 
 // =====================================================
@@ -46,6 +80,33 @@ export const GET_MY_PROFILE = /* GraphQL */ `
       matchesPlayed
       matchesWon
       winrate
+    }
+  }
+`;
+
+export const GET_MY_MATCHES = /* GraphQL */ `
+  query GetMyMatches($page: Int, $pageSize: Int) {
+    myMatches(page: $page, pageSize: $pageSize) {
+      items {
+        id
+        title
+        startTime
+        format
+        userTeam
+        userResult
+        scoreA
+        scoreB
+        isOrganizer
+        club {
+          id
+          name
+          zone
+        }
+      }
+      total
+      page
+      pageSize
+      hasMore
     }
   }
 `;

--- a/apps/frontend/src/pages/perfil.astro
+++ b/apps/frontend/src/pages/perfil.astro
@@ -1,6 +1,5 @@
 ---
 /**
- * [MODIFIED] Added avatar upload modal and trigger.
  * Perfil — SSR (auth required)
  *
  * Decision Context:
@@ -11,12 +10,15 @@
  *   file runs, so the accessToken cookie is guaranteed to be present. We re-read the
  *   cookie here only to forward it to the backend GraphQL endpoint.
  * - Fetch: native fetch instead of urqlClient because urql-client.ts reads the token
- *   from localStorage (client-side only). The user asked us not to modify lib/supabase.ts
- *   — we intentionally also leave urql-client.ts untouched and use fetch directly so the
- *   SSR token flow stays isolated to this page.
- * - Error UX: any GraphQL error is rendered inline instead of throwing a 500. The most
- *   common case is an expired token; the page still renders the navbar so the user can
- *   hit "Salir" and re-login without losing the session hint.
+ *   from localStorage (client-side only). We use fetch directly so the SSR token flow
+ *   stays isolated to this page.
+ * - Match history: the first page (page=1, pageSize=10) is fetched SSR alongside the
+ *   profile so the historial section renders with content immediately. Subsequent pages
+ *   are loaded by the MatchHistoryList.tsx React island via "Cargar más". We gracefully
+ *   degrade: if the history fetch fails, we pass an empty initialData and the island
+ *   shows the empty state without breaking the profile card above it.
+ * - MatchHistoryList uses client:visible (hydrated when scrolled into view) because
+ *   the "Cargar más" button is below the fold and does not need immediate interactivity.
  * - Previously fixed bugs: none relevant.
  */
 export const prerender = false;
@@ -24,8 +26,14 @@ export const prerender = false;
 import Layout from '../layouts/Layout.astro';
 import ProfileCard from '@/components/profile/ProfileCard.astro';
 import AvatarUpload from '@/components/profile/AvatarUpload.tsx';
+import { MatchHistoryList } from '@/components/profile/MatchHistoryList.tsx';
 import { ACCESS_TOKEN_COOKIE } from '../lib/auth';
-import { GET_MY_PROFILE, type Profile } from '../graphql/operations/profile';
+import {
+  GET_MY_PROFILE,
+  GET_MY_MATCHES,
+  type Profile,
+  type MatchHistoryConnection,
+} from '../graphql/operations/profile';
 
 const backendUrl =
   import.meta.env.PRIVATE_BACKEND_URL ||
@@ -40,28 +48,37 @@ const user = Astro.locals.user;
 const accessToken = Astro.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
 const displayName = user?.displayName || user?.email || 'Jugador';
 
+const EMPTY_HISTORY: MatchHistoryConnection = {
+  items: [], total: 0, page: 1, pageSize: 10, hasMore: false,
+};
+
 let profile: Profile | null = null;
 let errorMessage: string | null = null;
+let historyData: MatchHistoryConnection = EMPTY_HISTORY;
 
 if (!accessToken) {
   // Middleware already redirects on this path, but we keep a defensive guard.
   errorMessage = 'Sesión inválida. Iniciá sesión nuevamente.';
 } else {
-  try {
-    const response = await fetch(graphqlUrl, {
+  // Fetch profile and first page of history in parallel
+  const [profileResponse, historyResponse] = await Promise.allSettled([
+    fetch(graphqlUrl, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
       body: JSON.stringify({ query: GET_MY_PROFILE }),
-    });
+    }),
+    fetch(graphqlUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+      body: JSON.stringify({ query: GET_MY_MATCHES, variables: { page: 1, pageSize: 10 } }),
+    }),
+  ]);
 
-    const result = (await response.json().catch(() => null)) as
+  if (profileResponse.status === 'fulfilled') {
+    const result = (await profileResponse.value.json().catch(() => null)) as
       | { data?: { myProfile: Profile | null }; errors?: Array<{ message: string }> }
       | null;
-
-    if (!response.ok || !result) {
+    if (!result || !profileResponse.value.ok) {
       errorMessage = 'No pudimos cargar tu perfil. Intentá de nuevo en unos segundos.';
     } else if (result.errors?.length) {
       errorMessage = result.errors[0]?.message || 'Error al cargar tu perfil.';
@@ -70,8 +87,18 @@ if (!accessToken) {
     } else {
       errorMessage = 'Tu perfil no está disponible todavía.';
     }
-  } catch (e) {
-    errorMessage = e instanceof Error ? e.message : 'Error de red al cargar el perfil';
+  } else {
+    errorMessage = 'Error de red al cargar el perfil';
+  }
+
+  if (historyResponse.status === 'fulfilled') {
+    const histJson = (await historyResponse.value.json().catch(() => null)) as
+      | { data?: { myMatches?: MatchHistoryConnection }; errors?: Array<{ message: string }> }
+      | null;
+    if (histJson?.data?.myMatches) {
+      historyData = histJson.data.myMatches;
+    }
+    // Graceful degradation: if history fails, historyData stays EMPTY_HISTORY
   }
 }
 ---
@@ -126,6 +153,25 @@ if (!accessToken) {
           </div>
         )}
       </section>
+
+      <!-- Match history section -->
+      {profile && (
+        <section class="history-section">
+          <header class="history-header">
+            <div class="section-label">ACTIVIDAD</div>
+            <h2 class="history-title">Historial de partidos</h2>
+            <p class="history-sub">
+              Tus partidos completados — {historyData.total > 0 ? `${historyData.total} en total` : 'sin partidos aún'}
+            </p>
+          </header>
+          <MatchHistoryList
+            client:visible
+            initialData={historyData}
+            backendUrl={backendUrl}
+            accessToken={accessToken ?? ''}
+          />
+        </section>
+      )}
     </main>
 
     <!-- Avatar Upload Modal -->
@@ -530,5 +576,33 @@ if (!accessToken) {
     width: 100%;
     padding: 0.75rem;
     font-size: 0.9rem;
+  }
+
+  /* ---- Match history section ---- */
+  .history-section {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .history-header {
+    margin-bottom: 1.5rem;
+  }
+
+  .history-title {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.75rem;
+    font-weight: 400;
+    letter-spacing: 0.04em;
+    color: #ffffff;
+    margin: 0 0 0.25rem;
+    line-height: 1;
+  }
+
+  .history-sub {
+    margin: 0;
+    color: hsl(215 20% 50%);
+    font-size: 0.875rem;
+    font-family: 'Barlow', sans-serif;
   }
 </style>

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -741,3 +741,179 @@ Ejecutar tras levantar backend y frontend con `pnpm dev`.
 - **Organizer FK sin participante**: Si el organizador se salió del partido, `match.organizerId` apunta a un usuario que ya no está en `matchParticipants`. El badge "Org." no aparecerá en ningún jugador en ese caso. Esto es correcto e intencional (ver Decision Context de `matchService.leaveMatch`).
 - **preferredPosition raw**: El backend retorna el valor literal de la DB (ej: `'goalkeeper'`). El componente `PlayerCard.astro` mapea tanto mayúsculas como minúsculas para mayor robustez.
 - **phone en clubs legacy**: Clubs sin teléfono configurado simplemente no muestran esa fila en `ClubLocationCard`.
+
+---
+
+# Testing Manual — User Story: Historial de partidos jugados
+
+## Contexto
+
+Rama: `historial-de-partidos`  
+Query: `myMatches(page: Int, pageSize: Int): MatchHistoryConnection!`  
+Página: `/perfil` — sección "Historial de partidos" (debajo del ProfileCard)  
+Componentes: `MatchHistoryCard.tsx`, `MatchHistoryList.tsx`
+
+**Nota:** `userResult` siempre es `PENDING` hasta que se implemente la US "registrar resultado" (campos `scoreA/scoreB/winnerTeam` no existen aún en la DB).  
+Ejecutar tras levantar backend y frontend con `pnpm dev`.
+
+---
+
+## Test 1 — Usuario sin partidos completados (empty state)
+
+**Pasos:**
+1. Iniciar sesión como un jugador nuevo que no participó en ningún partido completado
+2. Navegar a `/perfil`
+
+**Resultado esperado:**
+- La sección "Historial de partidos" muestra "sin partidos aún" en el subtítulo
+- El componente muestra el empty state: ícono 🏟️, texto "Aún no tenés partidos jugados"
+- No hay tarjetas de partido ni botón "Cargar más"
+
+---
+
+## Test 2 — Usuario con 1 partido completado
+
+**Pasos:**
+1. Usar un jugador que tenga exactamente 1 partido con `status = 'completed'` en `matchParticipants`
+2. Navegar a `/perfil`
+
+**Resultado esperado:**
+- Sección muestra "1 en total" en el subtítulo
+- Aparece 1 tarjeta con fecha en español, nombre del club, formato (5v5/7v7/etc.), equipo (A o B)
+- Badge de resultado: gris "Sin resultado" (PENDING)
+- No aparece el botón "Cargar más"
+- "Mostrando todos tus partidos (1)" al final
+
+---
+
+## Test 3 — Paginación con más de 10 partidos
+
+**Pasos:**
+1. Usar un jugador con 15+ partidos completados
+2. Navegar a `/perfil`
+
+**Resultado esperado:**
+- Se muestran 10 tarjetas iniciales (primer page SSR)
+- Aparece botón "Cargar más" al final
+- Click en "Cargar más" → muestra un spinner/texto "Cargando…" → aparecen los siguientes partidos
+- Si quedan menos de 10, el botón desaparece y aparece "Mostrando todos tus partidos (X)"
+- El total en el subtítulo muestra el número correcto
+
+---
+
+## Test 4 — Partido WON (futuro, cuando se implemente resultado)
+
+> **Pendiente:** requiere la US "registrar resultado"
+
+**Resultado esperado cuando esté implementado:**
+- Badge verde "Ganado"
+- Score visible (ej: "3 — 2")
+- `userResult = WON` cuando `winnerTeam === userTeam.toLowerCase()`
+
+---
+
+## Test 5 — Partido LOST (futuro)
+
+> **Pendiente:** requiere la US "registrar resultado"
+
+**Resultado esperado cuando esté implementado:**
+- Badge rojo "Perdido"
+- Score visible
+
+---
+
+## Test 6 — Partido DRAW (futuro)
+
+> **Pendiente:** requiere la US "registrar resultado"
+
+**Resultado esperado cuando esté implementado:**
+- Badge ámbar "Empate"
+- Score visible (ej: "2 — 2")
+
+---
+
+## Test 7 — Badge "Sin resultado" (estado actual)
+
+**Pasos:**
+1. Ver cualquier partido completado en el historial
+
+**Resultado esperado:**
+- Badge gris "Sin resultado" visible en la fila de resultado
+- Sin score visible (scoreA/scoreB son null)
+
+---
+
+## Test 8 — Badge "Organizador" en partido creado por el usuario
+
+**Pasos:**
+1. Usar un jugador que creó al menos un partido que quedó completado
+2. Navegar a `/perfil`
+
+**Resultado esperado:**
+- En la tarjeta de ese partido aparece el badge naranja "Organizador"
+- En partidos donde no fue organizador, el badge no aparece
+
+---
+
+## Test 9 — Partidos cancelled NO aparecen en el historial
+
+**Pasos:**
+1. Usar un jugador inscripto en un partido que fue cancelado (`status = 'cancelled'`)
+2. Navegar a `/perfil`
+
+**Resultado esperado:**
+- Ese partido NO aparece en el historial
+- Solo aparecen partidos con `status = 'completed'`
+
+---
+
+## Test 10 — Cache Redis se usa en segunda request
+
+> Requiere `REDIS_URL` configurado en el backend
+
+**Pasos:**
+1. Navegar a `/perfil` con el historial → primera carga (cache MISS)
+2. Navegar a `/perfil` nuevamente dentro de los 5 minutos
+
+**Resultado esperado en logs del backend:**
+```
+[Redis] Cache MISS: user:matches:<userId>:page:1:size:10
+# (primer acceso)
+
+[Redis] Cache HIT: user:matches:<userId>:page:1:size:10
+# (segundo acceso, dentro de 5 minutos)
+```
+
+---
+
+## Test 11 — Cargar más y volver: datos consistentes
+
+**Pasos:**
+1. Cargar más de una página de historial
+2. Navegar a otra página y volver a `/perfil`
+
+**Resultado esperado:**
+- Al volver, se muestra solo la primera página (page 1) — el estado SSR reinicia
+- La segunda carga usa cache (si Redis está activo) y es rápida
+- No hay duplicados ni datos inconsistentes
+
+---
+
+## Test 12 — hasMore = false con 0 items restantes
+
+**Pasos:**
+1. Llegar al final del historial (cargar todas las páginas disponibles)
+
+**Resultado esperado:**
+- El botón "Cargar más" desaparece
+- Aparece el texto "Mostrando todos tus partidos (X)"
+- No hay llamadas a la API al no haber botón
+
+---
+
+## Notas de implementación
+
+- **Option B (sin resultado):** Los campos `scoreA/scoreB/winnerTeam` no existen en la DB. `userResult` siempre es `PENDING`. La arquitectura está preparada: cuando "registrar resultado" se implemente, solo hay que agregar las columnas vía MCP, actualizar `MATCH_HISTORY_COLUMNS` en el repository y reemplazar la lógica en `toMatchHistoryItem`.
+- **Ordering:** Los partidos se ordenan por `scheduledAt DESC` (fecha del partido, no de inscripción).
+- **TTL de cache:** 5 minutos (`USER_DATA`). Si se registra un resultado en esos 5 minutos, el historial no se actualiza hasta que expira el cache. Esto es aceptable para la frecuencia de uso prevista.
+- **client:visible:** La isla React se hidrata cuando el usuario hace scroll hasta la sección del historial, no al cargar la página.

--- a/docs/prompts/h7w3k9bm-prompt-log.md
+++ b/docs/prompts/h7w3k9bm-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-04-26 12:00:00
+- Task ID: h7w3k9bm
+
+## User Prompt
+
+> Como jugador, quiero ver mi historial de partidos jugados con resultados para llevar un registro de mi actividad. [Stack: Astro 6 + Express + Apollo + Supabase + Redis. Implementar query myMatches con paginación, cálculo WON/LOST/DRAW/PENDING, cache Redis, componentes MatchHistoryCard/MatchHistoryList, integración en /perfil, tests manuales en TESTING.md, typecheck limpio.]
+
+## Agent Main Actions
+
+- **Decisión DB (Opción B):** Supabase MCP no autenticado + columnas `scoreA/scoreB/winnerTeam` no existen → implementó historial sin resultado (`userResult: PENDING` siempre); documentó TODO en `match-history.graphql` y `matchService.ts` con instrucciones exactas para conectar cuando se implemente "registrar resultado". Creó rama `historial-de-partidos`.
+- **Backend completo:** Creó `match-history.graphql` (`MatchUserResult`, `MatchHistoryItem`, `MatchHistoryConnection`, query `myMatches`); añadió `CACHE_PREFIX.USER_MATCHES` en `redis.ts`; extendió `matchRepository.ts` con `getCompletedMatchesByUser()` (query desde `matches` con `matchParticipants!inner` para ordenar por `scheduledAt`); añadió `toMatchHistoryItem()` y `getMyMatches()` con cache de 5 min en `matchService.ts`; añadió resolver `myMatches` con Zod v4 (page≥1, pageSize 1–50, mensajes en español). Corrió codegen — 0 errores.
+- **Frontend + /perfil:** Extendió `profile.ts` y `profile.graphql` con tipos `MatchHistoryItem/Connection` y query `GET_MY_MATCHES`; creó `MatchHistoryCard.tsx` (fecha es-AR, badges resultado FIFA, equipo, organizador) y `MatchHistoryList.tsx` (React island `client:visible`, "Cargar más" paginado, empty/loading/error states); integró en `perfil.astro` con fetch paralelo de perfil + historial SSR y sección "Historial de partidos". Documentó 12 casos de prueba en `TESTING.md`. `turbo typecheck --force`: 0 errores, 0 warnings.


### PR DESCRIPTION
- Added GraphQL query `myMatches` to fetch authenticated player's completed match history with pagination.
- Created types `MatchHistoryItem` and `MatchHistoryConnection` in `profile.ts` and `profile.graphql`.
- Developed React components `MatchHistoryCard` and `MatchHistoryList` for displaying match history.
- Integrated match history section into the profile page (`perfil.astro`), fetching data server-side and handling pagination.
- Implemented caching for match history using Redis with a TTL of 5 minutes.
- Documented manual testing cases for match history functionality in `TESTING.md`.
- Updated backend service `matchService.ts` to include logic for converting database rows to GraphQL types.