### PR TITLE
cumplir epica de filtros de partidos" 

### DIFF
--- a/apps/frontend/src/components/matches/MatchFilters.tsx
+++ b/apps/frontend/src/components/matches/MatchFilters.tsx
@@ -1,182 +1,162 @@
 /**
- * MatchFilters Component - Filter controls for match listing
+ * MatchFilters Component - Filter controls for match listing.
  *
  * Decision Context:
- * - Why: Provides UI controls for filtering matches by format, zone, date, and text search.
- * - Pattern: Controlled component that emits filter changes to parent via callback.
- *   Parent (MatchList) manages state and triggers GraphQL refetch.
- * - Uses shadcn/ui primitives (Button, Input) for consistent styling.
- * - Format/zone options are derived from schema enums and common zones.
- * - Previously fixed bugs: none relevant.
+ * - Filters are controlled by the parent so list and map views can share the same state.
+ * - The list applies filters locally over the loaded open matches for instant feedback.
+ * - URL persistence is handled by MatchesView, keeping this component UI-only.
  */
 
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { Button } from '@/components/ui/button';
+import { DatePicker } from '@/components/ui/date-picker';
 import { Input } from '@/components/ui/input';
-import { Search, X, Filter } from 'lucide-react';
-import type { MatchFilters, MatchFormat, MatchStatus } from '@/graphql/operations/matches';
+import { Select } from '@/components/ui/select';
+import { Search, X } from 'lucide-react';
+import {
+  DEFAULT_MATCH_FILTERS,
+  normalizeMatchFilters,
+  toDateInputValue,
+  type ClientMatchFilters,
+} from '@/lib/match-filtering';
+import type { MatchFormat } from '@/graphql/operations/matches';
 
 interface MatchFiltersProps {
-  onFiltersChange: (filters: MatchFilters) => void;
-  initialFilters?: MatchFilters;
+  filters: ClientMatchFilters;
+  onFiltersChange: (filters: ClientMatchFilters) => void;
 }
 
-// Format options matching GraphQL enum
 const FORMAT_OPTIONS: { value: MatchFormat; label: string }[] = [
-  { value: 'FIVE_VS_FIVE', label: 'Fútbol 5' },
-  { value: 'SEVEN_VS_SEVEN', label: 'Fútbol 7' },
-  { value: 'TEN_VS_TEN', label: 'Fútbol 10' },
-  { value: 'ELEVEN_VS_ELEVEN', label: 'Fútbol 11' },
+  { value: 'FIVE_VS_FIVE', label: 'Futbol 5' },
+  { value: 'SEVEN_VS_SEVEN', label: 'Futbol 7' },
+  { value: 'TEN_VS_TEN', label: 'Futbol 10' },
+  { value: 'ELEVEN_VS_ELEVEN', label: 'Futbol 11' },
 ];
 
