### PR TITLE
tests de historial de partido agregados

### DIFF
--- a/apps/testing/tests/historial-partidos.spec.ts
+++ b/apps/testing/tests/historial-partidos.spec.ts
@@ -1,0 +1,246 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+/**
+ * Tests E2E del Historial de partidos jugados (sección de /perfil).
+ *
+ * Decision Context:
+ * - La página /perfil es SSR: Astro pide en paralelo `myProfile` y la primera página de
+ *   `myMatches` al backend, y le pasa esa data a la React island MatchHistoryList como
+ *   `initialData`. NO podemos mockear la primera carga desde el browser (page.route()
+ *   sólo intercepta requests que salen del navegador).
+ * - El botón "Cargar más", en cambio, dispara `fetch` desde la island al endpoint
+ *   /graphql del backend → SÍ es mockeable. Aprovechamos eso para los tests de
+ *   loading/error/append.
+ * - Adaptive design: ricardo (player de prueba) probablemente tenga 0 partidos
+ *   completados → para los tests del empty state alcanza con eso. Para los tests que
+ *   requieren cards renderizadas, miramos lo que la DB devuelva en el SSR y skipeamos
+ *   con mensaje claro si no hay data.
+ * - El test de "Cargar más" requiere que initialData.hasMore=true (si no, el botón ni
+ *   aparece). Eso depende de tener > pageSize partidos completados en la cuenta.
+ * - Assumptions:
+ *   * Frontend en :4321 y backend en :4000.
+ *   * Player de prueba: ricardo@gmail.com / bbbb1234.
+ *   * El middleware redirige /perfil a /login si no hay cookie de auth.
+ * - Previously fixed bugs: none relevant.
+ */
+
+const FRONTEND_URL = 'http://localhost:4321';
+const BACKEND_GRAPHQL_ROUTE = '**/graphql';
+const PERFIL_URL = `${FRONTEND_URL}/perfil`;
+
+const TEST_PLAYER = {
+  email: 'ricardo@gmail.com',
+  password: 'bbbb1234',
+};
+
+async function login(page: Page): Promise<void> {
+  await page.goto(`${FRONTEND_URL}/login`);
+  await page.getByRole('textbox', { name: 'Email' }).fill(TEST_PLAYER.email);
+  await page.getByRole('textbox', { name: /contrase/i }).fill(TEST_PLAYER.password);
+  await page.getByRole('button', { name: /ingresar/i }).click();
+  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
+}
+
+/**
+ * Mockea SOLO la query `myMatches` (la usa "Cargar más"). Deja pasar el resto del
+ * tráfico GraphQL — incluyendo la primera carga del SSR, que va por el server de
+ * Astro y no por el browser.
+ */
+async function mockMyMatchesQuery(
+  page: Page,
+  body: unknown,
+  options: { delayMs?: number } = {},
+): Promise<{ payloads: unknown[] }> {
+  const payloads: unknown[] = [];
+
+  await page.route(BACKEND_GRAPHQL_ROUTE, async (route: Route) => {
+    const raw = route.request().postData() ?? '{}';
+    const parsed = JSON.parse(raw) as { query?: string };
+
+    if (!parsed.query?.includes('myMatches')) {
+      await route.continue();
+      return;
+    }
+
+    payloads.push(parsed);
+    if (options.delayMs) {
+      await new Promise((resolve) => setTimeout(resolve, options.delayMs));
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+
+  return { payloads };
+}
+
+/**
+ * Devuelve la cantidad de cards visibles en el historial. Se usa para detectar si
+ * la cuenta tiene partidos jugados o no antes de correr tests adaptativos.
+ */
+async function countHistoryCards(page: Page): Promise<number> {
+  return await page.locator('.history-section article').count();
+}
+
+test.describe('Historial de partidos (/perfil → sección Historial)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('sin login redirige a /login antes de mostrar el perfil', async ({ page }) => {
+    await page.goto(PERFIL_URL);
+
+    // El middleware (PROTECTED_ROUTES incluye '/perfil') debe rebotar a /login.
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('renderiza el header de la sección "Historial de partidos"', async ({ page }) => {
+    await login(page);
+    await page.goto(PERFIL_URL);
+
+    // Wait for hidratación de la island (client:visible) — scrolleamos para que entre.
+    await page.locator('.history-section').scrollIntoViewIfNeeded();
+
+    await expect(page.getByText('ACTIVIDAD', { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Historial de partidos/i, level: 2 }),
+    ).toBeVisible();
+  });
+
+  test('el subtítulo refleja la cantidad: "X en total" o "sin partidos aún"', async ({ page }) => {
+    await login(page);
+    await page.goto(PERFIL_URL);
+
+    const sub = page.locator('.history-section .history-sub');
+    await expect(sub).toBeVisible();
+    // Una de las dos formas: o cuenta total, o el placeholder.
+    await expect(sub).toHaveText(/(\d+ en total|sin partidos aún)/i);
+  });
+
+  test('si el player no tiene historial, muestra el empty state con el icono y el mensaje', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto(PERFIL_URL);
+    await page.locator('.history-section').scrollIntoViewIfNeeded();
+
+    const cardsCount = await countHistoryCards(page);
+    test.skip(
+      cardsCount > 0,
+      `El player ${TEST_PLAYER.email} tiene ${cardsCount} partidos en su historial — el empty state no aplica.`,
+    );
+
+    await expect(page.getByText(/Aún no tenés partidos jugados/i)).toBeVisible();
+    await expect(page.getByText(/aparecerán aquí con el resultado/i)).toBeVisible();
+    // Y NO debe haber botón "Cargar más".
+    await expect(page.getByRole('button', { name: /cargar más/i })).toHaveCount(0);
+  });
+
+  test('si el player tiene partidos, las cards renderizan estructura básica (fecha + formato + resultado)', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto(PERFIL_URL);
+    await page.locator('.history-section').scrollIntoViewIfNeeded();
+
+    const cardsCount = await countHistoryCards(page);
+    test.skip(
+      cardsCount === 0,
+      `El player ${TEST_PLAYER.email} no tiene partidos jugados — no hay cards que validar.`,
+    );
+
+    const firstCard = page.locator('.history-section article').first();
+    // Cada card tiene un badge de formato (5v5/7v7/10v10/11v11) en el top-right.
+    await expect(firstCard.getByText(/^(5v5|7v7|10v10|11v11)$/)).toBeVisible();
+    // Y un badge de equipo A o B.
+    await expect(firstCard.getByText(/Equipo (A|B)/i)).toBeVisible();
+    // Y un badge de resultado (Ganado/Perdido/Empate/Sin resultado).
+    await expect(
+      firstCard.getByText(/^(Ganado|Perdido|Empate|Sin resultado)$/i),
+    ).toBeVisible();
+  });
+
+  test('al clickear "Cargar más" la mutation se dispara y aparece el estado loading', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto(PERFIL_URL);
+    await page.locator('.history-section').scrollIntoViewIfNeeded();
+
+    const loadMore = page.getByRole('button', { name: /^cargar más$/i });
+    const loadMoreVisible = await loadMore.isVisible().catch(() => false);
+    test.skip(
+      !loadMoreVisible,
+      `El player ${TEST_PLAYER.email} no tiene suficientes partidos para que aparezca "Cargar más" (necesita > pageSize=10).`,
+    );
+
+    // Mockeamos la respuesta de la página 2 con 1 item nuevo, para detectar el append.
+    const tracker = await mockMyMatchesQuery(
+      page,
+      {
+        data: {
+          myMatches: {
+            items: [
+              {
+                id: 'mock-page-2-item',
+                title: 'Partido mock pag2',
+                startTime: '2026-01-10T20:00:00Z',
+                format: 'FIVE_VS_FIVE',
+                userTeam: 'A',
+                userResult: 'WON',
+                scoreA: null,
+                scoreB: null,
+                isOrganizer: false,
+                club: null,
+              },
+            ],
+            total: 11,
+            page: 2,
+            pageSize: 10,
+            hasMore: false,
+          },
+        },
+      },
+      { delayMs: 500 },
+    );
+
+    const cardsBefore = await countHistoryCards(page);
+    await loadMore.click();
+
+    // Estado loading: el botón cambia el texto y queda deshabilitado.
+    await expect(page.getByRole('button', { name: /cargando/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /cargando/i })).toBeDisabled();
+
+    // Eventualmente la mutation se ejecuta y appendea el item nuevo.
+    await expect.poll(() => tracker.payloads.length, { timeout: 10_000 }).toBe(1);
+    await expect.poll(() => countHistoryCards(page), { timeout: 5_000 }).toBe(cardsBefore + 1);
+
+    // hasMore=false en el mock → ya no debe estar el botón "Cargar más", aparece el end label.
+    await expect(page.getByText(/Mostrando todos tus partidos/i)).toBeVisible();
+  });
+
+  test('si "Cargar más" devuelve error, se muestra el mensaje role=alert y el botón vuelve disponible', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto(PERFIL_URL);
+    await page.locator('.history-section').scrollIntoViewIfNeeded();
+
+    const loadMore = page.getByRole('button', { name: /^cargar más$/i });
+    const loadMoreVisible = await loadMore.isVisible().catch(() => false);
+    test.skip(
+      !loadMoreVisible,
+      `El player ${TEST_PLAYER.email} no tiene suficientes partidos para que aparezca "Cargar más".`,
+    );
+
+    await mockMyMatchesQuery(page, {
+      errors: [{ message: 'Falla simulada del backend' }],
+    });
+
+    await loadMore.click();
+
+    await expect(page.getByRole('alert')).toContainText(/falla simulada del backend/i);
+    // El botón vuelve a su estado inicial (no se queda en loading).
+    await expect(page.getByRole('button', { name: /^cargar más$/i })).toBeEnabled();
+  });
+});

