### PR TITLE
feat: implement match result voting feature

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -9,10 +9,11 @@
       "args": [
         "-y",
         "@supabase/mcp-server-supabase@latest",
-        "--project-ref=getfqjkfsueucoalvtcc"
+        "--project-ref=getfqjkfsueucoalvtcc",
+        "--access-token=sbp_b2c758b17c54968c866d088cc0be15dca21afbfd"
       ],
       "env": {
-        "SUPABASE_ACCESS_TOKEN": "sbp_86fd983ce49a8878376c322747ef8e390a766632"
+        "SUPABASE_ACCESS_TOKEN": "sbp_b2c758b17c54968c866d088cc0be15dca21afbfd"
       }
     }
   }

--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -175,6 +175,31 @@ export type MatchParticipantsData = {
   totalCount: Scalars['Int']['output'];
 };
 
+export type MatchResultSubmission = {
+  __typename?: 'MatchResultSubmission';
+  approveCount: Scalars['Int']['output'];
+  createdAt: Scalars['String']['output'];
+  hasUserVoted: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  matchId: Scalars['ID']['output'];
+  rejectCount: Scalars['Int']['output'];
+  scoreA: Scalars['Int']['output'];
+  scoreB: Scalars['Int']['output'];
+  status: SubmissionStatus;
+  submitter: TeamMember;
+  userVote?: Maybe<VoteValue>;
+  votes: Array<MatchResultVote>;
+  winnerTeam: WinnerTeam;
+};
+
+export type MatchResultVote = {
+  __typename?: 'MatchResultVote';
+  createdAt: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  vote: VoteValue;
+  voter: TeamMember;
+};
+
 export enum MatchStatus {
   Cancelled = 'CANCELLED',
   Completed = 'COMPLETED',
@@ -200,6 +225,8 @@ export type Mutation = {
   createMatch: CreateMatchResult;
   joinMatch: JoinMatchResult;
   leaveMatch: LeaveMatchResult;
+  proposeMatchResult: MatchResultSubmission;
+  voteMatchResult: VoteSubmissionResult;
 };
 
 
@@ -215,6 +242,16 @@ export type MutationJoinMatchArgs = {
 
 export type MutationLeaveMatchArgs = {
   input: LeaveMatchInput;
+};
+
+
+export type MutationProposeMatchResultArgs = {
+  input: ProposeMatchResultInput;
+};
+
+
+export type MutationVoteMatchResultArgs = {
+  input: VoteMatchResultInput;
 };
 
 export enum PlayerPosition {
@@ -237,11 +274,19 @@ export type Profile = {
   winrate?: Maybe<Scalars['Float']['output']>;
 };
 
+export type ProposeMatchResultInput = {
+  matchId: Scalars['ID']['input'];
+  scoreA: Scalars['Int']['input'];
+  scoreB: Scalars['Int']['input'];
+  winnerTeam?: InputMaybe<WinnerTeam>;
+};
+
 export type Query = {
   __typename?: 'Query';
   clubSlots: Array<ClubSlot>;
   clubs: Array<ClubDetail>;
   match?: Maybe<Match>;
+  matchResultSubmissions: Array<MatchResultSubmission>;
   matches: Array<Match>;
   myMatches: MatchHistoryConnection;
   myProfile: Profile;
@@ -259,6 +304,11 @@ export type QueryMatchArgs = {
 };
 
 
+export type QueryMatchResultSubmissionsArgs = {
+  matchId: Scalars['ID']['input'];
+};
+
+
 export type QueryMatchesArgs = {
   filters?: InputMaybe<MatchFilters>;
 };
@@ -268,6 +318,12 @@ export type QueryMyMatchesArgs = {
   page?: InputMaybe<Scalars['Int']['input']>;
   pageSize?: InputMaybe<Scalars['Int']['input']>;
 };
+
+export enum SubmissionStatus {
+  Confirmed = 'CONFIRMED',
+  Pending = 'PENDING',
+  Rejected = 'REJECTED'
+}
 
 export type TeamMember = {
   __typename?: 'TeamMember';
@@ -280,6 +336,28 @@ export type TeamMember = {
 export enum UserRole {
   ClubAdmin = 'CLUB_ADMIN',
   Player = 'PLAYER'
+}
+
+export type VoteMatchResultInput = {
+  submissionId: Scalars['ID']['input'];
+  vote: VoteValue;
+};
+
+export type VoteSubmissionResult = {
+  __typename?: 'VoteSubmissionResult';
+  statusChanged: Scalars['Boolean']['output'];
+  submission: MatchResultSubmission;
+};
+
+export enum VoteValue {
+  Approve = 'APPROVE',
+  Reject = 'REJECT'
+}
+
+export enum WinnerTeam {
+  A = 'A',
+  B = 'B',
+  Draw = 'DRAW'
 }
 
 export type WithIndex<TObject> = TObject & Record<string, any>;
@@ -377,16 +455,24 @@ export type ResolversTypes = ResolversObject<{
   MatchHistoryConnection: ResolverTypeWrapper<MatchHistoryConnection>;
   MatchHistoryItem: ResolverTypeWrapper<MatchHistoryItem>;
   MatchParticipantsData: ResolverTypeWrapper<MatchParticipantsData>;
+  MatchResultSubmission: ResolverTypeWrapper<MatchResultSubmission>;
+  MatchResultVote: ResolverTypeWrapper<MatchResultVote>;
   MatchStatus: MatchStatus;
   MatchTeam: MatchTeam;
   MatchUserResult: MatchUserResult;
   Mutation: ResolverTypeWrapper<Record<PropertyKey, never>>;
   PlayerPosition: PlayerPosition;
   Profile: ResolverTypeWrapper<Profile>;
+  ProposeMatchResultInput: ProposeMatchResultInput;
   Query: ResolverTypeWrapper<Record<PropertyKey, never>>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
+  SubmissionStatus: SubmissionStatus;
   TeamMember: ResolverTypeWrapper<TeamMember>;
   UserRole: UserRole;
+  VoteMatchResultInput: VoteMatchResultInput;
+  VoteSubmissionResult: ResolverTypeWrapper<VoteSubmissionResult>;
+  VoteValue: VoteValue;
+  WinnerTeam: WinnerTeam;
 }>;
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -410,11 +496,16 @@ export type ResolversParentTypes = ResolversObject<{
   MatchHistoryConnection: MatchHistoryConnection;
   MatchHistoryItem: MatchHistoryItem;
   MatchParticipantsData: MatchParticipantsData;
+  MatchResultSubmission: MatchResultSubmission;
+  MatchResultVote: MatchResultVote;
   Mutation: Record<PropertyKey, never>;
   Profile: Profile;
+  ProposeMatchResultInput: ProposeMatchResultInput;
   Query: Record<PropertyKey, never>;
   String: Scalars['String']['output'];
   TeamMember: TeamMember;
+  VoteMatchResultInput: VoteMatchResultInput;
+  VoteSubmissionResult: VoteSubmissionResult;
 }>;
 
 export type ClubResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Club'] = ResolversParentTypes['Club']> = ResolversObject<{
@@ -522,10 +613,35 @@ export type MatchParticipantsDataResolvers<ContextType = GraphQLContext, ParentT
   totalCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
+export type MatchResultSubmissionResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['MatchResultSubmission'] = ResolversParentTypes['MatchResultSubmission']> = ResolversObject<{
+  approveCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hasUserVoted?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  matchId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  rejectCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  scoreA?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  scoreB?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['SubmissionStatus'], ParentType, ContextType>;
+  submitter?: Resolver<ResolversTypes['TeamMember'], ParentType, ContextType>;
+  userVote?: Resolver<Maybe<ResolversTypes['VoteValue']>, ParentType, ContextType>;
+  votes?: Resolver<Array<ResolversTypes['MatchResultVote']>, ParentType, ContextType>;
+  winnerTeam?: Resolver<ResolversTypes['WinnerTeam'], ParentType, ContextType>;
+}>;
+
+export type MatchResultVoteResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['MatchResultVote'] = ResolversParentTypes['MatchResultVote']> = ResolversObject<{
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  vote?: Resolver<ResolversTypes['VoteValue'], ParentType, ContextType>;
+  voter?: Resolver<ResolversTypes['TeamMember'], ParentType, ContextType>;
+}>;
+
 export type MutationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = ResolversObject<{
   createMatch?: Resolver<ResolversTypes['CreateMatchResult'], ParentType, ContextType, RequireFields<MutationCreateMatchArgs, 'input'>>;
   joinMatch?: Resolver<ResolversTypes['JoinMatchResult'], ParentType, ContextType, RequireFields<MutationJoinMatchArgs, 'input'>>;
   leaveMatch?: Resolver<ResolversTypes['LeaveMatchResult'], ParentType, ContextType, RequireFields<MutationLeaveMatchArgs, 'input'>>;
+  proposeMatchResult?: Resolver<ResolversTypes['MatchResultSubmission'], ParentType, ContextType, RequireFields<MutationProposeMatchResultArgs, 'input'>>;
+  voteMatchResult?: Resolver<ResolversTypes['VoteSubmissionResult'], ParentType, ContextType, RequireFields<MutationVoteMatchResultArgs, 'input'>>;
 }>;
 
 export type ProfileResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Profile'] = ResolversParentTypes['Profile']> = ResolversObject<{
@@ -544,6 +660,7 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   clubSlots?: Resolver<Array<ResolversTypes['ClubSlot']>, ParentType, ContextType, RequireFields<QueryClubSlotsArgs, 'clubId' | 'date'>>;
   clubs?: Resolver<Array<ResolversTypes['ClubDetail']>, ParentType, ContextType>;
   match?: Resolver<Maybe<ResolversTypes['Match']>, ParentType, ContextType, RequireFields<QueryMatchArgs, 'id'>>;
+  matchResultSubmissions?: Resolver<Array<ResolversTypes['MatchResultSubmission']>, ParentType, ContextType, RequireFields<QueryMatchResultSubmissionsArgs, 'matchId'>>;
   matches?: Resolver<Array<ResolversTypes['Match']>, ParentType, ContextType, Partial<QueryMatchesArgs>>;
   myMatches?: Resolver<ResolversTypes['MatchHistoryConnection'], ParentType, ContextType, Partial<QueryMyMatchesArgs>>;
   myProfile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
@@ -554,6 +671,11 @@ export type TeamMemberResolvers<ContextType = GraphQLContext, ParentType extends
   displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   preferredPosition?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type VoteSubmissionResultResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['VoteSubmissionResult'] = ResolversParentTypes['VoteSubmissionResult']> = ResolversObject<{
+  statusChanged?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  submission?: Resolver<ResolversTypes['MatchResultSubmission'], ParentType, ContextType>;
 }>;
 
 export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
@@ -568,9 +690,12 @@ export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   MatchHistoryConnection?: MatchHistoryConnectionResolvers<ContextType>;
   MatchHistoryItem?: MatchHistoryItemResolvers<ContextType>;
   MatchParticipantsData?: MatchParticipantsDataResolvers<ContextType>;
+  MatchResultSubmission?: MatchResultSubmissionResolvers<ContextType>;
+  MatchResultVote?: MatchResultVoteResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Profile?: ProfileResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   TeamMember?: TeamMemberResolvers<ContextType>;
+  VoteSubmissionResult?: VoteSubmissionResultResolvers<ContextType>;
 }>;
 

--- a/apps/backend/src/graphql/resolvers/domains/match-result.ts
+++ b/apps/backend/src/graphql/resolvers/domains/match-result.ts
@@ -1,0 +1,79 @@
+/**
+ * Match Result Resolver — GraphQL resolvers for result voting
+ *
+ * Decision Context:
+ * - Why: Lives under resolvers/domains/ per backend.md mandatory layout.
+ * - All resolvers require authentication (requireAuth throws for unauthenticated callers).
+ * - matchResultSubmissions: read query — user-scoped client not strictly needed since the
+ *   service-role is used in the repository, but we pass userId for per-user DTO fields.
+ * - proposeMatchResult and voteMatchResult: write mutations — user-scoped client created
+ *   from context.accessToken so DB RLS INSERT policies are enforced.
+ * - Errors are returned via Apollo's thrown-error path so the client gets a clean Spanish
+ *   message in the errors array. The result types carry real data (no success/message shape)
+ *   because the mutations always return the updated submission or throw.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { createUserClient } from '../../../config/supabase.js';
+import { matchResultVoteService } from '../../../services/matchResultVoteService.js';
+import { requireAuth } from '../../../types/context.js';
+import type { MutationResolvers, QueryResolvers } from '../../generated/graphql.js';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const Query: QueryResolvers = {
+  /**
+   * Returns all result submissions for a match with per-user voting context.
+   * Requires auth. Caller must be a participant of the match.
+   */
+  matchResultSubmissions: async (_parent, args, ctx) => {
+    const user = requireAuth(ctx);
+
+    if (!UUID_REGEX.test(args.matchId)) {
+      console.warn(`[matchResultResolver.matchResultSubmissions] Invalid UUID: ${args.matchId}`);
+      return [];
+    }
+
+    return matchResultVoteService.getMatchResultSubmissions(args.matchId, { userId: user.id });
+  },
+};
+
+const Mutation: MutationResolvers = {
+  /**
+   * Create a new result proposal for a match.
+   * Requires auth + participant. User-scoped client enforces RLS INSERT policy.
+   */
+  proposeMatchResult: async (_parent, args, ctx) => {
+    const user = requireAuth(ctx);
+    const userClient = ctx.accessToken ? createUserClient(ctx.accessToken) : undefined;
+
+    return matchResultVoteService.proposeMatchResult(
+      {
+        matchId: args.input.matchId,
+        scoreA: args.input.scoreA,
+        scoreB: args.input.scoreB,
+        winnerTeam: args.input.winnerTeam ?? undefined,
+      },
+      { userId: user.id, supabase: userClient },
+    );
+  },
+
+  /**
+   * Cast or update a vote on a result submission.
+   * Requires auth + participant. UPSERT allows changing vote (Caso E).
+   */
+  voteMatchResult: async (_parent, args, ctx) => {
+    const user = requireAuth(ctx);
+    const userClient = ctx.accessToken ? createUserClient(ctx.accessToken) : undefined;
+
+    return matchResultVoteService.voteMatchResult(
+      {
+        submissionId: args.input.submissionId,
+        vote: args.input.vote,
+      },
+      { userId: user.id, supabase: userClient },
+    );
+  },
+};
+
+export const matchResultResolvers = { Query, Mutation };

--- a/apps/backend/src/graphql/resolvers/index.ts
+++ b/apps/backend/src/graphql/resolvers/index.ts
@@ -9,15 +9,18 @@
 
 import { clubResolvers } from './domains/club.js';
 import { matchResolvers } from './domains/match.js';
+import { matchResultResolvers } from './domains/match-result.js';
 import { profileResolvers } from './domains/profile.js';
 
 export const resolvers = {
   Query: {
     ...matchResolvers.Query,
+    ...matchResultResolvers.Query,
     ...profileResolvers.Query,
     ...clubResolvers.Query,
   },
   Mutation: {
     ...matchResolvers.Mutation,
+    ...matchResultResolvers.Mutation,
   },
 };

--- a/apps/backend/src/graphql/schema/match-result-vote.graphql
+++ b/apps/backend/src/graphql/schema/match-result-vote.graphql
@@ -1,0 +1,93 @@
+# GraphQL Schema: Match result voting
+#
+# Decision Context:
+# - Why this exists: players who participated in a match can propose the final score and
+#   vote to approve or reject each proposal. A submission is confirmed when it reaches a
+#   simple majority of participant votes.
+# - Column name mapping: DB uses scoreTeamA/scoreTeamB/winningTeam/submissionStatus;
+#   GraphQL exposes scoreA/scoreB/winnerTeam/status to align with the spec contract and
+#   keep the API clean regardless of the underlying schema.
+# - winnerTeam enum: DB has winnerTeamValue (a/b/draw); GraphQL exposes WinnerTeam (A/B/DRAW).
+# - SubmissionStatus: DB uses matchSubmissionStatus enum (pending/confirmed/rejected);
+#   isConfirmed boolean kept for backward compat but submissionStatus is authoritative.
+# - No DELETE policies: submissions and votes are immutable audit records.
+#   Service-role client is used for system-side UPDATE (confirm/reject) which bypasses RLS.
+# - Previously fixed bugs: none relevant.
+
+enum WinnerTeam {
+  A
+  B
+  DRAW
+}
+
+enum SubmissionStatus {
+  PENDING
+  CONFIRMED
+  REJECTED
+}
+
+enum VoteValue {
+  APPROVE
+  REJECT
+}
+
+type MatchResultVote {
+  id: ID!
+  voter: TeamMember!
+  vote: VoteValue!
+  createdAt: String!
+}
+
+type MatchResultSubmission {
+  id: ID!
+  matchId: ID!
+  submitter: TeamMember!
+  scoreA: Int!
+  scoreB: Int!
+  winnerTeam: WinnerTeam!
+  status: SubmissionStatus!
+  votes: [MatchResultVote!]!
+  approveCount: Int!
+  rejectCount: Int!
+  # True when the authenticated user already cast a vote on this submission
+  hasUserVoted: Boolean!
+  # The authenticated user's current vote — null if they haven't voted
+  userVote: VoteValue
+  createdAt: String!
+}
+
+type VoteSubmissionResult {
+  submission: MatchResultSubmission!
+  # True when this vote caused the submission to transition to CONFIRMED
+  statusChanged: Boolean!
+}
+
+input ProposeMatchResultInput {
+  matchId: ID!
+  scoreA: Int!
+  scoreB: Int!
+  # If omitted the resolver derives it automatically from the scores
+  winnerTeam: WinnerTeam
+}
+
+input VoteMatchResultInput {
+  submissionId: ID!
+  vote: VoteValue!
+}
+
+extend type Query {
+  # Returns all submissions for a match, newest first.
+  # Requires authentication. Caller must be a participant of the match.
+  matchResultSubmissions(matchId: ID!): [MatchResultSubmission!]!
+}
+
+extend type Mutation {
+  # Create a new result proposal for a match.
+  # Requires authentication. Caller must be a participant.
+  proposeMatchResult(input: ProposeMatchResultInput!): MatchResultSubmission!
+
+  # Cast or change a vote on an existing submission.
+  # Requires authentication. Caller must be a participant.
+  # Uses UPSERT — calling again with a different vote changes the existing vote.
+  voteMatchResult(input: VoteMatchResultInput!): VoteSubmissionResult!
+}

--- a/apps/backend/src/repositories/matchRepository.ts
+++ b/apps/backend/src/repositories/matchRepository.ts
@@ -648,12 +648,16 @@ export async function deleteMatch(matchId: string): Promise<void> {
 // =====================================================
 
 // Minimal columns selected for the history card — no capacity/createdAt/clubSlotId needed.
+// scoreTeamA/scoreTeamB/winningTeam added once "registrar resultado" US is implemented.
 const MATCH_HISTORY_COLUMNS = `
   id,
   description,
   "scheduledAt",
   format,
-  "organizerId"
+  "organizerId",
+  "scoreTeamA",
+  "scoreTeamB",
+  "winningTeam"
 `;
 
 // Club columns for history — no lat/lng/phone, only display fields needed.
@@ -679,6 +683,9 @@ export interface CompletedMatchRow {
   scheduledAt: string;
   format: string;
   organizerId: string;
+  scoreTeamA: number | null;
+  scoreTeamB: number | null;
+  winningTeam: 'a' | 'b' | 'draw' | null;
   clubs: HistoryClubRow | null;
   matchParticipants: HistoryParticipantRow[];
 }

--- a/apps/backend/src/repositories/matchResultVoteRepository.ts
+++ b/apps/backend/src/repositories/matchResultVoteRepository.ts
@@ -1,0 +1,414 @@
+/**
+ * MatchResultVote Repository — database access for result submissions and votes
+ *
+ * Decision Context:
+ * - Why: Isolated repository keeps DB queries out of the service layer per backend.md rules.
+ * - Column mapping: DB uses scoreTeamA/scoreTeamB/winningTeam/submissionStatus;
+ *   this layer returns raw DB rows — the service maps them to GraphQL names.
+ * - Egress prevention: every SELECT lists explicit columns (no select('*')).
+ * - Service-role vs user-scoped:
+ *   - createSubmission / upsertVote: called with user-scoped client so RLS INSERT policies
+ *     (submitterId/voterId = auth.uid() + participant check) are enforced.
+ *   - confirmSubmission / rejectOtherSubmissions / updateMatchWithResult: use the singleton
+ *     service-role client because these are system-triggered state transitions, not user
+ *     actions. The authenticated UPDATE policy on matches only allows the organizer, so
+ *     result confirmation must bypass RLS just like updateMatchStatus does.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { supabase } from '../config/supabase.js';
+import type { SupabaseClient } from '../config/supabase.js';
+
+// =====================================================
+// Column Definitions (NEVER select('*'))
+// =====================================================
+
+const SUBMISSION_COLUMNS = `
+  id,
+  "matchId",
+  "submitterId",
+  "scoreTeamA",
+  "scoreTeamB",
+  "winningTeam",
+  "submissionStatus",
+  "isConfirmed",
+  "createdAt"
+`;
+
+const SUBMITTER_COLUMNS = `id, "displayName", "avatarUrl"`;
+
+const VOTE_COLUMNS = `
+  id,
+  "submissionId",
+  "voterId",
+  vote,
+  "createdAt"
+`;
+
+const VOTER_COLUMNS = `id, "displayName", "avatarUrl"`;
+
+// =====================================================
+// Row Types
+// =====================================================
+
+export interface SubmitterRow {
+  id: string;
+  displayName: string;
+  avatarUrl: string | null;
+}
+
+export interface VoteRow {
+  id: string;
+  submissionId: string;
+  voterId: string;
+  vote: 'approve' | 'reject';
+  createdAt: string;
+  profiles: SubmitterRow;
+}
+
+export interface SubmissionRow {
+  id: string;
+  matchId: string;
+  submitterId: string;
+  scoreTeamA: number;
+  scoreTeamB: number;
+  winningTeam: 'a' | 'b' | 'draw';
+  submissionStatus: 'pending' | 'confirmed' | 'rejected';
+  isConfirmed: boolean;
+  createdAt: string;
+  profiles: SubmitterRow;
+  matchResultVotes: VoteRow[];
+}
+
+export interface MatchStatusRow {
+  id: string;
+  status: string;
+}
+
+export interface CreateSubmissionInput {
+  matchId: string;
+  submitterId: string;
+  scoreTeamA: number;
+  scoreTeamB: number;
+  winningTeam: 'a' | 'b' | 'draw';
+}
+
+// =====================================================
+// Repository Functions
+// =====================================================
+
+/**
+ * Fetch only the match status — minimal egress for the cancelled-match guard.
+ * Uses service-role; no user data involved.
+ */
+export async function getMatchStatus(matchId: string): Promise<MatchStatusRow | null> {
+  const { data, error } = await supabase
+    .from('matches')
+    .select('id, status')
+    .eq('id', matchId)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return null;
+    console.error(
+      `[matchResultVoteRepository.getMatchStatus] Supabase error matchId=${matchId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return data as MatchStatusRow;
+}
+
+/**
+ * Check if a user is a participant (matchParticipants row exists).
+ * Uses service-role — a plain existence check, no user data exposed.
+ */
+export async function isParticipant(matchId: string, userId: string): Promise<boolean> {
+  const { count, error } = await supabase
+    .from('matchParticipants')
+    .select('id', { count: 'exact', head: true })
+    .eq('matchId', matchId)
+    .eq('playerId', userId);
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.isParticipant] Supabase error matchId=${matchId} userId=${userId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return (count ?? 0) > 0;
+}
+
+/**
+ * Return all submissions for a match, including their votes and submitter profiles.
+ * Ordered newest-first.
+ */
+export async function getSubmissionsByMatch(matchId: string): Promise<SubmissionRow[]> {
+  const { data, error } = await supabase
+    .from('matchResultSubmissions')
+    .select(
+      `${SUBMISSION_COLUMNS},
+       profiles(${SUBMITTER_COLUMNS}),
+       matchResultVotes(${VOTE_COLUMNS}, profiles(${VOTER_COLUMNS}))`,
+    )
+    .eq('matchId', matchId)
+    .order('createdAt', { ascending: false });
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.getSubmissionsByMatch] Supabase error matchId=${matchId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return (data as unknown as SubmissionRow[]) ?? [];
+}
+
+/**
+ * Return a single submission by its ID, including votes and profiles.
+ */
+export async function getSubmissionById(submissionId: string): Promise<SubmissionRow | null> {
+  const { data, error } = await supabase
+    .from('matchResultSubmissions')
+    .select(
+      `${SUBMISSION_COLUMNS},
+       profiles(${SUBMITTER_COLUMNS}),
+       matchResultVotes(${VOTE_COLUMNS}, profiles(${VOTER_COLUMNS}))`,
+    )
+    .eq('id', submissionId)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return null;
+    console.error(
+      `[matchResultVoteRepository.getSubmissionById] Supabase error submissionId=${submissionId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return data as unknown as SubmissionRow;
+}
+
+/**
+ * Insert a new submission.
+ * Must be called with user-scoped client so RLS INSERT policy is enforced:
+ *   submitterId = auth.uid() AND user is participant.
+ */
+export async function createSubmission(
+  input: CreateSubmissionInput,
+  client: SupabaseClient,
+): Promise<SubmissionRow> {
+  const { data, error } = await client
+    .from('matchResultSubmissions')
+    .insert({
+      matchId: input.matchId,
+      submitterId: input.submitterId,
+      scoreTeamA: input.scoreTeamA,
+      scoreTeamB: input.scoreTeamB,
+      winningTeam: input.winningTeam,
+    })
+    .select(
+      `${SUBMISSION_COLUMNS},
+       profiles(${SUBMITTER_COLUMNS}),
+       matchResultVotes(${VOTE_COLUMNS}, profiles(${VOTER_COLUMNS}))`,
+    )
+    .single();
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.createSubmission] Supabase error matchId=${input.matchId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return data as unknown as SubmissionRow;
+}
+
+/**
+ * Upsert a vote (INSERT or UPDATE on the UNIQUE(submissionId, voterId) constraint).
+ * Must be called with user-scoped client so RLS INSERT policy is enforced.
+ *
+ * Decision Context:
+ * - onConflict targets the unique constraint so re-voting updates the existing row.
+ * - The UPDATE RLS policy (votes_voter_update) allows the voter to change their vote.
+ * - Previously fixed bugs: none relevant.
+ */
+export async function upsertVote(
+  submissionId: string,
+  voterId: string,
+  vote: 'approve' | 'reject',
+  client: SupabaseClient,
+): Promise<void> {
+  const { error } = await client
+    .from('matchResultVotes')
+    .upsert(
+      { submissionId, voterId, vote },
+      { onConflict: 'submissionId,voterId' },
+    );
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.upsertVote] Supabase error submissionId=${submissionId} voterId=${voterId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+}
+
+/**
+ * Count approve votes for a submission.
+ * head:true fetches only the count (egress prevention).
+ */
+export async function countApproveVotes(submissionId: string): Promise<number> {
+  const { count, error } = await supabase
+    .from('matchResultVotes')
+    .select('id', { count: 'exact', head: true })
+    .eq('submissionId', submissionId)
+    .eq('vote', 'approve');
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.countApproveVotes] Supabase error submissionId=${submissionId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return count ?? 0;
+}
+
+/**
+ * Count participants for a match (total voters eligible).
+ */
+export async function countMatchParticipants(matchId: string): Promise<number> {
+  const { count, error } = await supabase
+    .from('matchParticipants')
+    .select('id', { count: 'exact', head: true })
+    .eq('matchId', matchId);
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.countMatchParticipants] Supabase error matchId=${matchId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return count ?? 0;
+}
+
+/**
+ * Mark a submission as confirmed (service-role — system-triggered transition).
+ * Also sets isConfirmed = true for backward compatibility.
+ */
+export async function confirmSubmission(submissionId: string): Promise<void> {
+  const { error } = await supabase
+    .from('matchResultSubmissions')
+    .update({ submissionStatus: 'confirmed', isConfirmed: true })
+    .eq('id', submissionId);
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.confirmSubmission] Supabase error submissionId=${submissionId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+}
+
+/**
+ * Reject all pending submissions for a match except the confirmed one.
+ * Called after a submission reaches majority so the other candidates are closed.
+ */
+export async function rejectOtherSubmissions(
+  matchId: string,
+  exceptSubmissionId: string,
+): Promise<void> {
+  const { error } = await supabase
+    .from('matchResultSubmissions')
+    .update({ submissionStatus: 'rejected' })
+    .eq('matchId', matchId)
+    .eq('submissionStatus', 'pending')
+    .neq('id', exceptSubmissionId);
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.rejectOtherSubmissions] Supabase error matchId=${matchId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+}
+
+/**
+ * Update the match with the confirmed score/winner/status.
+ * Uses service-role because the authenticated UPDATE policy on matches only
+ * allows the organizer — result confirmation is a system operation.
+ */
+export async function updateMatchWithResult(
+  matchId: string,
+  scoreTeamA: number,
+  scoreTeamB: number,
+  winningTeam: 'a' | 'b' | 'draw',
+): Promise<void> {
+  const { error } = await supabase
+    .from('matches')
+    .update({
+      scoreTeamA,
+      scoreTeamB,
+      winningTeam,
+      resultStatus: 'confirmed',
+      status: 'completed',
+    })
+    .eq('id', matchId);
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.updateMatchWithResult] Supabase error matchId=${matchId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+}
+
+/**
+ * Get all participant userIds for a match.
+ * Used for cache invalidation after result confirmation.
+ */
+export async function getParticipantIds(matchId: string): Promise<string[]> {
+  const { data, error } = await supabase
+    .from('matchParticipants')
+    .select('"playerId"')
+    .eq('matchId', matchId);
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.getParticipantIds] Supabase error matchId=${matchId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return (data ?? []).map((r) => (r as { playerId: string }).playerId);
+}
+
+export const matchResultVoteRepository = {
+  getMatchStatus,
+  isParticipant,
+  getSubmissionsByMatch,
+  getSubmissionById,
+  createSubmission,
+  upsertVote,
+  countApproveVotes,
+  countMatchParticipants,
+  confirmSubmission,
+  rejectOtherSubmissions,
+  updateMatchWithResult,
+  getParticipantIds,
+};

--- a/apps/backend/src/services/matchResultVoteService.ts
+++ b/apps/backend/src/services/matchResultVoteService.ts
@@ -1,0 +1,377 @@
+/**
+ * MatchResultVote Service — business logic for result proposals and voting
+ *
+ * Decision Context:
+ * - Why: Separates business rules from DB access per backend.md service pattern.
+ * - Majority rule: a submission is confirmed when approveCount > totalParticipants / 2.
+ *   This means > 50% (strict majority), not >= 50%. With 5 players, 3 approvals confirm.
+ * - Column mapping: DB uses scoreTeamA/scoreTeamB/winningTeam; GraphQL uses scoreA/scoreB/
+ *   winnerTeam. Mapping lives here in toSubmissionDTO so resolvers see clean GQL types.
+ * - winnerTeam derivation: if scoreA > scoreB → 'a', scoreB > scoreA → 'b', else 'draw'.
+ *   If caller passes an explicit winnerTeam in ProposeMatchResultInput we use that instead,
+ *   but we still validate it matches the score (prevents inconsistent data).
+ * - Cache invalidation on confirmation:
+ *   - match:participants:{id} and match:{id} → cleared so detail page shows updated score
+ *   - user:matches:{userId}* → cleared for every participant so history shows result
+ *   - matches result submissions cache → cleared so future reads reflect confirmed state
+ * - Race condition on last vote: two simultaneous votes could both read approveCount < threshold
+ *   and both trigger confirmSubmission. confirmSubmission is idempotent (UPDATE WHERE id=x
+ *   always sets the same values). The second call is a harmless no-op.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { z } from 'zod';
+import {
+  cacheDelete,
+  cacheDeletePattern,
+  cacheGetOrSet,
+  CACHE_PREFIX,
+  CACHE_TTL,
+} from '../config/redis.js';
+import {
+  SubmissionStatus,
+  VoteValue,
+  WinnerTeam,
+  type MatchResultSubmission,
+  type VoteSubmissionResult,
+} from '../graphql/generated/graphql.js';
+import { matchResultVoteRepository, type SubmissionRow, type VoteRow, type MatchStatusRow } from '../repositories/matchResultVoteRepository.js';
+import type { ServiceContext } from '../types/context.js';
+
+// =====================================================
+// Cache key prefix for submissions lists
+// =====================================================
+
+const SUBMISSIONS_PREFIX = 'match:submissions:';
+
+// =====================================================
+// Zod Validation Schemas
+// =====================================================
+
+const uuidSchema = z.string().uuid({ message: 'ID inválido' });
+
+const proposeSchema = z.object({
+  matchId: uuidSchema,
+  scoreA: z.number().int().min(0, { message: 'El marcador no puede ser negativo' }).max(99, { message: 'Marcador demasiado alto' }),
+  scoreB: z.number().int().min(0, { message: 'El marcador no puede ser negativo' }).max(99, { message: 'Marcador demasiado alto' }),
+  winnerTeam: z.enum(['A', 'B', 'DRAW']).optional(),
+});
+
+const voteSchema = z.object({
+  submissionId: uuidSchema,
+  vote: z.enum(['APPROVE', 'REJECT'], { message: 'Voto inválido' }),
+});
+
+// =====================================================
+// Enum Mapping (GraphQL <-> Database)
+// =====================================================
+
+const DB_TO_WINNER: Record<string, WinnerTeam> = {
+  a: WinnerTeam.A,
+  b: WinnerTeam.B,
+  draw: WinnerTeam.Draw,
+};
+
+const WINNER_TO_DB: Record<WinnerTeam, 'a' | 'b' | 'draw'> = {
+  [WinnerTeam.A]: 'a',
+  [WinnerTeam.B]: 'b',
+  [WinnerTeam.Draw]: 'draw',
+};
+
+const DB_TO_STATUS: Record<string, SubmissionStatus> = {
+  pending: SubmissionStatus.Pending,
+  confirmed: SubmissionStatus.Confirmed,
+  rejected: SubmissionStatus.Rejected,
+};
+
+const DB_TO_VOTE: Record<string, VoteValue> = {
+  approve: VoteValue.Approve,
+  reject: VoteValue.Reject,
+};
+
+// =====================================================
+// DTO Transformation
+// =====================================================
+
+/**
+ * Derive winner from scores when not explicitly provided.
+ */
+function deriveWinner(scoreA: number, scoreB: number): 'a' | 'b' | 'draw' {
+  if (scoreA > scoreB) return 'a';
+  if (scoreB > scoreA) return 'b';
+  return 'draw';
+}
+
+function toVoteDTO(voteRow: VoteRow, callerId: string | undefined): ReturnType<typeof toSubmissionDTO>['votes'][number] {
+  return {
+    id: voteRow.id,
+    voter: {
+      id: voteRow.profiles.id,
+      displayName: voteRow.profiles.displayName,
+      avatarUrl: voteRow.profiles.avatarUrl ?? null,
+    },
+    vote: DB_TO_VOTE[voteRow.vote] ?? VoteValue.Approve,
+    createdAt: voteRow.createdAt,
+  };
+}
+
+function toSubmissionDTO(
+  row: SubmissionRow,
+  callerId: string | undefined,
+): MatchResultSubmission {
+  const votes = row.matchResultVotes.map((v) => toVoteDTO(v, callerId));
+  const approveCount = row.matchResultVotes.filter((v) => v.vote === 'approve').length;
+  const rejectCount = row.matchResultVotes.filter((v) => v.vote === 'reject').length;
+
+  const userVoteRow = callerId
+    ? row.matchResultVotes.find((v) => v.voterId === callerId)
+    : undefined;
+
+  return {
+    id: row.id,
+    matchId: row.matchId,
+    submitter: {
+      id: row.profiles.id,
+      displayName: row.profiles.displayName,
+      avatarUrl: row.profiles.avatarUrl ?? null,
+    },
+    scoreA: row.scoreTeamA,
+    scoreB: row.scoreTeamB,
+    winnerTeam: DB_TO_WINNER[row.winningTeam] ?? WinnerTeam.Draw,
+    status: DB_TO_STATUS[row.submissionStatus] ?? SubmissionStatus.Pending,
+    votes,
+    approveCount,
+    rejectCount,
+    hasUserVoted: !!userVoteRow,
+    userVote: userVoteRow ? (DB_TO_VOTE[userVoteRow.vote] ?? null) : null,
+    createdAt: row.createdAt,
+  };
+}
+
+// =====================================================
+// Service Functions
+// =====================================================
+
+/**
+ * Propose a match result.
+ *
+ * Decision Context:
+ * - Validation order:
+ *   1. Auth + user-scoped client required.
+ *   2. Zod schema validates IDs, score ranges.
+ *   3. Match existence + status check — cancelled matches reject proposals.
+ *   4. Participant check — non-participants are rejected with a clear error.
+ *   5. winnerTeam is derived from scores if omitted; if provided, must match the scores.
+ *   6. INSERT via user-scoped client so RLS INSERT policy is enforced.
+ * - Multiple pending submissions per match are allowed (Caso B in spec).
+ *   The first to reach majority wins; others are auto-rejected.
+ * - Previously fixed bugs: P1 audit — no status check allowed proposals on cancelled matches.
+ */
+export async function proposeMatchResult(
+  input: { matchId: string; scoreA: number; scoreB: number; winnerTeam?: WinnerTeam | null },
+  ctx: ServiceContext,
+): Promise<MatchResultSubmission> {
+  if (!ctx.userId) throw new Error('Se requiere autenticación');
+  const db = ctx.supabase;
+  if (!db) throw new Error('Se requiere cliente con contexto de usuario');
+
+  const parsed = proposeSchema.parse({
+    matchId: input.matchId,
+    scoreA: input.scoreA,
+    scoreB: input.scoreB,
+    winnerTeam: input.winnerTeam ?? undefined,
+  });
+
+  // Guard: load match status before any participant/DB write check
+  const matchStatus = await matchResultVoteRepository.getMatchStatus(parsed.matchId);
+  if (!matchStatus) throw new Error('Partido no encontrado');
+  if (matchStatus.status === 'cancelled') {
+    throw new Error('El partido fue cancelado, no se pueden proponer ni votar resultados');
+  }
+
+  const isPlayer = await matchResultVoteRepository.isParticipant(parsed.matchId, ctx.userId);
+  if (!isPlayer) {
+    throw new Error('Solo los participantes del partido pueden proponer resultados');
+  }
+
+  const dbWinner = parsed.winnerTeam
+    ? WINNER_TO_DB[parsed.winnerTeam as WinnerTeam]
+    : deriveWinner(parsed.scoreA, parsed.scoreB);
+
+  const expectedWinner = deriveWinner(parsed.scoreA, parsed.scoreB);
+  if (parsed.winnerTeam && dbWinner !== expectedWinner) {
+    throw new Error('El ganador indicado no coincide con el marcador');
+  }
+
+  const row = await matchResultVoteRepository.createSubmission(
+    {
+      matchId: parsed.matchId,
+      submitterId: ctx.userId,
+      scoreTeamA: parsed.scoreA,
+      scoreTeamB: parsed.scoreB,
+      winningTeam: dbWinner,
+    },
+    db,
+  );
+
+  console.info(
+    `[matchResultVoteService.proposeMatchResult] userId=${ctx.userId} matchId=${parsed.matchId} score=${parsed.scoreA}-${parsed.scoreB}`,
+  );
+
+  await cacheDelete(`${SUBMISSIONS_PREFIX}${parsed.matchId}`);
+
+  return toSubmissionDTO(row, ctx.userId);
+}
+
+/**
+ * Cast or change a vote on an existing submission.
+ *
+ * Decision Context:
+ * - Validation order:
+ *   1. Auth + user-scoped client required.
+ *   2. Zod validates submissionId UUID and vote enum.
+ *   3. Load submission to get matchId.
+ *   4. Match existence + status check — cancelled matches reject votes.
+ *   5. Submission status check — only pending submissions accept votes.
+ *   6. Participant check on the submission's match.
+ *   7. UPSERT vote — the UNIQUE(submissionId, voterId) constraint means a re-vote
+ *      updates the existing row (Caso E: user changes their vote).
+ *   8. Re-count approvals after the upsert.
+ *   9. If approveCount > totalParticipants / 2 → confirm submission, reject others,
+ *      update match, invalidate cache.
+ * - statusChanged is true only when this specific vote triggered the confirmation,
+ *   letting the frontend show a "partido confirmado" notification once.
+ * - Previously fixed bugs: P1 audit — no status check allowed votes on cancelled matches.
+ */
+export async function voteMatchResult(
+  input: { submissionId: string; vote: VoteValue },
+  ctx: ServiceContext,
+): Promise<VoteSubmissionResult> {
+  if (!ctx.userId) throw new Error('Se requiere autenticación');
+  const db = ctx.supabase;
+  if (!db) throw new Error('Se requiere cliente con contexto de usuario');
+
+  const parsed = voteSchema.parse({
+    submissionId: input.submissionId,
+    vote: input.vote,
+  });
+
+  const submission = await matchResultVoteRepository.getSubmissionById(parsed.submissionId);
+  if (!submission) throw new Error('Propuesta de resultado no encontrada');
+
+  // Guard: check match status before allowing vote
+  const matchStatus = await matchResultVoteRepository.getMatchStatus(submission.matchId);
+  if (!matchStatus) throw new Error('Partido no encontrado');
+  if (matchStatus.status === 'cancelled') {
+    throw new Error('El partido fue cancelado, no se pueden proponer ni votar resultados');
+  }
+
+  if (submission.submissionStatus !== 'pending') {
+    throw new Error('Solo se puede votar en propuestas pendientes');
+  }
+
+  const isPlayer = await matchResultVoteRepository.isParticipant(submission.matchId, ctx.userId);
+  if (!isPlayer) {
+    throw new Error('Solo los participantes del partido pueden votar');
+  }
+
+  const dbVote = parsed.vote === 'APPROVE' ? 'approve' : 'reject';
+  await matchResultVoteRepository.upsertVote(parsed.submissionId, ctx.userId, dbVote, db);
+
+  console.info(
+    `[matchResultVoteService.voteMatchResult] userId=${ctx.userId} submissionId=${parsed.submissionId} vote=${dbVote}`,
+  );
+
+  const [approveCount, totalParticipants] = await Promise.all([
+    matchResultVoteRepository.countApproveVotes(parsed.submissionId),
+    matchResultVoteRepository.countMatchParticipants(submission.matchId),
+  ]);
+
+  let statusChanged = false;
+
+  if (approveCount > totalParticipants / 2) {
+    statusChanged = true;
+
+    await matchResultVoteRepository.confirmSubmission(parsed.submissionId);
+    await matchResultVoteRepository.rejectOtherSubmissions(
+      submission.matchId,
+      parsed.submissionId,
+    );
+    await matchResultVoteRepository.updateMatchWithResult(
+      submission.matchId,
+      submission.scoreTeamA,
+      submission.scoreTeamB,
+      submission.winningTeam,
+    );
+
+    console.info(
+      `[matchResultVoteService.voteMatchResult] submissionId=${parsed.submissionId} confirmed — match ${submission.matchId} completed`,
+    );
+
+    // Invalidate match caches
+    await cacheDelete(`${CACHE_PREFIX.MATCH_PARTICIPANTS}${submission.matchId}`);
+    await cacheDelete(`${CACHE_PREFIX.MATCH_DETAIL}${submission.matchId}`);
+    await cacheDelete(CACHE_PREFIX.MATCHES_OPEN);
+    await cacheDeletePattern(`${CACHE_PREFIX.MATCHES_LIST}:*`);
+
+    // Invalidate history cache for all participants
+    const participantIds = await matchResultVoteRepository.getParticipantIds(submission.matchId);
+    await Promise.all(
+      participantIds.map((uid) =>
+        cacheDeletePattern(`${CACHE_PREFIX.USER_MATCHES}${uid}*`),
+      ),
+    );
+  }
+
+  await cacheDelete(`${SUBMISSIONS_PREFIX}${submission.matchId}`);
+
+  const updatedSubmission = await matchResultVoteRepository.getSubmissionById(parsed.submissionId);
+  if (!updatedSubmission) throw new Error('Error al cargar la propuesta actualizada');
+
+  return {
+    submission: toSubmissionDTO(updatedSubmission, ctx.userId),
+    statusChanged,
+  };
+}
+
+/**
+ * List all submissions for a match, with per-user voting context.
+ * Cached with a 5-minute TTL; invalidated on propose and vote mutations.
+ *
+ * Decision Context:
+ * - hasUserVoted and userVote are computed from the vote list in memory (no extra DB query).
+ * - The cache key is per-match (not per-user) because the vote list itself is the same for
+ *   all participants. Per-user fields (hasUserVoted, userVote) are re-derived after cache hit
+ *   using the callerId at the DTO layer.
+ * - Previously fixed bugs: none relevant.
+ */
+export async function getMatchResultSubmissions(
+  matchId: string,
+  ctx: ServiceContext,
+): Promise<MatchResultSubmission[]> {
+  if (!ctx.userId) throw new Error('Se requiere autenticación');
+
+  const parsed = uuidSchema.parse(matchId);
+
+  const isPlayer = await matchResultVoteRepository.isParticipant(parsed, ctx.userId);
+  if (!isPlayer) {
+    throw new Error('Solo los participantes del partido pueden ver los resultados propuestos');
+  }
+
+  const userId = ctx.userId;
+  const cacheKey = `${SUBMISSIONS_PREFIX}${parsed}`;
+
+  const rows = await cacheGetOrSet<SubmissionRow[]>(
+    cacheKey,
+    () => matchResultVoteRepository.getSubmissionsByMatch(parsed),
+    CACHE_TTL.USER_DATA,
+  );
+
+  return rows.map((row) => toSubmissionDTO(row, userId));
+}
+
+export const matchResultVoteService = {
+  proposeMatchResult,
+  voteMatchResult,
+  getMatchResultSubmissions,
+};

--- a/apps/backend/src/services/matchService.ts
+++ b/apps/backend/src/services/matchService.ts
@@ -664,19 +664,30 @@ export async function createMatch(
  * Convert a completed-match DB row into a MatchHistoryItem GraphQL type.
  *
  * Decision Context:
- * - userResult is always PENDING because scoreA/scoreB/winnerTeam do not exist in the DB yet.
- *   TODO: When "registrar resultado" US is implemented, replace PENDING with:
- *     WON  → winnerTeam && winnerTeam === userTeam.toLowerCase()
- *     LOST → winnerTeam && winnerTeam !== userTeam.toLowerCase() && winnerTeam !== 'draw'
- *     DRAW → winnerTeam === 'draw'
- *   At that point, add scoreA/scoreB/winnerTeam to MATCH_HISTORY_COLUMNS in the repo.
+ * - userResult is derived from winningTeam vs the player's team:
+ *     WON  → winningTeam === userTeam (lowercase)
+ *     LOST → winningTeam is the other team
+ *     DRAW → winningTeam === 'draw'
+ *     PENDING → winningTeam is null (result not yet confirmed)
+ * - scoreA/scoreB map from DB scoreTeamA/scoreTeamB (null until result is confirmed).
  * - isOrganizer is derived from `row.organizerId === userId` (no extra DB round-trip).
  * - matchParticipants[0] always exists because getCompletedMatchesByUser uses !inner
  *   join filtered by playerId — guarantees exactly one participant entry per row.
- * - Previously fixed bugs: none relevant.
+ * - Previously fixed bugs: scoreA/scoreB were always null before "registrar resultado" US.
  */
 function toMatchHistoryItem(row: CompletedMatchRow, userId: string): MatchHistoryItem {
   const userTeam = row.matchParticipants[0]?.team === 'a' ? 'A' : 'B';
+
+  let userResult: MatchUserResult = MatchUserResult.Pending;
+  if (row.winningTeam) {
+    if (row.winningTeam === 'draw') {
+      userResult = MatchUserResult.Draw;
+    } else if (row.winningTeam === userTeam.toLowerCase()) {
+      userResult = MatchUserResult.Won;
+    } else {
+      userResult = MatchUserResult.Lost;
+    }
+  }
 
   return {
     id: row.id,
@@ -687,9 +698,9 @@ function toMatchHistoryItem(row: CompletedMatchRow, userId: string): MatchHistor
       ? { id: row.clubs.id, name: row.clubs.name, zone: row.clubs.zone ?? null }
       : null,
     userTeam,
-    userResult: MatchUserResult.Pending,
-    scoreA: null,
-    scoreB: null,
+    userResult,
+    scoreA: row.scoreTeamA ?? null,
+    scoreB: row.scoreTeamB ?? null,
     isOrganizer: row.organizerId === userId,
   };
 }

--- a/apps/frontend/src/components/matches/MatchResultsSection.tsx
+++ b/apps/frontend/src/components/matches/MatchResultsSection.tsx
@@ -1,0 +1,377 @@
+/**
+ * MatchResultsSection — displays result submissions and voting UI for a match.
+ *
+ * Decision Context:
+ * - Why a React island: requires auth-aware interactivity (vote buttons, propose form).
+ *   client:visible in the parent page loads it lazily when scrolled into view.
+ * - State: submissions fetched on mount. After each mutation the affected submission is
+ *   replaced in-place from the response — no extra round-trip needed.
+ * - CTA visibility rules (P2 fix):
+ *   - No submissions OR all REJECTED → "Cargar resultado" CTA
+ *     (previously only showed when submissions.length === 0, missing the all-rejected case)
+ *   - Has PENDING, no CONFIRMED → show submissions + "Proponer otro resultado"
+ *   - Has CONFIRMED → show result card + hide all propose CTAs
+ * - Cancelled match guard: showResultSection in [id].astro already excludes cancelled
+ *   matches (P1 fix), so this component never renders for them.
+ * - Styling: Tailwind utility classes using @theme tokens from globals.css.
+ *   font-display → Bebas Neue, font-condensed → Barlow Condensed (tokens added for P3).
+ *   bg-success / text-success-foreground → hsl(142 72% 50%) / hsl(142 72% 65%).
+ * - Previously fixed bugs:
+ *   - P2 audit: "Cargar resultado" disappeared when all submissions were REJECTED.
+ *   - P3 audit: inline style objects replaced with Tailwind classes per design-system.md.
+ */
+
+import { useEffect, useState } from 'react';
+import type { MatchResultSubmission } from '../../graphql/operations/match-results.js';
+import {
+  GET_MATCH_RESULT_SUBMISSIONS,
+  VOTE_MATCH_RESULT,
+  type VoteValue,
+} from '../../graphql/operations/match-results.js';
+import ProposeResultForm from './ProposeResultForm.js';
+
+interface Props {
+  matchId: string;
+  isParticipant: boolean;
+  backendUrl: string;
+  accessToken: string;
+}
+
+async function gql<T>(
+  backendUrl: string,
+  accessToken: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<{ data?: T; errors?: { message: string }[] }> {
+  const res = await fetch(`${backendUrl}/graphql`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  return res.json() as Promise<{ data?: T; errors?: { message: string }[] }>;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('es-AR', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function ScoreBadge({
+  scoreA,
+  scoreB,
+  winnerTeam,
+}: {
+  scoreA: number;
+  scoreB: number;
+  winnerTeam: string;
+}) {
+  const label = winnerTeam === 'DRAW' ? 'Empate' : `Gana Equipo ${winnerTeam}`;
+  return (
+    <div className="flex items-center gap-[0.4rem]">
+      <span className="font-display text-[2rem] text-foreground leading-none">{scoreA}</span>
+      <span className="font-display text-[1.2rem] text-muted-foreground leading-none">—</span>
+      <span className="font-display text-[2rem] text-foreground leading-none">{scoreB}</span>
+      <span className="font-condensed text-[0.8rem] font-bold tracking-[0.08em] text-muted-foreground uppercase ml-[0.3rem]">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === 'CONFIRMED') {
+    return (
+      <span className="font-condensed text-[0.75rem] font-bold tracking-[0.07em] uppercase px-[0.65rem] py-[0.25rem] rounded-full bg-success/15 border border-success/40 text-success-foreground">
+        ✓ Resultado oficial
+      </span>
+    );
+  }
+  if (status === 'REJECTED') {
+    return (
+      <span className="font-condensed text-[0.75rem] font-bold tracking-[0.07em] uppercase px-[0.65rem] py-[0.25rem] rounded-full bg-white/5 border border-white/10 text-muted-foreground">
+        Rechazado
+      </span>
+    );
+  }
+  return (
+    <span className="font-condensed text-[0.75rem] font-bold tracking-[0.07em] uppercase px-[0.65rem] py-[0.25rem] rounded-full bg-primary/10 border border-primary/30 text-primary">
+      Pendiente
+    </span>
+  );
+}
+
+interface SubmissionCardProps {
+  submission: MatchResultSubmission;
+  isParticipant: boolean;
+  onVote: (submissionId: string, vote: VoteValue) => Promise<void>;
+  voting: string | null;
+}
+
+function SubmissionCard({ submission, isParticipant, onVote, voting }: SubmissionCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const isPending = submission.status === 'PENDING';
+  const isVoting = voting === submission.id;
+  const isConfirmed = submission.status === 'CONFIRMED';
+
+  return (
+    <div
+      className={`flex flex-col gap-[0.7rem] rounded-[10px] px-[1.4rem] py-[1.1rem] border ${
+        isConfirmed
+          ? 'bg-success-surface border-success/35'
+          : 'bg-card border-white/8'
+      }`}
+    >
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <ScoreBadge
+          scoreA={submission.scoreA}
+          scoreB={submission.scoreB}
+          winnerTeam={submission.winnerTeam}
+        />
+        <StatusBadge status={submission.status} />
+      </div>
+
+      <p className="m-0 font-body text-[0.825rem] text-muted-foreground">
+        Propuesto por <strong>{submission.submitter.displayName}</strong> ·{' '}
+        {formatDate(submission.createdAt)}
+      </p>
+
+      <div className="flex gap-4">
+        <span className="font-body text-[0.825rem] text-success-foreground">
+          ✓ {submission.approveCount} aprobaciones
+        </span>
+        <span className="font-body text-[0.825rem] text-destructive">
+          ✗ {submission.rejectCount} rechazos
+        </span>
+      </div>
+
+      {isPending && isParticipant && (
+        <div className="flex gap-[0.6rem] items-center flex-wrap">
+          {!submission.hasUserVoted ? (
+            <>
+              <button
+                onClick={() => onVote(submission.id, 'APPROVE')}
+                disabled={isVoting}
+                className="rounded-md font-condensed text-[0.85rem] font-bold tracking-[0.07em] px-4 py-[0.4rem] cursor-pointer bg-success/15 border border-success/40 text-success-foreground disabled:opacity-60"
+              >
+                {isVoting ? '…' : '✓ Aprobar'}
+              </button>
+              <button
+                onClick={() => onVote(submission.id, 'REJECT')}
+                disabled={isVoting}
+                className="rounded-md font-condensed text-[0.85rem] font-bold tracking-[0.07em] px-4 py-[0.4rem] cursor-pointer bg-destructive/12 border border-destructive/35 text-destructive disabled:opacity-60"
+              >
+                {isVoting ? '…' : '✗ Rechazar'}
+              </button>
+            </>
+          ) : (
+            <div className="flex items-center gap-3 flex-wrap font-body text-[0.85rem] text-muted-foreground">
+              <span>
+                Tu voto:{' '}
+                <strong>
+                  {submission.userVote === 'APPROVE' ? 'Aprobado ✓' : 'Rechazado ✗'}
+                </strong>
+              </span>
+              <button
+                onClick={() =>
+                  onVote(
+                    submission.id,
+                    submission.userVote === 'APPROVE' ? 'REJECT' : 'APPROVE',
+                  )
+                }
+                disabled={isVoting}
+                className="bg-transparent border border-white/12 rounded-[5px] text-muted-foreground font-body text-[0.8rem] py-[0.2rem] px-[0.7rem] cursor-pointer disabled:opacity-60"
+              >
+                {isVoting ? '…' : 'Cambiar voto'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {submission.votes.length > 0 && (
+        <div>
+          <button
+            onClick={() => setExpanded((x) => !x)}
+            className="bg-transparent border-none text-secondary font-body text-[0.8rem] p-0 cursor-pointer underline"
+          >
+            {expanded
+              ? 'Ocultar votos'
+              : `Ver ${submission.votes.length} voto${submission.votes.length !== 1 ? 's' : ''}`}
+          </button>
+          {expanded && (
+            <ul className="list-none m-0 mt-2 p-0 flex flex-col gap-[0.3rem]">
+              {submission.votes.map((v) => (
+                <li key={v.id} className="flex items-center gap-2">
+                  <span
+                    className={
+                      v.vote === 'APPROVE'
+                        ? 'font-body text-[0.825rem] text-success-foreground'
+                        : 'font-body text-[0.825rem] text-destructive'
+                    }
+                  >
+                    {v.vote === 'APPROVE' ? '✓' : '✗'}
+                  </span>
+                  <span className="font-body text-[0.825rem] text-muted-foreground">
+                    {v.voter.displayName}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function MatchResultsSection({
+  matchId,
+  isParticipant,
+  backendUrl,
+  accessToken,
+}: Props) {
+  const [submissions, setSubmissions] = useState<MatchResultSubmission[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [voting, setVoting] = useState<string | null>(null);
+  const [voteError, setVoteError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isParticipant) {
+      setLoading(false);
+      return;
+    }
+
+    gql<{ matchResultSubmissions: MatchResultSubmission[] }>(
+      backendUrl,
+      accessToken,
+      GET_MATCH_RESULT_SUBMISSIONS,
+      { matchId },
+    )
+      .then((json) => {
+        if (json.errors?.length) {
+          setFetchError(json.errors[0].message);
+        } else {
+          setSubmissions(json.data?.matchResultSubmissions ?? []);
+        }
+      })
+      .catch(() => setFetchError('Error de red'))
+      .finally(() => setLoading(false));
+  }, [matchId, isParticipant, backendUrl, accessToken]);
+
+  async function handleVote(submissionId: string, vote: VoteValue) {
+    setVoting(submissionId);
+    setVoteError(null);
+
+    const json = await gql<{
+      voteMatchResult: { statusChanged: boolean; submission: MatchResultSubmission };
+    }>(backendUrl, accessToken, VOTE_MATCH_RESULT, { input: { submissionId, vote } });
+
+    setVoting(null);
+
+    if (json.errors?.length) {
+      setVoteError(json.errors[0].message);
+      return;
+    }
+
+    if (json.data?.voteMatchResult) {
+      const updated = json.data.voteMatchResult.submission;
+      setSubmissions((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+
+      if (json.data.voteMatchResult.statusChanged) {
+        setSubmissions((prev) =>
+          prev.map((s) =>
+            s.id !== updated.id && s.status === 'PENDING'
+              ? { ...s, status: 'REJECTED' as const }
+              : s,
+          ),
+        );
+      }
+    }
+  }
+
+  function handleProposed(submission: MatchResultSubmission) {
+    setSubmissions((prev) => [submission, ...prev]);
+    setShowForm(false);
+  }
+
+  // P2 fix: track active (non-rejected) submissions separately
+  const hasPending = submissions.some((s) => s.status === 'PENDING');
+  const hasConfirmed = submissions.some((s) => s.status === 'CONFIRMED');
+  // Show initial CTA when there are no pending or confirmed submissions
+  // (covers: no submissions yet AND all-rejected case)
+  const hasActiveSubmission = hasPending || hasConfirmed;
+
+  if (!isParticipant) return null;
+
+  return (
+    <section className="flex flex-col gap-[0.9rem]">
+      <h2 className="m-0 font-display text-[1.35rem] tracking-[0.08em] text-foreground">
+        Resultado del partido
+      </h2>
+
+      {loading && (
+        <p className="m-0 font-body text-sm text-muted-foreground">Cargando…</p>
+      )}
+      {fetchError && (
+        <p className="m-0 font-body text-sm text-destructive">{fetchError}</p>
+      )}
+      {voteError && (
+        <p className="m-0 font-body text-sm text-destructive">{voteError}</p>
+      )}
+
+      {/* P2 fix: show CTA when no active (pending/confirmed) submissions exist */}
+      {!loading && !hasActiveSubmission && !showForm && (
+        <div className="bg-card border border-white/7 rounded-[10px] p-6 flex flex-col items-center gap-4">
+          <p className="m-0 font-body text-sm text-muted-foreground">
+            Ningún participante cargó el resultado todavía.
+          </p>
+          <button
+            onClick={() => setShowForm(true)}
+            className="bg-primary border-none rounded-lg text-background font-condensed text-[0.9rem] font-bold tracking-[0.08em] py-[0.55rem] px-6 cursor-pointer"
+          >
+            + Cargar resultado
+          </button>
+        </div>
+      )}
+
+      {submissions.map((s) => (
+        <SubmissionCard
+          key={s.id}
+          submission={s}
+          isParticipant={isParticipant}
+          onVote={handleVote}
+          voting={voting}
+        />
+      ))}
+
+      {/* Show "Proponer otro resultado" only when there are pending submissions but no confirmed one */}
+      {!showForm && hasPending && !hasConfirmed && (
+        <button
+          onClick={() => setShowForm(true)}
+          className="bg-transparent border border-white/12 rounded-lg text-muted-foreground font-condensed text-[0.85rem] font-bold tracking-[0.07em] py-[0.45rem] px-[1.1rem] cursor-pointer self-start"
+        >
+          + Proponer otro resultado
+        </button>
+      )}
+
+      {showForm && (
+        <ProposeResultForm
+          matchId={matchId}
+          backendUrl={backendUrl}
+          accessToken={accessToken}
+          onSuccess={handleProposed}
+          onCancel={() => setShowForm(false)}
+        />
+      )}
+    </section>
+  );
+}

--- a/apps/frontend/src/components/matches/ProposeResultForm.tsx
+++ b/apps/frontend/src/components/matches/ProposeResultForm.tsx
@@ -1,0 +1,173 @@
+/**
+ * ProposeResultForm — form to submit a new match result proposal.
+ *
+ * Decision Context:
+ * - winnerTeam is derived automatically from scores so the user cannot submit an
+ *   inconsistent result (e.g., scoreA=3, scoreB=2, winnerTeam=B).
+ * - Client-side validation mirrors the backend Zod schema (0–99 range).
+ * - On success, calls onSuccess(newSubmission) so the parent MatchResultsSection can
+ *   prepend the submission without a full re-fetch.
+ * - Styling: Tailwind utility classes using @theme tokens from globals.css per P3 audit fix.
+ *   font-display → Bebas Neue, font-condensed → Barlow Condensed.
+ * - Previously fixed bugs:
+ *   - P3 audit: inline style objects replaced with Tailwind classes per design-system.md.
+ */
+
+import { useState } from 'react';
+import type { MatchResultSubmission, WinnerTeam } from '../../graphql/operations/match-results.js';
+import { PROPOSE_MATCH_RESULT } from '../../graphql/operations/match-results.js';
+
+interface Props {
+  matchId: string;
+  backendUrl: string;
+  accessToken: string;
+  onSuccess: (submission: MatchResultSubmission) => void;
+  onCancel: () => void;
+}
+
+function deriveWinner(a: number, b: number): WinnerTeam {
+  if (a > b) return 'A';
+  if (b > a) return 'B';
+  return 'DRAW';
+}
+
+export default function ProposeResultForm({
+  matchId,
+  backendUrl,
+  accessToken,
+  onSuccess,
+  onCancel,
+}: Props) {
+  const [scoreA, setScoreA] = useState<string>('');
+  const [scoreB, setScoreB] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const numA = parseInt(scoreA, 10);
+  const numB = parseInt(scoreB, 10);
+  const bothValid =
+    !isNaN(numA) && !isNaN(numB) && numA >= 0 && numA <= 99 && numB >= 0 && numB <= 99;
+  const winnerLabel = bothValid
+    ? deriveWinner(numA, numB) === 'DRAW'
+      ? 'Empate'
+      : `Gana Equipo ${deriveWinner(numA, numB)}`
+    : '—';
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!bothValid) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`${backendUrl}/graphql`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          query: PROPOSE_MATCH_RESULT,
+          variables: {
+            input: {
+              matchId,
+              scoreA: numA,
+              scoreB: numB,
+              winnerTeam: deriveWinner(numA, numB),
+            },
+          },
+        }),
+      });
+
+      const json = (await res.json()) as {
+        data?: { proposeMatchResult: MatchResultSubmission };
+        errors?: { message: string }[];
+      };
+
+      if (json.errors?.length) {
+        setError(json.errors[0].message);
+        return;
+      }
+
+      if (json.data?.proposeMatchResult) {
+        onSuccess(json.data.proposeMatchResult);
+      }
+    } catch {
+      setError('Error de red al enviar el resultado');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-card border border-white/10 rounded-[10px] px-6 py-5 flex flex-col gap-[0.9rem]"
+    >
+      <p className="m-0 font-condensed font-bold text-[0.85rem] tracking-[0.1em] uppercase text-muted-foreground">
+        Marcador final
+      </p>
+
+      <div className="flex items-end gap-3">
+        <div className="flex flex-col gap-[0.3rem] flex-1">
+          <label className="font-body text-[0.8rem] text-muted-foreground">Equipo A</label>
+          <input
+            type="number"
+            min={0}
+            max={99}
+            value={scoreA}
+            onChange={(e) => setScoreA(e.target.value)}
+            placeholder="0"
+            required
+            className="bg-input border border-border rounded-lg text-foreground font-display text-[2rem] text-center px-2 py-[0.4rem] w-full outline-none focus:border-primary"
+          />
+        </div>
+
+        <span className="font-display text-[1.5rem] text-muted-foreground pb-2">—</span>
+
+        <div className="flex flex-col gap-[0.3rem] flex-1">
+          <label className="font-body text-[0.8rem] text-muted-foreground">Equipo B</label>
+          <input
+            type="number"
+            min={0}
+            max={99}
+            value={scoreB}
+            onChange={(e) => setScoreB(e.target.value)}
+            placeholder="0"
+            required
+            className="bg-input border border-border rounded-lg text-foreground font-display text-[2rem] text-center px-2 py-[0.4rem] w-full outline-none focus:border-primary"
+          />
+        </div>
+      </div>
+
+      {bothValid && (
+        <p className="m-0 font-body text-[0.875rem] text-muted-foreground">
+          Resultado: <strong className="text-foreground">{winnerLabel}</strong>
+        </p>
+      )}
+
+      {error && (
+        <p className="m-0 font-body text-[0.875rem] text-destructive">{error}</p>
+      )}
+
+      <div className="flex gap-3 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={loading}
+          className="bg-transparent border border-white/12 rounded-md text-muted-foreground font-condensed text-[0.85rem] font-semibold tracking-[0.08em] px-4 py-[0.45rem] cursor-pointer disabled:opacity-60"
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          disabled={!bothValid || loading}
+          className="bg-primary border-none rounded-md text-background font-condensed text-[0.875rem] font-bold tracking-[0.08em] px-5 py-[0.45rem] cursor-pointer disabled:opacity-60"
+        >
+          {loading ? 'Enviando…' : 'Enviar resultado'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/frontend/src/graphql/operations/match-results.graphql
+++ b/apps/frontend/src/graphql/operations/match-results.graphql
@@ -1,0 +1,48 @@
+# Frontend GraphQL operations for match result voting
+#
+# Decision Context:
+# - Kept separate from matches.graphql to isolate the result-voting feature domain.
+# - All operations require authentication (enforced server-side via requireAuth).
+# - VoteFragment is reused in both the query and mutation responses to avoid duplication.
+
+fragment VoteFields on MatchResultVote {
+  id
+  voter { id displayName avatarUrl }
+  vote
+  createdAt
+}
+
+fragment SubmissionFields on MatchResultSubmission {
+  id
+  matchId
+  submitter { id displayName avatarUrl }
+  scoreA
+  scoreB
+  winnerTeam
+  status
+  approveCount
+  rejectCount
+  hasUserVoted
+  userVote
+  createdAt
+  votes { ...VoteFields }
+}
+
+query GetMatchResultSubmissions($matchId: ID!) {
+  matchResultSubmissions(matchId: $matchId) {
+    ...SubmissionFields
+  }
+}
+
+mutation ProposeMatchResult($input: ProposeMatchResultInput!) {
+  proposeMatchResult(input: $input) {
+    ...SubmissionFields
+  }
+}
+
+mutation VoteMatchResult($input: VoteMatchResultInput!) {
+  voteMatchResult(input: $input) {
+    statusChanged
+    submission { ...SubmissionFields }
+  }
+}

--- a/apps/frontend/src/graphql/operations/match-results.ts
+++ b/apps/frontend/src/graphql/operations/match-results.ts
@@ -1,0 +1,124 @@
+/**
+ * Match result voting — GraphQL operations and TypeScript types.
+ *
+ * Decision Context:
+ * - Mirrors match-results.graphql until frontend codegen is wired.
+ * - Keep in sync with the backend schema (match-result-vote.graphql).
+ * - Previously fixed bugs: none relevant.
+ */
+
+// =====================================================
+// Types
+// =====================================================
+
+export type WinnerTeam = 'A' | 'B' | 'DRAW';
+export type SubmissionStatus = 'PENDING' | 'CONFIRMED' | 'REJECTED';
+export type VoteValue = 'APPROVE' | 'REJECT';
+
+export interface VoterInfo {
+  id: string;
+  displayName: string;
+  avatarUrl: string | null;
+}
+
+export interface MatchResultVote {
+  id: string;
+  voter: VoterInfo;
+  vote: VoteValue;
+  createdAt: string;
+}
+
+export interface MatchResultSubmission {
+  id: string;
+  matchId: string;
+  submitter: VoterInfo;
+  scoreA: number;
+  scoreB: number;
+  winnerTeam: WinnerTeam;
+  status: SubmissionStatus;
+  approveCount: number;
+  rejectCount: number;
+  hasUserVoted: boolean;
+  userVote: VoteValue | null;
+  createdAt: string;
+  votes: MatchResultVote[];
+}
+
+export interface VoteSubmissionResult {
+  statusChanged: boolean;
+  submission: MatchResultSubmission;
+}
+
+export interface ProposeMatchResultInput {
+  matchId: string;
+  scoreA: number;
+  scoreB: number;
+  winnerTeam?: WinnerTeam;
+}
+
+export interface VoteMatchResultInput {
+  submissionId: string;
+  vote: VoteValue;
+}
+
+// =====================================================
+// GraphQL Operation Strings
+// =====================================================
+
+const VOTE_FIELDS = /* GraphQL */ `
+  fragment VoteFields on MatchResultVote {
+    id
+    voter { id displayName avatarUrl }
+    vote
+    createdAt
+  }
+`;
+
+const SUBMISSION_FIELDS = /* GraphQL */ `
+  fragment SubmissionFields on MatchResultSubmission {
+    id
+    matchId
+    submitter { id displayName avatarUrl }
+    scoreA
+    scoreB
+    winnerTeam
+    status
+    approveCount
+    rejectCount
+    hasUserVoted
+    userVote
+    createdAt
+    votes { ...VoteFields }
+  }
+`;
+
+export const GET_MATCH_RESULT_SUBMISSIONS = /* GraphQL */ `
+  ${VOTE_FIELDS}
+  ${SUBMISSION_FIELDS}
+  query GetMatchResultSubmissions($matchId: ID!) {
+    matchResultSubmissions(matchId: $matchId) {
+      ...SubmissionFields
+    }
+  }
+`;
+
+export const PROPOSE_MATCH_RESULT = /* GraphQL */ `
+  ${VOTE_FIELDS}
+  ${SUBMISSION_FIELDS}
+  mutation ProposeMatchResult($input: ProposeMatchResultInput!) {
+    proposeMatchResult(input: $input) {
+      ...SubmissionFields
+    }
+  }
+`;
+
+export const VOTE_MATCH_RESULT = /* GraphQL */ `
+  ${VOTE_FIELDS}
+  ${SUBMISSION_FIELDS}
+  mutation VoteMatchResult($input: VoteMatchResultInput!) {
+    voteMatchResult(input: $input) {
+      statusChanged
+      submission { ...SubmissionFields }
+    }
+  }
+`;

--- a/apps/frontend/src/pages/partidos/[id].astro
+++ b/apps/frontend/src/pages/partidos/[id].astro
@@ -40,6 +40,7 @@ import LeaveMatchButton from '../../components/matches/LeaveMatchButton.tsx';
 import MatchInfoCard from '../../components/matches/MatchInfoCard.astro';
 import ClubLocationCard from '../../components/matches/ClubLocationCard.astro';
 import PlayerCard from '../../components/matches/PlayerCard.astro';
+import MatchResultsSection from '../../components/matches/MatchResultsSection.tsx';
 import { GET_MATCH_DETAIL } from '../../graphql/operations/matches';
 import type { MatchDetailData } from '../../graphql/operations/matches';
 import { readAccessToken } from '../../lib/auth';
@@ -99,6 +100,17 @@ const matchCancelled = match?.status === 'CANCELLED';
 const matchInProgress = match?.status === 'IN_PROGRESS';
 const matchCompleted = match?.status === 'COMPLETED';
 const currentUserTeam = match?.currentUserTeam ?? null;
+
+// Show result section when the match has already taken place:
+// - status is COMPLETED or IN_PROGRESS, OR
+// - match start time is in the past (slot already happened)
+// Only visible to participants of non-cancelled matches.
+// Previously fixed bugs: P1 audit — cancelled matches with past startTime were showing
+// the section; the !matchCancelled guard prevents proposals/votes on cancelled matches.
+const matchStarted = match
+  ? matchCompleted || matchInProgress || new Date(match.startTime) < new Date()
+  : false;
+const showResultSection = matchStarted && isJoined && isPlayer && !matchCancelled;
 
 const allParticipants = [...teamA, ...teamB];
 const organizerParticipant = match?.organizerId
@@ -245,7 +257,18 @@ const organizerPosition = organizerParticipant?.preferredPosition ?? null;
             </div>
           )}
 
-          <!-- Section 4: Teams -->
+          <!-- Section 4: Result voting — only after match has started, only for participants -->
+          {showResultSection && (
+            <MatchResultsSection
+              client:visible
+              matchId={match.id}
+              isParticipant={isJoined}
+              backendUrl={backendUrl}
+              accessToken={accessToken}
+            />
+          )}
+
+          <!-- Section 5: Teams -->
           {participants ? (
             <div class="teams-grid">
 

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -60,6 +60,15 @@
   --color-surface-glass: rgba(255, 255, 255, 0.05);
   --color-surface-glass-hover: rgba(255, 255, 255, 0.08);
   --color-surface-border: rgba(255, 255, 255, 0.1);
+
+  /* --- Success / voting semantic colors --- */
+  --color-success: hsl(142 72% 50%);
+  --color-success-foreground: hsl(142 72% 65%);
+  --color-success-surface: hsl(142 30% 8%);
+
+  /* --- Typography utilities --- */
+  --font-display: 'Bebas Neue', sans-serif;
+  --font-condensed: 'Barlow Condensed', system-ui, sans-serif;
 }
 
 /* =====================================================

--- a/docs/TESTING-votar-resultado.md
+++ b/docs/TESTING-votar-resultado.md
@@ -1,0 +1,285 @@
+# Testing Manual — User Story: Votar Resultado
+
+## Contexto
+
+Rama: `votar-resultado`  
+Página de prueba: `/partidos/[id]` (un partido donde el usuario autenticado es participante y cuyo `scheduledAt` ya pasó)
+
+Levantar backend (`pnpm dev` desde la raíz) y frontend antes de ejecutar estos tests.
+
+---
+
+## Prerequisitos
+
+- Al menos 3 usuarios de prueba (jugadores) inscritos en el mismo partido
+- El partido debe tener `scheduledAt` en el pasado (o status `completed`/`in_progress`)
+- El partido debe tener status que no sea `cancelled`
+
+---
+
+## Casos de prueba
+
+### TC-01: Participante propone primer resultado
+
+**Actor:** Usuario A (participante del partido)
+
+**Pasos:**
+1. Ir a `/partidos/[id]` con el partido en el pasado
+2. Verificar que aparece la sección "Resultado del partido"
+3. Verificar que aparece el botón "+ Cargar resultado"
+4. Hacer clic en "+ Cargar resultado"
+5. Ingresar scoreA=3, scoreB=2
+6. Verificar que el label "Gana Equipo A" aparece automáticamente
+7. Hacer clic en "Enviar resultado"
+
+**Resultado esperado:**
+- Nueva submission aparece con estado `PENDIENTE` (badge naranja)
+- Conteos muestran "0 aprobaciones / 0 rechazos"
+- Botones "Aprobar" y "Rechazar" visibles para usuarios que no votaron
+
+---
+
+### TC-02: No participante no ve la sección de resultados
+
+**Actor:** Usuario X (no participante del partido)
+
+**Pasos:**
+1. Ir a `/partidos/[id]` con un usuario que NO está en `matchParticipants`
+
+**Resultado esperado:**
+- La sección "Resultado del partido" NO aparece en la página
+
+---
+
+### TC-03: No participante intenta proponer via GraphQL directamente
+
+**Pasos:**
+1. Ejecutar `proposeMatchResult` mutation con el token de un usuario que NO es participante
+
+**Resultado esperado:**
+- Error GraphQL: "Solo los participantes del partido pueden proponer resultados"
+
+---
+
+### TC-04: Participante vota approve
+
+**Actor:** Usuario B (participante, no propuso)
+
+**Pasos:**
+1. Ir a `/partidos/[id]`
+2. Ver la submission pendiente de TC-01
+3. Hacer clic en "✓ Aprobar"
+
+**Resultado esperado:**
+- Conteo actualiza a "1 aprobaciones / 0 rechazos"
+- Botones desaparecen y aparece "Tu voto: Aprobado ✓"
+- Opción "Cambiar voto" visible
+
+---
+
+### TC-05: Participante vota reject
+
+**Actor:** Usuario C (participante, no propuso)
+
+**Pasos:**
+1. Ir a `/partidos/[id]`
+2. Ver la submission pendiente
+3. Hacer clic en "✗ Rechazar"
+
+**Resultado esperado:**
+- Conteo actualiza a "1 aprobaciones / 1 rechazos"
+- Submission permanece en estado PENDIENTE
+
+---
+
+### TC-06: Mayoría aprueba — submission confirmada
+
+**Setup:** Partido con 4 participantes, submission pendiente con 1 aprobación
+
+**Actor:** Usuario D (participante, no votó)
+
+**Pasos:**
+1. El Usuario D vota "Aprobar" (llevando approveCount a 2 de 4)
+
+**Resultado esperado:**
+- Submission pasa a estado `CONFIRMADO` (badge verde "✓ Resultado oficial")
+- Botones de voto desaparecen
+- Si había otras submissions pendientes → aparecen como `RECHAZADO`
+- El partido muestra status actualizado en MatchInfoCard si era open/full
+
+---
+
+### TC-07: Proponer resultado alternativo (coexistencia de submissions)
+
+**Actor:** Usuario B (participante, no propuso el original)
+
+**Pasos:**
+1. Con una submission en estado PENDIENTE, hacer clic en "+ Proponer otro resultado"
+2. Ingresar scoreA=1, scoreB=1 (Empate)
+3. Enviar
+
+**Resultado esperado:**
+- Aparecen dos submissions PENDIENTE en la lista
+- Ambas muestran sus propios botones de voto
+- El resultado automático muestra "Empate"
+
+---
+
+### TC-08: Cambio de voto (UPSERT)
+
+**Actor:** Usuario que votó "Rechazar" en TC-05
+
+**Pasos:**
+1. Ver la submission con "Tu voto: Rechazado ✗"
+2. Hacer clic en "Cambiar voto"
+
+**Resultado esperado:**
+- El voto cambia a "Aprobado ✓"
+- Conteos se recalculan inmediatamente
+- Si el cambio genera mayoría → submission se confirma
+
+---
+
+### TC-09: Cuando submission B se confirma, submission A queda rechazada
+
+**Setup:** Dos submissions pendientes A y B, B llega a mayoría primero
+
+**Resultado esperado:**
+- Submission B → badge "✓ Resultado oficial"
+- Submission A → badge "Rechazado" (gris)
+- `matches.scoreTeamA`, `matches.scoreTeamB`, `matches.winningTeam` actualizados en DB
+
+---
+
+### TC-10: Match status pasa a "completed" al confirmar resultado
+
+**Pasos:**
+1. Confirmar una submission (TC-06)
+2. Recargar la página `/partidos/[id]`
+
+**Resultado esperado:**
+- Banner "✅ Este partido ya finalizó" visible
+- Status del partido = COMPLETED
+
+---
+
+### TC-11: Historial muestra el resultado correcto post-confirmación
+
+**Pasos:**
+1. Ir a `/historial` (myMatches) con el usuario participante
+2. Verificar la entrada del partido donde se confirmó el resultado
+
+**Resultado esperado:**
+- `scoreA` y `scoreB` muestran los valores confirmados (ej: "3 — 2")
+- `userResult` muestra WON/LOST/DRAW según el equipo del usuario
+
+---
+
+### TC-12: RLS — usuario no participante no ve submissions via API
+
+**Pasos:**
+1. Llamar `matchResultSubmissions(matchId)` con token de usuario que NO participó
+
+**Resultado esperado:**
+- Error GraphQL: "Solo los participantes del partido pueden ver los resultados propuestos"
+
+---
+
+### TC-13: Validación de scores inválidos
+
+**Pasos:**
+1. Intentar proponer scoreA=-1 o scoreA=100
+
+**Resultado esperado (cliente):**
+- El input tiene `min=0, max=99` — el browser bloquea el envío
+- Backend también rechaza con Zod: "El marcador no puede ser negativo" / "Marcador demasiado alto"
+
+---
+
+### TC-14: Partido aún no empezado — sin sección de resultados
+
+**Pasos:**
+1. Ir a un partido con `scheduledAt` en el futuro y status `open`
+
+**Resultado esperado:**
+- La sección "Resultado del partido" NO aparece, aunque el usuario sea participante
+
+---
+
+### TC-15: Cache Redis invalidada al confirmar resultado (si Redis está activo)
+
+**Pasos:**
+1. Hacer GET `match:participants:{matchId}` en Redis antes del voto confirmatorio
+2. Confirmar resultado
+3. Verificar que la key fue eliminada
+
+**Resultado esperado:**
+- La key `match:participants:{matchId}` ya no existe en Redis
+- El historial del usuario (`user:matches:{userId}*`) también fue invalidado
+- La próxima carga de la página de detalle trae datos frescos de la DB
+
+---
+
+### TC-16: Match cancelled — no permite proposals ni votos
+
+**Pre-condición:** Match con `status = 'cancelled'` cuyo `scheduledAt` ya pasó, con al menos un usuario participante.
+
+**Pasos:**
+1. Autenticarse como un participante del match cancelado
+2. Ir a `/partidos/[id]` — verificar que la sección "Resultado del partido" **NO** se renderiza
+   (el guard `!matchCancelled` en `[id].astro` lo impide en la UI)
+3. Intentar directamente via API GraphQL:
+   ```graphql
+   mutation {
+     proposeMatchResult(input: { matchId: "<id>", scoreA: 1, scoreB: 0 }) { id }
+   }
+   ```
+4. Intentar votar sobre una submission existente (si existe alguna del partido):
+   ```graphql
+   mutation {
+     voteMatchResult(input: { submissionId: "<id>", vote: APPROVE }) { statusChanged }
+   }
+   ```
+
+**Resultado esperado:**
+- Paso 2: la sección de votación NO aparece en el frontend (guard en `[id].astro`)
+- Paso 3: error GraphQL `"El partido fue cancelado, no se pueden proponer ni votar resultados"`
+- Paso 4: mismo error que paso 3
+
+---
+
+### TC-17: Race condition — dos votos simultáneos al último faltante para mayoría
+
+**Pre-condición:** Match con 4 participantes (A, B, C, D). Submission S1 con 1 approve (de A). Mayoría requiere > 2 votos (es decir, 3 de 4). Setup: A ya aprobó, B y C envían approve simultáneamente.
+
+**Setup reproducible:**
+- Partido con 4 participantes inscritos
+- Una submission pending con 1 approve ya registrado
+- Tener listos dos tokens válidos para usuarios B y C
+
+**Pasos:**
+1. Enviar dos requests `voteMatchResult(APPROVE)` en paralelo:
+   - Request 1: token de usuario B, submissionId = S1
+   - Request 2: token de usuario C, submissionId = S1
+2. Esperar a que ambos completen
+3. Verificar la submission S1 en la DB (GET matchResultSubmissions)
+4. Verificar el match en la DB
+
+**Resultado esperado:**
+- Ambas requests completan sin error (HTTP 200, sin `errors[]` en respuesta GraphQL)
+- S1 tiene `status = CONFIRMED`
+- `matches.status = 'completed'`
+- El count de approves en S1 es exactamente 3 (no 4 ni más)
+- Al menos una respuesta tiene `statusChanged: true`; la otra puede tener `statusChanged: true` también (race condition documentada — `confirmSubmission` es idempotente, el segundo `true` es un falso positivo benigno)
+- No hay submissions duplicadas ni votos duplicados (UNIQUE constraint previene doble-insert del mismo votador)
+
+**Nota:** Para simular requests simultáneas usar `Promise.all` en un script de test o `curl &` en paralelo.
+
+---
+
+## Notas de implementación
+
+- `winningTeam` en DB: `'a'` | `'b'` | `'draw'` (lowercase)
+- `winningTeam` en GraphQL: `'A'` | `'B'` | `'DRAW'` (uppercase)
+- Confirmación usa service-role (bypass RLS) porque la política UPDATE en matches solo permite al organizador
+- El UPSERT de votos usa `onConflict: 'submissionId,voterId'` — la restricción UNIQUE ya existe en la DB

--- a/docs/prompts/k7q2x9p4-prompt-log.md
+++ b/docs/prompts/k7q2x9p4-prompt-log.md
@@ -1,0 +1,19 @@
+# Prompt Log
+
+- Timestamp: 2026-04-26 19:18:00
+- Task ID: k7q2x9p4
+
+## User Prompt
+
+> Sos un desarrollador senior fullstack especializado en Astro 6, GraphQL y Supabase. Necesito que implementes la siguiente User Story completa en el proyecto sumate-ya.
+>
+> ## User Story
+> Como jugador que participó en un partido, quiero votar si el resultado cargado es correcto o proponer uno alternativo.
+>
+> [Stack, contexto, tareas 1–13 descritas en el prompt original — sin secretos]
+
+## Agent Main Actions
+
+- Investigó el schema de Supabase con MCP y detectó que `matchResultSubmissions` y `matchResultVotes` ya existían pero les faltaban: el enum `winnerTeamValue` (con soporte para empate), la columna `submissionStatus` (pending/confirmed/rejected) y todas las RLS policies. Aplicó una migración MCP para agregar todo eso.
+- Implementó el stack completo de backend: schema GraphQL (`match-result-vote.graphql`), repository (`matchResultVoteRepository.ts`), service (`matchResultVoteService.ts`) con lógica de mayoría simple y cache Redis, resolver (`match-result.ts`) y actualizó `matchRepository`/`matchService` para que el historial de partidos muestre scores reales.
+- Implementó el frontend: operaciones GraphQL (`match-results.graphql` + `match-results.ts`), componentes React `MatchResultsSection` e `ProposeResultForm` con la paleta FIFA dark, e integró la sección en `/partidos/[id].astro` visible solo para participantes tras el inicio del partido. Typecheck pasó con 0 errores.

--- a/docs/prompts/n8r3w5j1-prompt-log.md
+++ b/docs/prompts/n8r3w5j1-prompt-log.md
@@ -1,0 +1,20 @@
+# Prompt Log
+
+- Timestamp: 2026-04-26 19:40:00
+- Task ID: n8r3w5j1
+
+## User Prompt
+
+> Estoy en la rama votar-resultado. Necesito resolver los 2 bugs críticos detectados en la auditoría reciente para poder cerrar la User Story "Votar Resultado". También quiero resolver los problemas menores P3, P4 y P5.
+>
+> P1 — CRÍTICO — Sin validación de match status en proposeMatchResult y voteMatchResult
+> P2 — CRÍTICO — Botón "Cargar resultado" desaparece si todas las submissions están REJECTED
+> P3 — MENOR — Inline styles violan design-system.md
+> P4 — MENOR — Falta test case para match cancelled
+> P5 — MENOR — Falta test case para race condition
+
+## Agent Main Actions
+
+- Corrigió P1 en backend (matchResultVoteRepository.ts + matchResultVoteService.ts): agregó `getMatchStatus()` al repository y guards de `status !== 'cancelled'` en `proposeMatchResult` y `voteMatchResult` con mensaje "El partido fue cancelado, no se pueden proponer ni votar resultados". En frontend ([id].astro) agregó `&& !matchCancelled` a la condición `showResultSection`.
+- Corrigió P2 (MatchResultsSection.tsx): reemplazó la condición `submissions.length === 0` por `!hasActiveSubmission` (que es `!(hasPending || hasConfirmed)`), cubriendo el caso donde todas las submissions están REJECTED; también ajustó el CTA "Proponer otro resultado" para que no aparezca cuando ya hay un resultado confirmado.
+- Corrigió P3 (MatchResultsSection.tsx + ProposeResultForm.tsx): eliminó todos los inline style objects (`S.xxx`), agregó tokens de diseño (`--color-success`, `--font-display`, `--font-condensed`) a globals.css, y reemplazó todos los estilos con clases Tailwind que usan los tokens del @theme. Agregó TC-16 (match cancelado) y TC-17 (race condition) a docs/TESTING-votar-resultado.md. Typecheck pasó con 0 errores.


### PR DESCRIPTION
- Add MatchResultsSection component for displaying result submissions and voting UI.
- Create ProposeResultForm component for submitting new match result proposals.
- Implement GraphQL operations for fetching submissions, proposing results, and voting.
- Introduce TypeScript types for match result submissions and votes.
- Add manual testing documentation for the voting user story.
- Fix critical bugs related to match status validation and submission visibility.
- Replace inline styles with Tailwind CSS classes for better design consistency.