-// Status options matching GraphQL enum
-const STATUS_OPTIONS: { value: MatchStatus; label: string }[] = [
-  { value: 'OPEN', label: 'Abiertos' },
-  { value: 'FULL', label: 'Completos' },
-  { value: 'IN_PROGRESS', label: 'En curso' },
-  { value: 'COMPLETED', label: 'Finalizados' },
+const ZONE_OPTIONS = ['Norte', 'Sur', 'Este', 'Oeste', 'Centro'].map((zone) => ({
+  value: zone,
+  label: zone,
+}));
+
+const TIME_RANGE_OPTIONS = [
+  { value: '06:00|12:00', label: 'Manana' },
+  { value: '12:00|18:00', label: 'Tarde' },
+  { value: '18:00|23:59', label: 'Noche' },
+  { value: '20:00|02:00', label: 'Nocturno' },
 ];
 
-// Common zones (could be fetched from API in future)
-const ZONE_OPTIONS = ['Norte', 'Sur', 'Este', 'Oeste', 'Centro'];
+function toDateFilter(value: string, endOfDay = false): string | undefined {
+  if (!value) return undefined;
+  return `${value}T${endOfDay ? '23:59:59' : '00:00:00'}`;
+}
 
-export function MatchFilters({ onFiltersChange, initialFilters }: MatchFiltersProps) {
-  const [filters, setFilters] = useState<MatchFilters>(initialFilters || { status: 'OPEN' });
-  const [showAdvanced, setShowAdvanced] = useState(false);
+function toTimeRangeValue(filters: ClientMatchFilters): string {
+  return filters.timeFrom && filters.timeTo ? `${filters.timeFrom}|${filters.timeTo}` : '';
+}
 
+export function MatchFilters({ filters, onFiltersChange }: MatchFiltersProps) {
   const updateFilters = useCallback(
-    (updates: Partial<MatchFilters>) => {
-      const newFilters = { ...filters, ...updates };
-      // Remove undefined/empty values
-      Object.keys(newFilters).forEach((key) => {
-        const k = key as keyof MatchFilters;
-        if (newFilters[k] === undefined || newFilters[k] === '') {
-          delete newFilters[k];
-        }
-      });
-      setFilters(newFilters);
-      onFiltersChange(newFilters);
+    (updates: Partial<ClientMatchFilters>) => {
+      onFiltersChange(normalizeMatchFilters({ ...filters, ...updates }));
     },
-    [filters, onFiltersChange]
+    [filters, onFiltersChange],
   );
 
   const clearFilters = useCallback(() => {
-    const defaultFilters: MatchFilters = { status: 'OPEN' };
-    setFilters(defaultFilters);
-    onFiltersChange(defaultFilters);
+    onFiltersChange(DEFAULT_MATCH_FILTERS);
   }, [onFiltersChange]);
 
+  const handleTimeRangeChange = useCallback(
+    (value: string) => {
+      if (!value) {
+        updateFilters({ timeFrom: undefined, timeTo: undefined });
+        return;
+      }
+
+      const [timeFrom, timeTo] = value.split('|');
+      updateFilters({ timeFrom, timeTo });
+    },
+    [updateFilters],
+  );
+
   const hasActiveFilters =
-    filters.format || filters.zone || filters.search || filters.dateFrom || filters.dateTo;
+    filters.format ||
+    filters.zone ||
+    filters.search ||
+    filters.dateFrom ||
+    filters.dateTo ||
+    filters.timeFrom ||
+    filters.timeTo;
 
   return (
-    <div className="space-y-4 mb-6">
-      {/* Main filter row */}
-      <div className="flex flex-wrap gap-3 items-center">
-        {/* Search input */}
-        <div className="relative flex-1 min-w-[200px] max-w-md">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+    <div className="mb-6 rounded-lg border border-border bg-card/70 p-4 shadow-sm">
+      <div className="grid gap-3 md:grid-cols-[minmax(220px,1.4fr)_repeat(3,minmax(140px,1fr))]">
+        <div className="relative min-w-0">
+          <Search
+            aria-hidden="true"
+            className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          />
           <Input
             type="text"
-            placeholder="Buscar por partido o club..."
+            aria-label="Buscar partidos"
+            placeholder="Buscar partido o club"
             value={filters.search || ''}
-            onChange={(e) => updateFilters({ search: e.target.value || undefined })}
+            onChange={(event) => updateFilters({ search: event.target.value || undefined })}
             className="pl-10"
           />
         </div>
 
-        {/* Format filter */}
-        <select
+        <Select
+          aria-label="Formato"
           value={filters.format || ''}
-          onChange={(e) => updateFilters({ format: (e.target.value as MatchFormat) || undefined })}
-          className="h-10 px-3 rounded-md border border-input bg-background text-sm"
-        >
-          <option value="">Todos los formatos</option>
-          {FORMAT_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
+          placeholder="Formato"
+          options={FORMAT_OPTIONS}
+          onValueChange={(value) =>
+            updateFilters({ format: (value as MatchFormat) || undefined })
+          }
+        />
 
-        {/* Zone filter */}
-        <select
+        <Select
+          aria-label="Zona"
           value={filters.zone || ''}
-          onChange={(e) => updateFilters({ zone: e.target.value || undefined })}
-          className="h-10 px-3 rounded-md border border-input bg-background text-sm"
-        >
-          <option value="">Todas las zonas</option>
-          {ZONE_OPTIONS.map((zone) => (
-            <option key={zone} value={zone}>
-              {zone}
-            </option>
-          ))}
-        </select>
+          placeholder="Zona"
+          options={ZONE_OPTIONS}
+          onValueChange={(value) => updateFilters({ zone: value || undefined })}
+        />
 
-        {/* Status filter */}
-        <select
-          value={filters.status || 'OPEN'}
-          onChange={(e) => updateFilters({ status: (e.target.value as MatchStatus) || undefined })}
-          className="h-10 px-3 rounded-md border border-input bg-background text-sm"
-        >
-          {STATUS_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-
-        {/* Advanced toggle */}
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setShowAdvanced(!showAdvanced)}
-          className="gap-2"
-        >
-          <Filter className="h-4 w-4" />
-          {showAdvanced ? 'Menos filtros' : 'Más filtros'}
-        </Button>
-
-        {/* Clear filters */}
-        {hasActiveFilters && (
-          <Button variant="ghost" size="sm" onClick={clearFilters} className="gap-2">
-            <X className="h-4 w-4" />
-            Limpiar
-          </Button>
-        )}
+        <Select
+          aria-label="Horario"
+          value={toTimeRangeValue(filters)}
+          placeholder="Horario"
+          options={TIME_RANGE_OPTIONS}
+          onValueChange={handleTimeRangeChange}
+        />
       </div>
 
-      {/* Advanced filters (date range) */}
-      {showAdvanced && (
-        <div className="flex flex-wrap gap-3 items-center p-4 bg-muted/50 rounded-lg">
-          <div className="flex items-center gap-2">
-            <label className="text-sm text-muted-foreground whitespace-nowrap">Desde:</label>
-            <Input
-              type="date"
-              value={filters.dateFrom?.split('T')[0] || ''}
-              onChange={(e) =>
-                updateFilters({
-                  dateFrom: e.target.value ? `${e.target.value}T00:00:00Z` : undefined,
-                })
-              }
-              className="w-auto"
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <label className="text-sm text-muted-foreground whitespace-nowrap">Hasta:</label>
-            <Input
-              type="date"
-              value={filters.dateTo?.split('T')[0] || ''}
-              onChange={(e) =>
-                updateFilters({
-                  dateTo: e.target.value ? `${e.target.value}T23:59:59Z` : undefined,
-                })
-              }
-              className="w-auto"
-            />
-          </div>
-        </div>
-      )}
+      <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(150px,1fr)_minmax(150px,1fr)_auto]">
+        <DatePicker
+          aria-label="Fecha desde"
+          value={toDateInputValue(filters.dateFrom)}
+          onValueChange={(value) => updateFilters({ dateFrom: toDateFilter(value) })}
+        />
+
+        <DatePicker
+          aria-label="Fecha hasta"
+          value={toDateInputValue(filters.dateTo)}
+          onValueChange={(value) => updateFilters({ dateTo: toDateFilter(value, true) })}
+        />
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={clearFilters}
+          disabled={!hasActiveFilters}
+          className="gap-2"
+        >
+          <X className="h-4 w-4" />
+          Limpiar
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/components/matches/MatchFilters.tsx
+++ b/apps/frontend/src/components/matches/MatchFilters.tsx
@@ -16,6 +16,7 @@ import { Search, X } from 'lucide-react';
 import {
   DEFAULT_MATCH_FILTERS,
   normalizeMatchFilters,
+  toDateFilter,
   toDateInputValue,
   type ClientMatchFilters,
 } from '@/lib/match-filtering';
@@ -44,11 +45,6 @@ const TIME_RANGE_OPTIONS = [
   { value: '18:00|23:59', label: 'Noche' },
   { value: '20:00|02:00', label: 'Nocturno' },
 ];
-
-function toDateFilter(value: string, endOfDay = false): string | undefined {
-  if (!value) return undefined;
-  return `${value}T${endOfDay ? '23:59:59' : '00:00:00'}`;
-}
 
 function toTimeRangeValue(filters: ClientMatchFilters): string {
   return filters.timeFrom && filters.timeTo ? `${filters.timeFrom}|${filters.timeTo}` : '';

--- a/apps/frontend/src/components/matches/MatchList.tsx
+++ b/apps/frontend/src/components/matches/MatchList.tsx
@@ -5,6 +5,9 @@
  * - Loads the open match dataset once, then filters locally for immediate UX.
  * - Backend GraphQL filters remain available for larger datasets and map/list parity.
  * - Can render its own filters, or receive controlled filters from MatchesView.
+ * - Empty state distinguishes "no open matches at all" (matches.length === 0) from
+ *   "matches exist but all are hidden by filters" (visibleMatches.length === 0) so
+ *   players know whether to wait or to adjust their search.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -111,7 +114,9 @@ export function MatchList({
         <div className="text-center py-12">
           <p className="text-xl font-medium">No hay partidos disponibles</p>
           <p className="text-muted-foreground mt-2">
-            Proba con otros filtros o vuelve mas tarde
+            {matches.length > 0
+              ? 'Ningún partido coincide con los filtros. Probá ajustando la búsqueda.'
+              : 'No hay partidos abiertos por el momento. Volvé más tarde.'}
           </p>
         </div>
       )}

--- a/apps/frontend/src/components/matches/MatchList.tsx
+++ b/apps/frontend/src/components/matches/MatchList.tsx
@@ -1,46 +1,60 @@
 /**
- * MatchList Component - Displays grid of match cards with filtering
+ * MatchList Component - Displays a grid of match cards with instant filtering.
  *
  * Decision Context:
- * - Why: Encapsulates data fetching with urql and renders the MatchCard grid.
- * - Pattern: Client-side fetch on mount and filter change; hydrated via `client:visible`
- *   in Astro so the request only fires when the user scrolls the section into view.
- *   SSR-populated `initialMatches` can skip the fetch entirely.
- * - Filter integration: Uses MatchFilters component for user input, passes filters to
- *   GraphQL query via GET_MATCHES operation.
- * - GraphQL operations live in `src/graphql/operations/matches.ts` (frontend.md rule:
- *   no inline GraphQL strings inside UI components). If you need to edit the query,
- *   update BOTH `operations/matches.graphql` (codegen source of truth) and `operations/matches.ts`.
- * - Error + empty + loading states are handled inline because they are layout-specific
- *   skeletons; extract to a shared component if another list reuses them.
- * - Previously fixed bugs: inline `GET_OPEN_MATCHES` string was defined in this file,
- *   which broke the frontend GraphQL rule and duplicated the `.graphql` operation.
+ * - Loads the open match dataset once, then filters locally for immediate UX.
+ * - Backend GraphQL filters remain available for larger datasets and map/list parity.
+ * - Can render its own filters, or receive controlled filters from MatchesView.
  */
 
-import { useEffect, useState, useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { MatchCard, type Match } from './MatchCard';
 import { MatchFilters as MatchFiltersComponent } from './MatchFilters';
 import { executeQuery } from '@/lib/urql-client';
-import { GET_MATCHES, type MatchFilters } from '@/graphql/operations/matches';
+import { GET_MATCHES } from '@/graphql/operations/matches';
+import {
+  DEFAULT_MATCH_FILTERS,
+  filterMatches,
+  normalizeMatchFilters,
+  toServerMatchFilters,
+  type ClientMatchFilters,
+} from '@/lib/match-filtering';
 
 interface MatchListProps {
   /** Initial matches for SSR/SSG hydration (optional) */
   initialMatches?: Match[];
-  /** Whether the current user is authenticated — gates the join action */
+  /** Whether the current user is authenticated; gates the join action */
   isAuthenticated?: boolean;
+  /** Controlled filters shared with other views, e.g. map */
+  filters?: ClientMatchFilters;
+  /** Called when this list owns and renders the filter controls */
+  onFiltersChange?: (filters: ClientMatchFilters) => void;
+  /** Allows MatchesView to render a single filter bar for list + map */
+  showFilters?: boolean;
 }
 
-export function MatchList({ initialMatches, isAuthenticated = false }: MatchListProps) {
+export function MatchList({
+  initialMatches,
+  isAuthenticated = false,
+  filters: controlledFilters,
+  onFiltersChange,
+  showFilters = true,
+}: MatchListProps) {
   const [matches, setMatches] = useState<Match[]>(initialMatches || []);
   const [loading, setLoading] = useState(!initialMatches);
   const [error, setError] = useState<string | null>(null);
-  const [filters, setFilters] = useState<MatchFilters>({ status: 'OPEN' });
+  const [internalFilters, setInternalFilters] =
+    useState<ClientMatchFilters>(DEFAULT_MATCH_FILTERS);
 
-  const fetchMatches = useCallback(async (currentFilters: MatchFilters) => {
+  const filters = controlledFilters ?? internalFilters;
+
+  const fetchMatches = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const data = await executeQuery<{ matches: Match[] }>(GET_MATCHES, { filters: currentFilters });
+      const data = await executeQuery<{ matches: Match[] }>(GET_MATCHES, {
+        filters: toServerMatchFilters(DEFAULT_MATCH_FILTERS),
+      });
       setMatches(data.matches);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error al cargar partidos');
@@ -51,24 +65,29 @@ export function MatchList({ initialMatches, isAuthenticated = false }: MatchList
 
   useEffect(() => {
     if (initialMatches) return;
-    fetchMatches(filters);
-  }, [initialMatches, fetchMatches, filters]);
+    fetchMatches();
+  }, [initialMatches, fetchMatches]);
 
-  const handleFiltersChange = useCallback((newFilters: MatchFilters) => {
-    setFilters(newFilters);
-    fetchMatches(newFilters);
-  }, [fetchMatches]);
+  const handleFiltersChange = useCallback(
+    (newFilters: ClientMatchFilters) => {
+      const normalized = normalizeMatchFilters(newFilters);
+      setInternalFilters(normalized);
+      onFiltersChange?.(normalized);
+    },
+    [onFiltersChange],
+  );
+
+  const visibleMatches = useMemo(() => filterMatches(matches, filters), [matches, filters]);
 
   const handleJoin = (matchId: string) => {
-    // Navigate to the match detail page where team selection + JoinTeamButton
-    // handle the full join flow (auth, team A/B choice, mutation, reload).
-    // Previously fixed bugs: was a placeholder alert() — replaced with navigation.
     window.location.href = `/partidos/${matchId}`;
   };
 
   return (
     <div>
-      <MatchFiltersComponent onFiltersChange={handleFiltersChange} initialFilters={filters} />
+      {showFilters && (
+        <MatchFiltersComponent filters={filters} onFiltersChange={handleFiltersChange} />
+      )}
 
       {loading && (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -88,19 +107,24 @@ export function MatchList({ initialMatches, isAuthenticated = false }: MatchList
         </div>
       )}
 
-      {!loading && !error && matches.length === 0 && (
+      {!loading && !error && visibleMatches.length === 0 && (
         <div className="text-center py-12">
           <p className="text-xl font-medium">No hay partidos disponibles</p>
           <p className="text-muted-foreground mt-2">
-            Probá con otros filtros o vuelve más tarde
+            Proba con otros filtros o vuelve mas tarde
           </p>
         </div>
       )}
 
-      {!loading && !error && matches.length > 0 && (
+      {!loading && !error && visibleMatches.length > 0 && (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {matches.map((match) => (
-            <MatchCard key={match.id} match={match} onJoin={handleJoin} isAuthenticated={isAuthenticated} />
+          {visibleMatches.map((match) => (
+            <MatchCard
+              key={match.id}
+              match={match}
+              onJoin={handleJoin}
+              isAuthenticated={isAuthenticated}
+            />
           ))}
         </div>
       )}

--- a/apps/frontend/src/components/matches/MatchMap.tsx
+++ b/apps/frontend/src/components/matches/MatchMap.tsx
@@ -24,6 +24,12 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import type { Match } from './MatchCard';
 import { executeQuery } from '@/lib/urql-client';
 import { GET_MATCHES_WITH_COORDS } from '@/graphql/operations/matches';
+import {
+  DEFAULT_MATCH_FILTERS,
+  filterMatches,
+  toServerMatchFilters,
+  type ClientMatchFilters,
+} from '@/lib/match-filtering';
 
 // Fix Leaflet default icon — bundlers mangle the internal _getIconUrl path.
 // Using CDN URLs is the most reliable cross-bundler solution.
@@ -177,7 +183,11 @@ function EmptyMap({ message, mapStyle }: { message: string; mapStyle: React.CSSP
 
 // ─── Main component ──────────────────────────────────────────────────────────
 
-export function MatchMap() {
+interface MatchMapProps {
+  filters?: ClientMatchFilters;
+}
+
+export function MatchMap({ filters = DEFAULT_MATCH_FILTERS }: MatchMapProps) {
   const [matches, setMatches] = useState<Match[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -192,14 +202,16 @@ export function MatchMap() {
 
   useEffect(() => {
     executeQuery<{ matches: Match[] }>(GET_MATCHES_WITH_COORDS, {
-      filters: { status: 'OPEN' },
+      filters: toServerMatchFilters(DEFAULT_MATCH_FILTERS),
     })
       .then((data) => setMatches(data.matches))
       .catch((err) => setError(err instanceof Error ? err.message : 'Error al cargar el mapa'))
       .finally(() => setLoading(false));
   }, []);
 
-  const geoMatches = matches.filter((m) => {
+  const filteredMatches = useMemo(() => filterMatches(matches, filters), [matches, filters]);
+
+  const geoMatches = filteredMatches.filter((m) => {
     if (m.club?.lat == null || m.club?.lng == null) {
       if (m.club) {
         console.warn(`[MatchMap] Club sin coordenadas, omitido del mapa: matchId=${m.id}`);
@@ -225,7 +237,7 @@ export function MatchMap() {
     );
   }
 
-  if (matches.length === 0) {
+  if (filteredMatches.length === 0) {
     return <EmptyMap message="No hay partidos disponibles" mapStyle={mapStyle} />;
   }
 

--- a/apps/frontend/src/components/matches/MatchesView.tsx
+++ b/apps/frontend/src/components/matches/MatchesView.tsx
@@ -12,8 +12,16 @@
  * - Previously fixed bugs: none relevant.
  */
 
-import { useState, lazy, Suspense } from 'react';
+import { useCallback, useEffect, useState, lazy, Suspense } from 'react';
 import { MatchList } from './MatchList';
+import { MatchFilters } from './MatchFilters';
+import {
+  DEFAULT_MATCH_FILTERS,
+  normalizeMatchFilters,
+  parseMatchFiltersFromSearch,
+  writeMatchFiltersToUrl,
+  type ClientMatchFilters,
+} from '@/lib/match-filtering';
 
 // Lazy import — Leaflet uses browser-only APIs (window/document) and crashes in Node SSR
 // if imported statically. React.lazy defers the import until the user clicks "Mapa",
@@ -29,9 +37,31 @@ interface MatchesViewProps {
 
 export function MatchesView({ isAuthenticated = false }: MatchesViewProps) {
   const [view, setView] = useState<View>('list');
+  const [filters, setFilters] = useState<ClientMatchFilters>(DEFAULT_MATCH_FILTERS);
+  const [urlReady, setUrlReady] = useState(false);
+
+  useEffect(() => {
+    const filtersFromUrl = parseMatchFiltersFromSearch(window.location.search);
+    setFilters(filtersFromUrl);
+    setUrlReady(true);
+  }, []);
+
+  const handleFiltersChange = useCallback(
+    (newFilters: ClientMatchFilters) => {
+      const normalized = normalizeMatchFilters(newFilters);
+      setFilters(normalized);
+
+      if (urlReady) {
+        window.history.replaceState(null, '', writeMatchFiltersToUrl(normalized, window.location.href));
+      }
+    },
+    [urlReady],
+  );
 
   return (
     <div>
+      <MatchFilters filters={filters} onFiltersChange={handleFiltersChange} />
+
       {/* View toggle */}
       <div className="view-toggle">
         <button
@@ -54,7 +84,12 @@ export function MatchesView({ isAuthenticated = false }: MatchesViewProps) {
 
       {/* Active view */}
       {view === 'list' ? (
-        <MatchList isAuthenticated={isAuthenticated} />
+        <MatchList
+          isAuthenticated={isAuthenticated}
+          filters={filters}
+          onFiltersChange={handleFiltersChange}
+          showFilters={false}
+        />
       ) : (
         <Suspense
           fallback={
@@ -63,7 +98,7 @@ export function MatchesView({ isAuthenticated = false }: MatchesViewProps) {
             </div>
           }
         >
-          <MatchMap />
+          <MatchMap filters={filters} />
         </Suspense>
       )}
 

--- a/apps/frontend/src/components/ui/date-picker.tsx
+++ b/apps/frontend/src/components/ui/date-picker.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { CalendarDays } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+interface DatePickerProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'onChange'> {
+  onValueChange?: (value: string) => void;
+}
+
+function DatePicker({ className, value, onValueChange, ...props }: DatePickerProps) {
+  return (
+    <div className={cn('relative min-w-0', className)}>
+      <CalendarDays
+        aria-hidden="true"
+        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+      />
+      <Input
+        data-slot="date-picker"
+        type="date"
+        value={value}
+        onChange={(event) => onValueChange?.(event.target.value)}
+        className="pl-10"
+        {...props}
+      />
+    </div>
+  );
+}
+
+export { DatePicker };

--- a/apps/frontend/src/components/ui/select.tsx
+++ b/apps/frontend/src/components/ui/select.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'onChange'> {
+  options: SelectOption[];
+  placeholder?: string;
+  onValueChange?: (value: string) => void;
+}
+
+function Select({
+  className,
+  options,
+  placeholder,
+  value,
+  onValueChange,
+  disabled,
+  ...props
+}: SelectProps) {
+  return (
+    <div className={cn('relative min-w-0', className)}>
+      <select
+        data-slot="select"
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onValueChange?.(event.target.value)}
+        className={cn(
+          'border-input bg-background text-foreground focus-visible:border-ring focus-visible:ring-ring/50 flex h-9 w-full appearance-none rounded-md border px-3 py-1 pr-9 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+        )}
+        {...props}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <ChevronDown
+        aria-hidden="true"
+        className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+      />
+    </div>
+  );
+}
+
+export { Select };

--- a/apps/frontend/src/lib/match-filtering.ts
+++ b/apps/frontend/src/lib/match-filtering.ts
@@ -1,0 +1,154 @@
+import type { MatchFilters, MatchFormat } from '@/graphql/operations/matches';
+import type { Match } from '@/components/matches/MatchCard';
+
+export type ClientMatchFilters = MatchFilters & {
+  timeFrom?: string;
+  timeTo?: string;
+};
+
+export const DEFAULT_MATCH_FILTERS: ClientMatchFilters = { status: 'OPEN' };
+
+const URL_FILTER_KEYS = [
+  'format',
+  'zone',
+  'dateFrom',
+  'dateTo',
+  'timeFrom',
+  'timeTo',
+  'search',
+] as const;
+
+const VALID_FORMATS = new Set<MatchFormat>([
+  'FIVE_VS_FIVE',
+  'SEVEN_VS_SEVEN',
+  'TEN_VS_TEN',
+  'ELEVEN_VS_ELEVEN',
+]);
+
+function compactFilters(filters: ClientMatchFilters): ClientMatchFilters {
+  const next: ClientMatchFilters = {};
+
+  for (const [key, value] of Object.entries(filters)) {
+    if (value == null || value === '') continue;
+    next[key as keyof ClientMatchFilters] = value as never;
+  }
+
+  return { ...DEFAULT_MATCH_FILTERS, ...next };
+}
+
+function dateOnly(value?: string): string | undefined {
+  if (!value) return undefined;
+  return value.includes('T') ? value.split('T')[0] : value;
+}
+
+function toLocalDateStart(value?: string): Date | null {
+  const date = dateOnly(value);
+  return date ? new Date(`${date}T00:00:00`) : null;
+}
+
+function toLocalDateEnd(value?: string): Date | null {
+  const date = dateOnly(value);
+  return date ? new Date(`${date}T23:59:59.999`) : null;
+}
+
+function timeToMinutes(value?: string): number | null {
+  if (!value) return null;
+  const [hours, minutes] = value.split(':').map(Number);
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null;
+  return hours * 60 + minutes;
+}
+
+function matchesTimeRange(matchDate: Date, filters: ClientMatchFilters): boolean {
+  const from = timeToMinutes(filters.timeFrom);
+  const to = timeToMinutes(filters.timeTo);
+  if (from == null && to == null) return true;
+
+  const current = matchDate.getHours() * 60 + matchDate.getMinutes();
+  if (from != null && to != null && from > to) {
+    return current >= from || current <= to;
+  }
+
+  if (from != null && current < from) return false;
+  if (to != null && current > to) return false;
+  return true;
+}
+
+export function normalizeMatchFilters(filters: ClientMatchFilters): ClientMatchFilters {
+  return compactFilters(filters);
+}
+
+export function filterMatches(matches: Match[], filters: ClientMatchFilters): Match[] {
+  const normalized = normalizeMatchFilters(filters);
+  const fromDate = toLocalDateStart(normalized.dateFrom);
+  const toDate = toLocalDateEnd(normalized.dateTo);
+  const search = normalized.search?.trim().toLowerCase();
+
+  return matches.filter((match) => {
+    if (normalized.status && match.status && match.status !== normalized.status) return false;
+    if (normalized.format && match.format !== normalized.format) return false;
+    if (normalized.zone && match.club?.zone !== normalized.zone) return false;
+
+    const matchDate = new Date(match.startTime);
+    if (fromDate && matchDate < fromDate) return false;
+    if (toDate && matchDate > toDate) return false;
+    if (!matchesTimeRange(matchDate, normalized)) return false;
+
+    if (search) {
+      const haystack = [
+        match.title,
+        match.club?.name,
+        match.club?.zone,
+        match.club?.address,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+
+      if (!haystack.includes(search)) return false;
+    }
+
+    return true;
+  });
+}
+
+export function parseMatchFiltersFromSearch(search: string): ClientMatchFilters {
+  const params = new URLSearchParams(search);
+  const format = params.get('format') as MatchFormat | null;
+
+  return normalizeMatchFilters({
+    format: format && VALID_FORMATS.has(format) ? format : undefined,
+    zone: params.get('zone') || undefined,
+    dateFrom: params.get('dateFrom') || undefined,
+    dateTo: params.get('dateTo') || undefined,
+    timeFrom: params.get('timeFrom') || undefined,
+    timeTo: params.get('timeTo') || undefined,
+    search: params.get('search') || undefined,
+  });
+}
+
+export function writeMatchFiltersToUrl(filters: ClientMatchFilters, href: string): string {
+  const url = new URL(href);
+  const normalized = normalizeMatchFilters(filters);
+
+  for (const key of URL_FILTER_KEYS) {
+    url.searchParams.delete(key);
+  }
+
+  for (const key of URL_FILTER_KEYS) {
+    const value = normalized[key];
+    if (!value) continue;
+    url.searchParams.set(key, key.startsWith('date') ? dateOnly(value) ?? value : value);
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function toServerMatchFilters(filters: ClientMatchFilters): MatchFilters {
+  return {
+    status: filters.status ?? 'OPEN',
+  };
+}
+
+export function toDateInputValue(value?: string): string {
+  return dateOnly(value) ?? '';
+}

--- a/apps/frontend/src/lib/match-filtering.ts
+++ b/apps/frontend/src/lib/match-filtering.ts
@@ -58,6 +58,21 @@ function timeToMinutes(value?: string): number | null {
   return hours * 60 + minutes;
 }
 
+/**
+ * Checks if a match's start time falls within the requested time range.
+ *
+ * Timezone: uses the browser's LOCAL time (Date.prototype.getHours).
+ * Match startTime is stored as ISO-8601 UTC in the DB and parsed by
+ * `new Date()`, which converts it to the browser's local timezone automatically.
+ * Since the platform is exclusively for players and clubs in Montevideo, Uruguay
+ * (UTC-3 / UTC-2 during DST), local browser time is the correct reference for
+ * slot labels like "Mañana / Tarde / Noche". Accessing from outside Uruguay will
+ * produce offset results — if multi-timezone support is added, replace
+ * `getHours()` with Intl.DateTimeFormat using the club's IANA timezone.
+ *
+ * Cross-midnight ranges (e.g. 20:00–02:00): when `from > to`, the
+ * match is valid if current >= from OR current <= to.
+ */
 function matchesTimeRange(matchDate: Date, filters: ClientMatchFilters): boolean {
   const from = timeToMinutes(filters.timeFrom);
   const to = timeToMinutes(filters.timeTo);
@@ -65,6 +80,7 @@ function matchesTimeRange(matchDate: Date, filters: ClientMatchFilters): boolean
 
   const current = matchDate.getHours() * 60 + matchDate.getMinutes();
   if (from != null && to != null && from > to) {
+    // Cross-midnight range (e.g. Nocturno: 20:00–02:00)
     return current >= from || current <= to;
   }
 
@@ -143,6 +159,20 @@ export function writeMatchFiltersToUrl(filters: ClientMatchFilters, href: string
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
+/**
+ * Converts client filters to the MatchFilters shape expected by the GraphQL API.
+ *
+ * INTENTIONAL: only `status` is forwarded. The current architecture loads all
+ * OPEN matches in one request and applies every other filter locally via
+ * `filterMatches()` for instant UX. Passing extra filters here would cause
+ * cache fragmentation (a separate Redis key per filter combo) and gain nothing
+ * for the current dataset size.
+ *
+ * When the dataset grows large enough to require server-side filtering, extend
+ * this function to map the remaining ClientMatchFilters fields (format, zone,
+ * dateFrom, dateTo, search) to their MatchFilters equivalents and remove the
+ * matching predicates from `filterMatches`.
+ */
 export function toServerMatchFilters(filters: ClientMatchFilters): MatchFilters {
   return {
     status: filters.status ?? 'OPEN',
@@ -151,4 +181,16 @@ export function toServerMatchFilters(filters: ClientMatchFilters): MatchFilters 
 
 export function toDateInputValue(value?: string): string {
   return dateOnly(value) ?? '';
+}
+
+/**
+ * Converts a plain date string (YYYY-MM-DD) from a `<input type="date">`
+ * into an ISO-like datetime string suitable for `filters.dateFrom / dateTo`.
+ * The T suffix is consumed by the private `toLocalDateStart` / `toLocalDateEnd`
+ * helpers in this module (which build a `Date` object in local time) and is
+ * stripped before URL serialisation in `writeMatchFiltersToUrl`.
+ */
+export function toDateFilter(value: string, endOfDay = false): string | undefined {
+  if (!value) return undefined;
+  return `${value}T${endOfDay ? '23:59:59' : '00:00:00'}`;
 }

--- a/docs/prompts/m3r8t5xb-prompt-log.md
+++ b/docs/prompts/m3r8t5xb-prompt-log.md
@@ -1,0 +1,15 @@
+# Prompt Log
+
+- Timestamp: 2026-04-28 02:23:45
+- Task ID: m3r8t5xb
+
+## User Prompt
+
+> @copilot review this.
+> (PR: "cumplir epica de filtros de partidos" — MatchFilters component with zone/format/date/time controls, client-side filtering, URL param persistence, and list/map shared state)
+
+## Agent Main Actions
+
+- Reviewed the full PR diff (MatchFilters, MatchList, MatchMap, MatchesView, match-filtering.ts, select.tsx, date-picker.tsx) and identified four actionable issues.
+- Fixed the empty-state UX in MatchList to distinguish "no open matches at all" from "all matches hidden by active filters" so players get clearer feedback.
+- Centralized date utilities by moving `toDateFilter` from a local MatchFilters.tsx function to the shared `match-filtering.ts` module, and added explicit doc comments explaining the `toServerMatchFilters` intentional filter-stripping strategy and the `matchesTimeRange` timezone assumption.


### PR DESCRIPTION
Implementa la user story para que el jugador pueda filtrar partidos por zona, formato, rango de fecha y horario, encontrando opciones convenientes de forma rapida.

Crea el componente MatchFilters con controles tipo shadcn/ui Select, DatePicker y Button. Los filtros se aplican client-side sobre los partidos ya cargados para dar una UX instantanea con hydration client:visible.

Tambien persiste los filtros en URL params para compartir busquedas y sincroniza el mismo estado de filtros entre la vista de lista y mapa. La query GraphQL matches(filters) y el filtrado server-side con WHERE dinamico quedan disponibles como soporte para datasets grandes.