--- a/apps/testing/tests/match-detail.spec.ts
+++ b/apps/testing/tests/match-detail.spec.ts
@@ -200,17 +200,28 @@ async function gotoMatchDetail(page: Page, matchId: string): Promise<void> {
 // listener y la mutation no se ejecuta nunca, fallando el `expect.poll(payloads.length)`
 // con timeout. El web component <astro-island> trackea su estado: mientras hidrata
 // expone el atributo `ssr` y/o `await-children`; al completar la hidratacion los
-// remueve. Esperamos a que TODAS las islands del detalle hayan terminado para que
-// los clicks aterricen sobre handlers de React reales.
-// Previously fixed bugs: tests "Sumarme por equipo" y "error inline al salir" fallaban
-// con `expected 1, received 0` porque el click se hacia antes de la hidratacion.
+// remueve.
+// IMPORTANTE: filtramos SOLO las islands con `client="load"`. Las que usan
+// `client:visible` (ej: MatchResultsSection en el bottom de la pagina) nunca pierden
+// el atributo `ssr` hasta que el usuario las scrollea a la vista — esperar por ellas
+// hace timeoutear el helper. Para nuestros tests solo importan los CTAs above the
+// fold (JoinTeamButton, LeaveMatchButton).
+// Previously fixed bugs:
+//   1. Tests "Sumarme por equipo" y "error inline al salir" fallaban con
+//      `expected 1, received 0` porque el click se hacia antes de la hidratacion.
+//   2. Despues de agregarse MatchResultsSection con client:visible, el helper
+//      timeouteaba a los 10s porque esa island nunca hidrata sin scroll —
+//      filtrado por client="load" lo arregla.
 async function waitForIslandsHydrated(page: Page): Promise<void> {
+  // Astro 6 marca cada island hidratada agregando el atributo `client-render-time`
+  // (que registra cuántos ms tardó React en montar). En cambio `await-children`
+  // queda pegado al elemento incluso después de hidratar — por eso NO sirve como
+  // señal negativa. Usamos la presencia de `client-render-time` como indicador
+  // positivo: si está, el handler onClick ya está enganchado.
   await page.waitForFunction(() => {
-    const islands = Array.from(document.querySelectorAll('astro-island'));
+    const islands = Array.from(document.querySelectorAll('astro-island[client="load"]'));
     if (islands.length === 0) return true;
-    return islands.every(
-      (island) => !island.hasAttribute('ssr') && !island.hasAttribute('await-children'),
-    );
+    return islands.every((island) => island.hasAttribute('client-render-time'));
   }, { timeout: 10_000 });
 }
 

--- a/apps/testing/tests/matches-list.spec.ts
+++ b/apps/testing/tests/matches-list.spec.ts
@@ -206,9 +206,16 @@ test.describe('Listado de partidos (/partidos)', () => {
     // pueda clickear y ver quiénes están anotados antes de decidir si esperar un cupo.
     // Previously fixed bugs: el CTA anterior era un botón disabled "Completo" — los
     // usuarios no tenían forma de abrir el detalle de un partido 10/10 desde el listado.
+    // Decision Context: el id DEBE ser un UUID válido. El SSR de /partidos/[id]
+    // valida el formato con UUID_REGEX (ver matchResolver.match) y redirige a
+    // /partidos cuando el id no matchea — eso hacía que este test fallara con
+    // "Expected /partidos/full-1, Received /partidos".
+    // Previously fixed bugs: el id era 'full-1' (no UUID) → el detalle redirigía
+    // al listado y la assertion de URL fallaba. Cambiado a un UUID memorable.
+    const FULL_MATCH_ID = '00000000-0000-0000-0000-00000000fff1';
     await mockMatchesQuery(page, [
       buildMatch({
-        id: 'full-1',
+        id: FULL_MATCH_ID,
         title: 'Partido lleno',
         totalSlots: 10,
         availableSlots: 0,
@@ -234,13 +241,16 @@ test.describe('Listado de partidos (/partidos)', () => {
 
     // Click en el CTA navega al detalle
     await detailBtn.click();
-    await expect(page).toHaveURL(/\/partidos\/full-1$/);
+    await expect(page).toHaveURL(new RegExp(`/partidos/${FULL_MATCH_ID}$`));
   });
 
   test('partido lleno: clickear el card también navega al detalle', async ({ page }) => {
+    // UUID válido — el SSR del detalle valida el formato y redirige al listado
+    // si el id no es un UUID. Ver decision context del test anterior.
+    const FULL_MATCH_ID = '00000000-0000-0000-0000-00000000fff2';
     await mockMatchesQuery(page, [
       buildMatch({
-        id: 'full-2',
+        id: FULL_MATCH_ID,
         title: 'Otro partido lleno',
         totalSlots: 10,
         availableSlots: 0,
@@ -251,14 +261,23 @@ test.describe('Listado de partidos (/partidos)', () => {
 
     // Clickear el título (parte de la card, fuera del botón) navega al detalle
     await page.getByText('Otro partido lleno').click();
-    await expect(page).toHaveURL(/\/partidos\/full-2$/);
+    await expect(page).toHaveURL(new RegExp(`/partidos/${FULL_MATCH_ID}$`));
   });
 
   test('empty-state muestra mensaje amigable cuando no hay partidos', async ({ page }) => {
     await gotoMatchesPage(page);
 
     await expect(page.getByText('No hay partidos disponibles')).toBeVisible();
-    await expect(page.getByText(/Probá con otros filtros/i)).toBeVisible();
+    // El subtítulo varía según haya filtros activos o no:
+    // - sin filtros: "No hay partidos abiertos por el momento. Volvé más tarde."
+    // - con filtros: "Ningún partido coincide con los filtros. Probá ajustando la búsqueda."
+    // El test no aplica filtros → matcheamos el copy del caso sin filtros, pero dejamos
+    // el regex flexible por si en el futuro se unifica el wording.
+    // Previously fixed bugs: el copy original "Probá con otros filtros" fue reemplazado
+    // por dos variantes contextuales — el test fallaba con el wording viejo.
+    await expect(
+      page.getByText(/Volvé más tarde|ajustando la búsqueda|otros filtros/i),
+    ).toBeVisible();
   });
 
   test('muestra mensaje de error cuando la query falla', async ({ page }) => {

--- a/docs/prompts/h5q9w3kt-prompt-log.md
+++ b/docs/prompts/h5q9w3kt-prompt-log.md
@@ -1,0 +1,16 @@
+# Prompt Log
+
+- Timestamp: 2026-05-02 00:00:00
+- Task ID: h5q9w3kt
+
+## User Prompt
+
+> ahi funciona ahora hace los tests
+
+(Contexto: el usuario fue asignado para testear la feature "historial de partidos jugados", que vive en la sección Historial de `/perfil`. Pidió escribir los tests E2E.)
+
+## Agent Main Actions
+
+- Creó la branch `test/historial-partidos` desde el último `main` y exploró los componentes `MatchHistoryList`, `MatchHistoryCard` y la página SSR `/perfil` para entender el flujo (SSR carga la primera página, "Cargar más" hace fetch desde el browser).
+- Agregó `apps/testing/tests/historial-partidos.spec.ts` con 7 tests organizados como `describe.serial`: auth gate, render del header, sub label adaptativo, empty state (skipea si el player tiene historial), cards renderizadas (skipea si no hay), y dos tests mockeando `myMatches` para validar el flow de "Cargar más" (loading + append + end label, y manejo de error con role=alert). El mock interceptea solo la query del browser, no el SSR.
+- Documentó por qué el SSR no se puede mockear desde Playwright y por qué algunos tests son adaptativos (la cloud DB cambia con el tiempo). Validó con `turbo typecheck --force` (3/3 tasks verdes).


### PR DESCRIPTION
Tests de historial de partidos agregados y otros tests de otras funciones que daban error ahora pasan.

Hay algunos de los tests que pueden llegar a no correr dependiendo de la cantidad de partidos jugados que tiene el usuario(si tiene 0 corre uno pero no otro, si tiene 1 o mas corre otro pero no el de 0, y si tiene mas de 10 corre otros dos)
<img width="1002" height="365" alt="image" src="https://github.com/user-attachments/assets/848c0245-2387-439f-b26a-be7f29d58beb" />
