### PR TITLE
feat(tests): implement page objects for e2e testing across various pages

### DIFF
--- a/.claude/rules/e2e-testing.md
+++ b/.claude/rules/e2e-testing.md
@@ -1,0 +1,119 @@
+# E2E Testing Rules (apps/testing)
+
+These rules govern every e2e spec and supporting helper under
+`apps/testing/tests/**`. The goal is keeping spec bodies short, declarative,
+and focused on behaviour — every shared helper, locator, or login flow lives
+in `apps/testing/tests/support/`, never duplicated in specs.
+
+Read this file BEFORE adding or refactoring an e2e spec.
+
+## Required structure
+
+```
+apps/testing/tests/
+  support/
+    constants.ts                — URLs, GraphQL routes, cookie names, seed match IDs
+    users.ts                    — TEST_USERS map (email/password/storageStatePath)
+    auth.ts                     — loginViaForm, readAccessToken, loginAndReadToken
+    graphql.ts                  — gqlPost(OrThrow), mockGraphQLAll, mockGraphQLOperation, NETWORK_ERROR
+    network.ts                  — mockLeafletAssets, mockJsonRoute, TRANSPARENT_PNG
+    builders.ts                 — buildMatch, buildMockSlot, MockMatch / MockSlot types
+    fixtures.ts                 — extends test with one fixture per Page Object
+    page-objects/<Surface>Page.ts — one PO per page (Login, Profile, MatchDetail, …)
+    index.ts                    — barrel export consumed by every spec
+  auth.setup.ts                 — Playwright setup project that warms storage states
+  <flow>.spec.ts                — actual specs
+```
+
+## Hard rules
+
+1. **Import from the barrel.** Specs MUST import `test`, `expect`, helpers,
+   constants, and Page Objects from `./support` (the barrel). Importing from
+   `@playwright/test` directly inside a spec is only allowed for *types*
+   (`type Page`, `type Route`, `type APIRequestContext`) when the helper layer
+   doesn't already expose them.
+
+2. **Page Objects own selectors.** Specs MUST NOT contain raw selectors for
+   pages that have a Page Object. If a selector is missing from the PO, add it
+   there. PO fields hold `Locator` instances; methods perform user-visible
+   actions or expose composite waits (`waitForIslandsHydrated`, `expectListSettled`).
+
+3. **No duplicated helpers.** If two specs need the same helper, move it to
+   `support/`. Things like `login()`, `readAccessToken()`, `gqlPost()`,
+   `buildMatch()`, `mockGraphQLOperation()`, `waitForIslandsHydrated()` live
+   in support — never copy them into specs.
+
+4. **Authentication uses storage state, not per-test logins.** Specs that need
+   a logged-in browser MUST set `test.use({ storageState:
+   TEST_USERS.<role>.storageStatePath })` at the top of the file (or inside a
+   nested `describe.use`). The setup project (`tests/auth.setup.ts`) writes
+   those files once per run. The only exception: `login.spec.ts` exercises the
+   form itself and intentionally skips the saved state.
+
+5. **For tests that mix anonymous and authenticated cases**, prefer creating a
+   fresh `browser.newContext()` for the anonymous case and leave the spec's
+   `test.use({ storageState })` for the rest. Don't write a per-test
+   `loginPage.loginAs(...)` call when storage state could do the work.
+
+6. **Mock at the right boundary.**
+   - SSR pages: the initial GraphQL fetch happens server-side and CANNOT be
+     intercepted with `page.route`. Either let it hit the real backend (with
+     `test.skip` for missing fixtures) or hit the backend yourself via
+     `gqlPostOrThrow` for setup.
+   - Browser-issued queries (urql client, React island fetch): use
+     `mockGraphQLAll(page, route, body)` for one-shot mocks of the entire
+     route, or `mockGraphQLOperation(page, route, marker, body)` to pass
+     other operations through unchanged.
+   - Use `GRAPHQL_PROXY_ROUTE` for /api/graphql, `BACKEND_GRAPHQL_ROUTE` for
+     /graphql, and `GRAPHQL_ANY_ROUTE` (regex) when you don't care which path
+     the client takes. Never inline glob/regex strings in specs.
+
+7. **Reuse data builders.** `buildMatch()` / `buildMockSlot()` are the
+   canonical mock factories. Spread overrides for the fields under test, do
+   not re-declare a competing factory in a spec.
+
+8. **Decision Context blocks.** Every PO file and every spec MUST keep a
+   leading `Decision Context` comment block explaining mocking strategy,
+   hydration waits, previously-fixed bugs, and assumptions. Update the block
+   when behaviour changes — never let it go stale. (This is a project-wide
+   rule restated here.)
+
+9. **Match IDs with seed expectations.** If you depend on a seeded match,
+   reference it through `SEED_MATCHES.full` / `SEED_MATCHES.open` (in
+   `support/constants.ts`). Never hard-code the UUID inside a spec — that's
+   how seed/spec drift starts.
+
+10. **Pre-completion checks** (project rules):
+    - Run `turbo typecheck --force` from the repo root after editing any
+      spec or support file. The task is not complete until it passes.
+    - Run a narrow e2e covering the touched flow before declaring done.
+
+## Adding a new flow — checklist
+
+1. Identify the page(s) under test. If a Page Object exists, extend it; if
+   not, add one under `support/page-objects/`.
+2. Export the new PO from `support/index.ts` and the matching fixture from
+   `support/fixtures.ts`.
+3. Decide the auth posture: anonymous, `playerMateo`, `playerRicardo`, or
+   `clubAdmin`. If a new role is needed, extend `TEST_USERS` and
+   `auth.setup.ts`.
+4. Write the spec using only barrel imports + PO fixtures. Spec bodies should
+   read like a description of the behaviour.
+5. Add a Decision Context comment at the top of the spec with the rationale
+   for the mocking choice and any seed/account assumptions.
+6. Run `pnpm exec turbo typecheck --force` from the repo root.
+7. Run the new spec via `pnpm test --grep <pattern>` to confirm the flow
+   passes.
+
+## Naming and style
+
+- One Page Object per page (or per cohesive surface, e.g. profile card +
+  avatar modal share `ProfilePage`). PO methods are imperatives that read like
+  user actions: `selectFirstClubAndContinue`, `openLeaveDialog`,
+  `chooseValidPng`.
+- Prefer locators by accessible role/label/title. CSS selectors are a last
+  resort and must be commented when used.
+- Test titles describe behaviour, not implementation. They stay in Spanish to
+  match the existing suite.
+- Inside specs, avoid local `async function` helpers more than 5 lines long —
+  if it's reusable, lift it to `support/`.

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -43,6 +43,7 @@ const DEFAULT_DEV_ORIGINS = [
   'http://127.0.0.1:4324',
   'http://127.0.0.1:5173',
   'http://127.0.0.1:3000',
+  'http://localhost:4000',
 ];
 
 const extraOrigins = (process.env.FRONTEND_URLS ?? '')

--- a/apps/backend/src/config/redis.ts
+++ b/apps/backend/src/config/redis.ts
@@ -57,6 +57,10 @@ export const CACHE_PREFIX = {
   // `user:matches:<userId>:page:<page>:size:<pageSize>` — per-user history pagination.
   // Invalidate when a match this user participated in transitions to 'completed'.
   USER_MATCHES: 'user:matches:',
+  // `geocode:<normalizedAddress>` — Nominatim geocoding result cache.
+  // Long TTL (GEOCODING) because addresses rarely move and Nominatim usage policy
+  // requires aggressive caching. See geocodingService for details.
+  GEOCODE: 'geocode:',
 } as const;
 
 // =====================================================
@@ -68,6 +72,11 @@ export const CACHE_TTL = {
   SINGLE_ENTITY: 1800, // 30 minutes for individual items
   DYNAMIC_DATA: 180, // 3 minutes for frequently changing data (match slots)
   USER_DATA: 300, // 5 minutes for user-specific data
+  // 30 days. Geocoding results from Nominatim are stable (street addresses rarely move)
+  // and OSM's usage policy requires aggressive caching to avoid hammering the public
+  // service. We also persist the result back to clubs.lat/lng, so this cache is mostly
+  // a guard against repeated misses across cold restarts of the same address.
+  GEOCODING: 60 * 60 * 24 * 30,
 } as const;
 
 // =====================================================

--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -129,6 +129,7 @@ export type MatchFilters = {
   dateFrom?: InputMaybe<Scalars['String']['input']>;
   dateTo?: InputMaybe<Scalars['String']['input']>;
   format?: InputMaybe<MatchFormat>;
+  onlyMine?: InputMaybe<Scalars['Boolean']['input']>;
   search?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<MatchStatus>;
   zone?: InputMaybe<Scalars['String']['input']>;

--- a/apps/backend/src/graphql/resolvers/domains/match.ts
+++ b/apps/backend/src/graphql/resolvers/domains/match.ts
@@ -43,9 +43,19 @@ const Query: QueryResolvers = {
   /**
    * Get matches with optional filters. Public endpoint - no auth required.
    * Returns lightweight Match objects (no participant data) for list performance.
+   *
+   * Decision Context:
+   * - `onlyMine`: when the client requests only-my-matches we forward the authenticated
+   *   user id to the service so the repo can constrain `id IN (matchIds the user joined)`.
+   *   Anonymous callers passing `onlyMine=true` get the unfiltered public list because
+   *   `ctx.user?.id` is undefined — the service silently drops the flag in that case.
+   *   This intentionally avoids surfacing an "auth required" error so the frontend toggle
+   *   can stay enabled without forcing a sign-in redirect — the UI hides the toggle for
+   *   anonymous users as the primary guard.
+   * - Previously fixed bugs: none relevant.
    */
-  matches: async (_parent, args, _ctx) => {
-    return matchService.listMatches({}, args.filters);
+  matches: async (_parent, args, ctx) => {
+    return matchService.listMatches({ userId: ctx.user?.id }, args.filters);
   },
 
   /**

--- a/apps/backend/src/graphql/schema/match.graphql
+++ b/apps/backend/src/graphql/schema/match.graphql
@@ -100,6 +100,11 @@ input MatchFilters {
   dateFrom: String
   dateTo: String
   search: String
+  # When true, restrict the result to matches the authenticated user joined.
+  # Ignored when no auth context is present so anonymous callers see the public list.
+  # Used by /partidos "Pasados → Solo los míos" toggle to inspect personal history
+  # without leaving the listing UI.
+  onlyMine: Boolean
 }
 
 type Query {

--- a/apps/backend/src/repositories/clubRepository.ts
+++ b/apps/backend/src/repositories/clubRepository.ts
@@ -77,4 +77,38 @@ export async function getClubById(
   return data as unknown as ClubDetailRow;
 }
 
-export const clubRepository = { listClubs, getClubById };
+/**
+ * Persist geocoded coordinates for a club.
+ *
+ * Decision Context:
+ * - Why service-role: this is a backfill-on-read driven by geocodingService and runs in
+ *   read-path resolvers where no user-scoped client is guaranteed (the matches list is
+ *   public). Coordinates are derived from a public address, not a sensitive write — RLS
+ *   would only complicate the read path without protecting anything new.
+ * - Best-effort: errors are logged but never thrown. A failed persist just means the
+ *   next request will re-geocode (Redis cache still avoids the network hit) — that's
+ *   strictly better than poisoning the read path.
+ * - Idempotent: callers only invoke this when lat/lng are null on read; concurrent
+ *   updates with the same value are safe.
+ */
+export async function updateClubCoords(
+  clubId: string,
+  lat: number,
+  lng: number,
+  client: SupabaseClient = supabase,
+): Promise<void> {
+  const { error } = await client
+    .from('clubs')
+    .update({ lat, lng })
+    .eq('id', clubId);
+
+  if (error) {
+    console.error(
+      `[clubRepository.updateClubCoords] Failed to persist coords for clubId=${clubId}:`,
+      error.message,
+    );
+    // Intentionally do not throw — see Decision Context above.
+  }
+}
+
+export const clubRepository = { listClubs, getClubById, updateClubCoords };

--- a/apps/backend/src/repositories/matchRepository.ts
+++ b/apps/backend/src/repositories/matchRepository.ts
@@ -114,6 +114,13 @@ export interface MatchFilterOptions {
   dateFrom?: string;
   dateTo?: string;
   search?: string;
+  /**
+   * Restrict to matches the given user joined. When set, the query inner-joins
+   * matchParticipants on `playerId = participantUserId`. Resolved at the service
+   * layer from `MatchFilters.onlyMine + ctx.user.id` — never trusted from the
+   * client directly.
+   */
+  participantUserId?: string;
 }
 
 // =====================================================
@@ -141,6 +148,38 @@ export async function getMatchesWithFilters(
   // If search is provided, we need to run parallel queries and merge
   if (filters.search) {
     return getMatchesWithSearch(filters, client);
+  }
+
+  // Decision Context: "onlyMine" filter via two-step lookup
+  // - The repo could inner-join matchParticipants on playerId, but PostgREST then drops the
+  //   `matchParticipants(count)` aggregate (you can't request both a filter and a count on
+  //   the same relation cleanly). Without the aggregate the list cards would show 0/10
+  //   players for past matches the user actually played in.
+  // - Two-step approach: (1) fetch the user's participated matchIds, (2) constrain the main
+  //   query with `.in('id', ids)`. Keeps `matchParticipants(count)` intact so slot counts
+  //   remain accurate. Adds one extra round-trip per request, acceptable at our scale
+  //   (< few hundred matches per user, single roundtrip cost is small).
+  // - Authorization: the resolver enforces that participantUserId equals ctx.user.id, so
+  //   anonymous callers cannot enumerate other users' match history through this path.
+  // - Edge case: if the user has zero participations, the IN clause receives an empty array.
+  //   Supabase `.in('id', [])` returns an empty result set, which is the correct behavior.
+  let participatedMatchIds: string[] | null = null;
+  if (filters.participantUserId) {
+    const { data: participantRows, error: partError } = await client
+      .from('matchParticipants')
+      .select('matchId')
+      .eq('playerId', filters.participantUserId);
+    if (partError) {
+      console.error(
+        `[matchRepository.getMatchesWithFilters] Failed to fetch participated matchIds for userId=${filters.participantUserId}:`,
+        partError.message,
+      );
+      throw new Error(partError.message);
+    }
+    participatedMatchIds = (participantRows ?? []).map((row) => row.matchId as string);
+    if (participatedMatchIds.length === 0) {
+      return [];
+    }
   }
 
   // Standard query without search
@@ -175,6 +214,10 @@ export async function getMatchesWithFilters(
     query = query.lte('scheduledAt', filters.dateTo);
   }
 
+  if (participatedMatchIds) {
+    query = query.in('id', participatedMatchIds);
+  }
+
   // Order by scheduled date
   query = query.order('scheduledAt', { ascending: true });
 
@@ -204,6 +247,28 @@ async function getMatchesWithSearch(
 ): Promise<MatchWithClub[]> {
   const searchTerm = `%${filters.search}%`;
 
+  // When filtering by participation, fetch the user's matchIds first and constrain
+  // the main queries with `.in('id', ids)`. Same rationale as getMatchesWithFilters —
+  // preserves the matchParticipants(count) aggregate for accurate slot counts.
+  let participatedMatchIds: string[] | null = null;
+  if (filters.participantUserId) {
+    const { data: participantRows, error: partError } = await client
+      .from('matchParticipants')
+      .select('matchId')
+      .eq('playerId', filters.participantUserId);
+    if (partError) {
+      console.error(
+        `[matchRepository.getMatchesWithSearch] Failed to fetch participated matchIds for userId=${filters.participantUserId}:`,
+        partError.message,
+      );
+      throw new Error(partError.message);
+    }
+    participatedMatchIds = (participantRows ?? []).map((row) => row.matchId as string);
+    if (participatedMatchIds.length === 0) {
+      return [];
+    }
+  }
+
   // Query 1: Search in match description
   let descriptionQuery = client
     .from('matches')
@@ -218,6 +283,9 @@ async function getMatchesWithSearch(
   }
   if (filters.dateTo) {
     descriptionQuery = descriptionQuery.lte('scheduledAt', filters.dateTo);
+  }
+  if (participatedMatchIds) {
+    descriptionQuery = descriptionQuery.in('id', participatedMatchIds);
   }
 
   const descriptionQueryWithSearch = descriptionQuery
@@ -238,6 +306,9 @@ async function getMatchesWithSearch(
   }
   if (filters.dateTo) {
     clubQuery = clubQuery.lte('scheduledAt', filters.dateTo);
+  }
+  if (participatedMatchIds) {
+    clubQuery = clubQuery.in('id', participatedMatchIds);
   }
 
   const clubQueryWithSearch = clubQuery
@@ -263,6 +334,9 @@ async function getMatchesWithSearch(
     }
     if (filters.dateTo) {
       descriptionZoneQuery = descriptionZoneQuery.lte('scheduledAt', filters.dateTo);
+    }
+    if (participatedMatchIds) {
+      descriptionZoneQuery = descriptionZoneQuery.in('id', participatedMatchIds);
     }
 
     q1 = descriptionZoneQuery

--- a/apps/backend/src/services/geocodingService.ts
+++ b/apps/backend/src/services/geocodingService.ts
@@ -1,0 +1,226 @@
+/**
+ * Geocoding Service — convert street addresses to lat/lng using OpenStreetMap Nominatim.
+ *
+ * Decision Context:
+ * - Why Nominatim: free, no API key, matches the OSM tile provider already used by the
+ *   match map (visual + licensing consistency). Mapbox/Google would add billing setup
+ *   and a key-management story we don't need at current scale.
+ * - Why server-side: addresses are stored in `clubs.address` and we need to display pins
+ *   on /partidos. Geocoding on the client would require shipping each address to the
+ *   browser plus dealing with CORS to Nominatim from end-user devices, which is exactly
+ *   the abuse pattern Nominatim's policy forbids. The backend can rate-limit + cache.
+ * - Persistence path: callers (matchService) write the geocoded result back into
+ *   `clubs.lat`/`clubs.lng` so the next read served from DB already has coords. Redis
+ *   acts as a short-circuit between the Supabase update and the read of a fresh club row.
+ * - Rate limiting: Nominatim's usage policy requires <= 1 request/second from a single
+ *   source plus a descriptive User-Agent. We serialize calls through a promise chain so
+ *   bursts (e.g. cache-miss on 5 unique clubs) become a controlled trickle. The chain is
+ *   per-process — at our current scale a single backend instance is fine; if we scale
+ *   horizontally we'll need a Redis-based token bucket.
+ * - Cache TTL: 30 days. Addresses don't move and Nominatim explicitly asks for
+ *   "aggressive caching". DB persistence dominates anyway — Redis is a safety net for
+ *   addresses that fail to persist (e.g. transient Supabase error).
+ * - Failure mode: returns `null` on any error so callers can fall through gracefully.
+ *   The map already filters clubs without coords, so a failed geocode just keeps the
+ *   pre-existing "no pin" behavior. Errors are logged but never propagated.
+ * - Dedup: `geocodeAddresses` collapses identical addresses before the network calls so
+ *   a list of 50 matches at 3 unique clubs costs at most 3 Nominatim hits.
+ * - Country bias: hardcoded to Uruguay (`countrycodes=uy`) because the platform launched
+ *   there and ambiguous toponyms (e.g. "Las Acacias") otherwise resolve to the wrong country.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { cacheGet, cacheSet, CACHE_PREFIX, CACHE_TTL } from '../config/redis.js';
+
+// =====================================================
+// Configuration
+// =====================================================
+
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org/search';
+// Nominatim policy: identify the application + a contact path. Update if the project
+// changes domain — operators may block User-Agents that look generic.
+const USER_AGENT = 'SumateYa/1.0 (https://sumateya.app)';
+// Slightly above 1s to stay safely under the "max 1 req/s" policy even with clock skew.
+const MIN_INTERVAL_MS = 1100;
+const REQUEST_TIMEOUT_MS = 5000;
+// Country bias: Uruguay only — see Decision Context.
+const COUNTRY_CODES = 'uy';
+
+// =====================================================
+// Types
+// =====================================================
+
+export interface GeoCoords {
+  lat: number;
+  lng: number;
+}
+
+interface NominatimHit {
+  lat: string;
+  lon: string;
+}
+
+// =====================================================
+// Rate limiter (per-process serial queue)
+// =====================================================
+
+let lastCallAt = 0;
+let chain: Promise<unknown> = Promise.resolve();
+
+/**
+ * Serialize Nominatim calls and enforce ≥ MIN_INTERVAL_MS between requests.
+ * Each call appends to the chain so concurrent callers automatically queue.
+ */
+function enqueue<T>(task: () => Promise<T>): Promise<T> {
+  const next = chain.then(async () => {
+    const wait = lastCallAt + MIN_INTERVAL_MS - Date.now();
+    if (wait > 0) {
+      await new Promise((r) => setTimeout(r, wait));
+    }
+    try {
+      return await task();
+    } finally {
+      lastCallAt = Date.now();
+    }
+  });
+  // Keep the chain alive even if a task rejects — otherwise a single failure would
+  // poison every subsequent enqueue.
+  chain = next.catch(() => undefined);
+  return next;
+}
+
+// =====================================================
+// Helpers
+// =====================================================
+
+function normalizeAddress(address: string): string {
+  return address.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function geocodeCacheKey(address: string): string {
+  // Short, stable, URL-safe encoding of the normalized address.
+  // Base64url keeps Redis keys human-readable enough for ops while bounding length.
+  const normalized = normalizeAddress(address);
+  return `${CACHE_PREFIX.GEOCODE}${Buffer.from(normalized).toString('base64url')}`;
+}
+
+async function callNominatim(address: string): Promise<GeoCoords | null> {
+  const url = new URL(NOMINATIM_URL);
+  url.searchParams.set('format', 'json');
+  url.searchParams.set('q', address);
+  url.searchParams.set('limit', '1');
+  url.searchParams.set('countrycodes', COUNTRY_CODES);
+  url.searchParams.set('addressdetails', '0');
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'application/json',
+      },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.warn(
+        `[geocodingService.callNominatim] Non-OK response status=${res.status} address="${address}"`,
+      );
+      return null;
+    }
+    const json = (await res.json()) as NominatimHit[];
+    const hit = json[0];
+    if (!hit) return null;
+    const lat = Number(hit.lat);
+    const lng = Number(hit.lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+    return { lat, lng };
+  } catch (error) {
+    console.warn(
+      `[geocodingService.callNominatim] Fetch failed for address="${address}":`,
+      error instanceof Error ? error.message : String(error),
+    );
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// =====================================================
+// Public API
+// =====================================================
+
+/**
+ * Geocode a single address. Returns `null` on missing input or network failure so
+ * callers can fall through without throwing.
+ */
+export async function geocodeAddress(address: string | null | undefined): Promise<GeoCoords | null> {
+  if (!address || !address.trim()) return null;
+
+  const key = geocodeCacheKey(address);
+  const cached = await cacheGet<GeoCoords | null>(key);
+  if (cached !== null) return cached;
+
+  const coords = await enqueue(() => callNominatim(address));
+
+  // Cache both hits and explicit misses. Caching the miss avoids re-hitting Nominatim
+  // every 3 minutes (matches list TTL) for an address that doesn't resolve. We use a
+  // shorter TTL on misses so a fixed/refined address gets picked up within a day.
+  if (coords) {
+    await cacheSet(key, coords, CACHE_TTL.GEOCODING);
+  } else {
+    await cacheSet(key, null, CACHE_TTL.SINGLE_ENTITY);
+  }
+
+  return coords;
+}
+
+/**
+ * Geocode multiple addresses, deduplicating identical ones so the network/rate-limit
+ * cost scales with the unique-address count instead of the input length.
+ *
+ * Returns a Map keyed by the original (un-normalized) input string the caller passed in,
+ * so callers can map back without re-running normalizeAddress.
+ */
+export async function geocodeAddresses(
+  addresses: ReadonlyArray<string | null | undefined>,
+): Promise<Map<string, GeoCoords | null>> {
+  const result = new Map<string, GeoCoords | null>();
+  const uniques = new Map<string, string>(); // normalized -> original
+
+  for (const a of addresses) {
+    if (!a || !a.trim()) continue;
+    const norm = normalizeAddress(a);
+    if (!uniques.has(norm)) {
+      uniques.set(norm, a);
+    }
+  }
+
+  // Resolve each unique address sequentially through the rate-limited queue.
+  // Promise.all is fine: enqueue() serializes the actual network calls internally.
+  const entries = await Promise.all(
+    Array.from(uniques.values()).map(async (original) => {
+      const coords = await geocodeAddress(original);
+      return [original, coords] as const;
+    }),
+  );
+
+  // Map back to ALL inputs (preserves duplicates pointing to the same coords).
+  const normToCoords = new Map<string, GeoCoords | null>();
+  for (const [original, coords] of entries) {
+    normToCoords.set(normalizeAddress(original), coords);
+  }
+  for (const a of addresses) {
+    if (!a || !a.trim()) continue;
+    const norm = normalizeAddress(a);
+    result.set(a, normToCoords.get(norm) ?? null);
+  }
+
+  return result;
+}
+
+export const geocodingService = {
+  geocodeAddress,
+  geocodeAddresses,
+};

--- a/apps/backend/src/services/matchResultVoteService.test.ts
+++ b/apps/backend/src/services/matchResultVoteService.test.ts
@@ -1,0 +1,605 @@
+/**
+ * Tests for matchResultVoteService
+ *
+ * Decision Context:
+ * - Why: Cover the propose/vote/list flows that power the result-confirmation modal
+ *   so future refactors do not regress the majority rule, status guards, participant
+ *   gating, or cache-invalidation contract documented in the service file.
+ * - Strategy: Mock the repository and the redis cache helpers so the tests focus on
+ *   service-level business logic — DTO mapping, Zod validation, majority threshold,
+ *   and side-effect orchestration. The repository itself is exercised by integration
+ *   tests against Supabase, not here.
+ * - Edge cases covered:
+ *   - Missing auth / missing user-scoped client
+ *   - Zod boundaries: negative scores, scores above 99, invalid UUID, invalid vote enum
+ *   - Match not found / cancelled match guard for both propose and vote
+ *   - Non-participant rejection on propose, vote, and list
+ *   - Submission not pending (already confirmed/rejected) → vote rejected
+ *   - Winner derivation from scores (A wins, B wins, draw)
+ *   - Explicit winnerTeam mismatching scores → rejected
+ *   - Strict majority boundary: approveCount == half does NOT confirm; > half does
+ *   - statusChanged true only on the vote that crosses the threshold
+ *   - Reject vote never triggers confirmation even when approveCount is high
+ *   - Cache invalidation on propose, on vote, and on confirmation cascade
+ *   - hasUserVoted / userVote computed per caller in DTO
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const repoMock = vi.hoisted(() => ({
+  getMatchStatus: vi.fn(),
+  isParticipant: vi.fn(),
+  getSubmissionsByMatch: vi.fn(),
+  getSubmissionById: vi.fn(),
+  createSubmission: vi.fn(),
+  upsertVote: vi.fn(),
+  countApproveVotes: vi.fn(),
+  countMatchParticipants: vi.fn(),
+  confirmSubmission: vi.fn(),
+  rejectOtherSubmissions: vi.fn(),
+  updateMatchWithResult: vi.fn(),
+  getParticipantIds: vi.fn(),
+}));
+
+const cacheMock = vi.hoisted(() => ({
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn(),
+  cacheGetOrSet: vi.fn(),
+  cacheDelete: vi.fn(),
+  cacheDeletePattern: vi.fn(),
+}));
+
+vi.mock('../repositories/matchResultVoteRepository.js', () => ({
+  matchResultVoteRepository: repoMock,
+}));
+
+vi.mock('../config/redis.js', () => ({
+  cacheGet: cacheMock.cacheGet,
+  cacheSet: cacheMock.cacheSet,
+  cacheGetOrSet: cacheMock.cacheGetOrSet,
+  cacheDelete: cacheMock.cacheDelete,
+  cacheDeletePattern: cacheMock.cacheDeletePattern,
+  CACHE_PREFIX: {
+    MATCH_PARTICIPANTS: 'match:participants:',
+    MATCH_DETAIL: 'match:',
+    MATCHES_OPEN: 'matches:open',
+    MATCHES_LIST: 'matches:list',
+    USER_MATCHES: 'user:matches:',
+  },
+  CACHE_TTL: {
+    USER_DATA: 300,
+  },
+}));
+
+import { matchResultVoteService } from './matchResultVoteService.js';
+import { SubmissionStatus, VoteValue, WinnerTeam } from '../graphql/generated/graphql.js';
+
+// Valid hex-format UUIDs that match our permissive uuidSchema regex.
+const MATCH_ID = 'a1111111-1111-1111-1111-111111111111';
+const USER_ID = 'b2222222-2222-2222-2222-222222222222';
+const OTHER_USER_ID = 'c3333333-3333-3333-3333-333333333333';
+const SUBMISSION_ID = 'd4444444-4444-4444-4444-444444444444';
+const OTHER_SUBMISSION_ID = 'e5555555-5555-5555-5555-555555555555';
+
+const supabaseStub = { __scoped: true } as unknown as import('@supabase/supabase-js').SupabaseClient;
+
+const baseCtx = () => ({ userId: USER_ID, supabase: supabaseStub });
+
+function buildSubmissionRow(overrides: Partial<{
+  id: string;
+  matchId: string;
+  submitterId: string;
+  scoreTeamA: number;
+  scoreTeamB: number;
+  winningTeam: 'a' | 'b' | 'draw';
+  submissionStatus: 'pending' | 'confirmed' | 'rejected';
+  votes: Array<{ voterId: string; vote: 'approve' | 'reject' }>;
+}> = {}) {
+  const votes = (overrides.votes ?? []).map((v, i) => ({
+    id: `vote-${i}`,
+    submissionId: overrides.id ?? SUBMISSION_ID,
+    voterId: v.voterId,
+    vote: v.vote,
+    createdAt: '2026-05-04T00:00:00Z',
+    profiles: { id: v.voterId, displayName: `Player ${v.voterId.slice(0, 4)}`, avatarUrl: null },
+  }));
+
+  return {
+    id: overrides.id ?? SUBMISSION_ID,
+    matchId: overrides.matchId ?? MATCH_ID,
+    submitterId: overrides.submitterId ?? USER_ID,
+    scoreTeamA: overrides.scoreTeamA ?? 3,
+    scoreTeamB: overrides.scoreTeamB ?? 1,
+    winningTeam: overrides.winningTeam ?? 'a',
+    submissionStatus: overrides.submissionStatus ?? 'pending',
+    isConfirmed: false,
+    createdAt: '2026-05-04T00:00:00Z',
+    profiles: { id: overrides.submitterId ?? USER_ID, displayName: 'Submitter', avatarUrl: null },
+    matchResultVotes: votes,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  repoMock.getMatchStatus.mockResolvedValue({ id: MATCH_ID, status: 'open' });
+  repoMock.isParticipant.mockResolvedValue(true);
+  repoMock.createSubmission.mockResolvedValue(buildSubmissionRow());
+  repoMock.upsertVote.mockResolvedValue(undefined);
+  repoMock.countApproveVotes.mockResolvedValue(1);
+  repoMock.countMatchParticipants.mockResolvedValue(5);
+  repoMock.confirmSubmission.mockResolvedValue(undefined);
+  repoMock.rejectOtherSubmissions.mockResolvedValue(undefined);
+  repoMock.updateMatchWithResult.mockResolvedValue(undefined);
+  repoMock.getParticipantIds.mockResolvedValue([USER_ID, OTHER_USER_ID]);
+  repoMock.getSubmissionsByMatch.mockResolvedValue([]);
+  repoMock.getSubmissionById.mockResolvedValue(buildSubmissionRow());
+
+  cacheMock.cacheGetOrSet.mockImplementation(async (_key: string, loader: () => unknown) => loader());
+  cacheMock.cacheDelete.mockResolvedValue(undefined);
+  cacheMock.cacheDeletePattern.mockResolvedValue(undefined);
+});
+
+describe('matchResultVoteService.proposeMatchResult', () => {
+  it('creates a submission, derives winner=A from scores, and invalidates the submissions cache', async () => {
+    const result = await matchResultVoteService.proposeMatchResult(
+      { matchId: MATCH_ID, scoreA: 3, scoreB: 1 },
+      baseCtx(),
+    );
+
+    expect(repoMock.getMatchStatus).toHaveBeenCalledWith(MATCH_ID);
+    expect(repoMock.isParticipant).toHaveBeenCalledWith(MATCH_ID, USER_ID);
+    expect(repoMock.createSubmission).toHaveBeenCalledWith(
+      {
+        matchId: MATCH_ID,
+        submitterId: USER_ID,
+        scoreTeamA: 3,
+        scoreTeamB: 1,
+        winningTeam: 'a',
+      },
+      supabaseStub,
+    );
+    expect(cacheMock.cacheDelete).toHaveBeenCalledWith(`match:submissions:${MATCH_ID}`);
+    expect(result.scoreA).toBe(3);
+    expect(result.scoreB).toBe(1);
+    expect(result.winnerTeam).toBe(WinnerTeam.A);
+    expect(result.status).toBe(SubmissionStatus.Pending);
+  });
+
+  it('derives winner=B when scoreB > scoreA', async () => {
+    repoMock.createSubmission.mockResolvedValueOnce(
+      buildSubmissionRow({ scoreTeamA: 0, scoreTeamB: 2, winningTeam: 'b' }),
+    );
+
+    await matchResultVoteService.proposeMatchResult(
+      { matchId: MATCH_ID, scoreA: 0, scoreB: 2 },
+      baseCtx(),
+    );
+
+    expect(repoMock.createSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ winningTeam: 'b' }),
+      supabaseStub,
+    );
+  });
+
+  it('derives winner=draw on a 0-0 tie', async () => {
+    repoMock.createSubmission.mockResolvedValueOnce(
+      buildSubmissionRow({ scoreTeamA: 0, scoreTeamB: 0, winningTeam: 'draw' }),
+    );
+
+    await matchResultVoteService.proposeMatchResult(
+      { matchId: MATCH_ID, scoreA: 0, scoreB: 0 },
+      baseCtx(),
+    );
+
+    expect(repoMock.createSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ winningTeam: 'draw' }),
+      supabaseStub,
+    );
+  });
+
+  it('accepts an explicit winnerTeam that matches the scores', async () => {
+    await matchResultVoteService.proposeMatchResult(
+      { matchId: MATCH_ID, scoreA: 3, scoreB: 1, winnerTeam: WinnerTeam.A },
+      baseCtx(),
+    );
+
+    expect(repoMock.createSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ winningTeam: 'a' }),
+      supabaseStub,
+    );
+  });
+
+  it('rejects an explicit winnerTeam that does not match the scores', async () => {
+    await expect(
+      matchResultVoteService.proposeMatchResult(
+        { matchId: MATCH_ID, scoreA: 3, scoreB: 1, winnerTeam: WinnerTeam.B },
+        baseCtx(),
+      ),
+    ).rejects.toThrow('El ganador indicado no coincide con el marcador');
+
+    expect(repoMock.createSubmission).not.toHaveBeenCalled();
+  });
+
+  it('throws when caller is not authenticated', async () => {
+    await expect(
+      matchResultVoteService.proposeMatchResult(
+        { matchId: MATCH_ID, scoreA: 1, scoreB: 0 },
+        { supabase: supabaseStub },
+      ),
+    ).rejects.toThrow('Se requiere autenticación');
+
+    expect(repoMock.getMatchStatus).not.toHaveBeenCalled();
+  });
+
+  it('throws when caller has no user-scoped Supabase client', async () => {
+    await expect(
+      matchResultVoteService.proposeMatchResult(
+        { matchId: MATCH_ID, scoreA: 1, scoreB: 0 },
+        { userId: USER_ID },
+      ),
+    ).rejects.toThrow('Se requiere cliente con contexto de usuario');
+  });
+
+  it('rejects negative scores via Zod', async () => {
+    await expect(
+      matchResultVoteService.proposeMatchResult(
+        { matchId: MATCH_ID, scoreA: -1, scoreB: 0 },
+        baseCtx(),
+      ),
+    ).rejects.toThrow();
+
+    expect(repoMock.createSubmission).not.toHaveBeenCalled();
+  });
+
+  it('rejects scores above the 99 cap via Zod', async () => {
+    await expect(
+      matchResultVoteService.proposeMatchResult(
+        { matchId: MATCH_ID, scoreA: 100, scoreB: 0 },
+        baseCtx(),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('rejects an invalid matchId via Zod', async () => {
+    await expect(
+      matchResultVoteService.proposeMatchResult(
+        { matchId: 'not-a-uuid', scoreA: 1, scoreB: 0 },
+        baseCtx(),
+      ),
+    ).rejects.toThrow();
+
+    expect(repoMock.getMatchStatus).not.toHaveBeenCalled();
+  });
+
+  it('throws when the match does not exist', async () => {
+    repoMock.getMatchStatus.mockResolvedValueOnce(null);
+
+    await expect(
+      matchResultVoteService.proposeMatchResult(
+        { matchId: MATCH_ID, scoreA: 1, scoreB: 0 },
+        baseCtx(),
+      ),
+    ).rejects.toThrow('Partido no encontrado');
+
+    expect(repoMock.isParticipant).not.toHaveBeenCalled();
+  });
+
+  it('throws when the match is cancelled', async () => {
+    repoMock.getMatchStatus.mockResolvedValueOnce({ id: MATCH_ID, status: 'cancelled' });
+
+    await expect(
+      matchResultVoteService.proposeMatchResult(
+        { matchId: MATCH_ID, scoreA: 1, scoreB: 0 },
+        baseCtx(),
+      ),
+    ).rejects.toThrow('El partido fue cancelado, no se pueden proponer ni votar resultados');
+
+    expect(repoMock.isParticipant).not.toHaveBeenCalled();
+  });
+
+  it('throws when caller is not a participant', async () => {
+    repoMock.isParticipant.mockResolvedValueOnce(false);
+
+    await expect(
+      matchResultVoteService.proposeMatchResult(
+        { matchId: MATCH_ID, scoreA: 1, scoreB: 0 },
+        baseCtx(),
+      ),
+    ).rejects.toThrow('Solo los participantes del partido pueden proponer resultados');
+
+    expect(repoMock.createSubmission).not.toHaveBeenCalled();
+  });
+});
+
+describe('matchResultVoteService.voteMatchResult', () => {
+  beforeEach(() => {
+    repoMock.getSubmissionById.mockResolvedValue(
+      buildSubmissionRow({ submissionStatus: 'pending' }),
+    );
+  });
+
+  it('records an APPROVE vote without confirming when below strict majority', async () => {
+    repoMock.countApproveVotes.mockResolvedValueOnce(2); // 2/5 → not > 2.5
+    repoMock.countMatchParticipants.mockResolvedValueOnce(5);
+
+    const result = await matchResultVoteService.voteMatchResult(
+      { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+      baseCtx(),
+    );
+
+    expect(repoMock.upsertVote).toHaveBeenCalledWith(
+      SUBMISSION_ID,
+      USER_ID,
+      'approve',
+      supabaseStub,
+    );
+    expect(repoMock.confirmSubmission).not.toHaveBeenCalled();
+    expect(repoMock.rejectOtherSubmissions).not.toHaveBeenCalled();
+    expect(repoMock.updateMatchWithResult).not.toHaveBeenCalled();
+    expect(result.statusChanged).toBe(false);
+    expect(cacheMock.cacheDelete).toHaveBeenCalledWith(`match:submissions:${MATCH_ID}`);
+  });
+
+  it('does NOT confirm at the boundary where approveCount == participants/2 (strict majority required)', async () => {
+    // 4 participants, 2 approves → 2 > 2 is false → no confirmation.
+    repoMock.countApproveVotes.mockResolvedValueOnce(2);
+    repoMock.countMatchParticipants.mockResolvedValueOnce(4);
+
+    const result = await matchResultVoteService.voteMatchResult(
+      { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+      baseCtx(),
+    );
+
+    expect(repoMock.confirmSubmission).not.toHaveBeenCalled();
+    expect(result.statusChanged).toBe(false);
+  });
+
+  it('confirms the submission when approveCount crosses the strict majority threshold', async () => {
+    repoMock.countApproveVotes.mockResolvedValueOnce(3); // 3/5 → > 2.5
+    repoMock.countMatchParticipants.mockResolvedValueOnce(5);
+
+    const confirmed = buildSubmissionRow({ submissionStatus: 'confirmed' });
+    repoMock.getSubmissionById
+      .mockResolvedValueOnce(buildSubmissionRow({ submissionStatus: 'pending' })) // initial load
+      .mockResolvedValueOnce(confirmed); // post-vote reload
+
+    const result = await matchResultVoteService.voteMatchResult(
+      { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+      baseCtx(),
+    );
+
+    expect(repoMock.confirmSubmission).toHaveBeenCalledWith(SUBMISSION_ID);
+    expect(repoMock.rejectOtherSubmissions).toHaveBeenCalledWith(MATCH_ID, SUBMISSION_ID);
+    expect(repoMock.updateMatchWithResult).toHaveBeenCalledWith(MATCH_ID, 3, 1, 'a');
+    expect(result.statusChanged).toBe(true);
+    expect(result.submission.status).toBe(SubmissionStatus.Confirmed);
+
+    // Match-level caches cleared
+    expect(cacheMock.cacheDelete).toHaveBeenCalledWith(`match:participants:${MATCH_ID}`);
+    expect(cacheMock.cacheDelete).toHaveBeenCalledWith(`match:${MATCH_ID}`);
+    expect(cacheMock.cacheDelete).toHaveBeenCalledWith('matches:open');
+    expect(cacheMock.cacheDeletePattern).toHaveBeenCalledWith('matches:list:*');
+
+    // Per-participant history caches cleared
+    expect(cacheMock.cacheDeletePattern).toHaveBeenCalledWith(`user:matches:${USER_ID}*`);
+    expect(cacheMock.cacheDeletePattern).toHaveBeenCalledWith(`user:matches:${OTHER_USER_ID}*`);
+
+    // Submission list cache cleared
+    expect(cacheMock.cacheDelete).toHaveBeenCalledWith(`match:submissions:${MATCH_ID}`);
+  });
+
+  it('does not confirm when the cast vote is REJECT, even if approveCount happens to be high', async () => {
+    repoMock.countApproveVotes.mockResolvedValueOnce(0);
+    repoMock.countMatchParticipants.mockResolvedValueOnce(5);
+
+    const result = await matchResultVoteService.voteMatchResult(
+      { submissionId: SUBMISSION_ID, vote: VoteValue.Reject },
+      baseCtx(),
+    );
+
+    expect(repoMock.upsertVote).toHaveBeenCalledWith(
+      SUBMISSION_ID,
+      USER_ID,
+      'reject',
+      supabaseStub,
+    );
+    expect(repoMock.confirmSubmission).not.toHaveBeenCalled();
+    expect(result.statusChanged).toBe(false);
+  });
+
+  it('throws when caller is not authenticated', async () => {
+    await expect(
+      matchResultVoteService.voteMatchResult(
+        { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+        { supabase: supabaseStub },
+      ),
+    ).rejects.toThrow('Se requiere autenticación');
+  });
+
+  it('throws when caller has no user-scoped client', async () => {
+    await expect(
+      matchResultVoteService.voteMatchResult(
+        { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+        { userId: USER_ID },
+      ),
+    ).rejects.toThrow('Se requiere cliente con contexto de usuario');
+  });
+
+  it('rejects an invalid submissionId via Zod', async () => {
+    await expect(
+      matchResultVoteService.voteMatchResult(
+        { submissionId: 'not-a-uuid', vote: VoteValue.Approve },
+        baseCtx(),
+      ),
+    ).rejects.toThrow();
+
+    expect(repoMock.getSubmissionById).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid vote value via Zod', async () => {
+    await expect(
+      matchResultVoteService.voteMatchResult(
+        { submissionId: SUBMISSION_ID, vote: 'MAYBE' as unknown as VoteValue },
+        baseCtx(),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('throws when the submission does not exist', async () => {
+    repoMock.getSubmissionById.mockResolvedValueOnce(null);
+
+    await expect(
+      matchResultVoteService.voteMatchResult(
+        { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+        baseCtx(),
+      ),
+    ).rejects.toThrow('Propuesta de resultado no encontrada');
+
+    expect(repoMock.upsertVote).not.toHaveBeenCalled();
+  });
+
+  it('throws when the match is cancelled', async () => {
+    repoMock.getMatchStatus.mockResolvedValueOnce({ id: MATCH_ID, status: 'cancelled' });
+
+    await expect(
+      matchResultVoteService.voteMatchResult(
+        { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+        baseCtx(),
+      ),
+    ).rejects.toThrow('El partido fue cancelado, no se pueden proponer ni votar resultados');
+
+    expect(repoMock.upsertVote).not.toHaveBeenCalled();
+  });
+
+  it('throws when the underlying match is missing (race with deletion)', async () => {
+    repoMock.getMatchStatus.mockResolvedValueOnce(null);
+
+    await expect(
+      matchResultVoteService.voteMatchResult(
+        { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+        baseCtx(),
+      ),
+    ).rejects.toThrow('Partido no encontrado');
+  });
+
+  it('throws when the submission is no longer pending', async () => {
+    repoMock.getSubmissionById.mockResolvedValueOnce(
+      buildSubmissionRow({ submissionStatus: 'rejected' }),
+    );
+
+    await expect(
+      matchResultVoteService.voteMatchResult(
+        { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+        baseCtx(),
+      ),
+    ).rejects.toThrow('Solo se puede votar en propuestas pendientes');
+
+    expect(repoMock.upsertVote).not.toHaveBeenCalled();
+  });
+
+  it('throws when caller is not a participant of the submission match', async () => {
+    repoMock.isParticipant.mockResolvedValueOnce(false);
+
+    await expect(
+      matchResultVoteService.voteMatchResult(
+        { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+        baseCtx(),
+      ),
+    ).rejects.toThrow('Solo los participantes del partido pueden votar');
+
+    expect(repoMock.upsertVote).not.toHaveBeenCalled();
+  });
+
+  it('throws if the post-vote reload returns null (data integrity guard)', async () => {
+    repoMock.getSubmissionById
+      .mockResolvedValueOnce(buildSubmissionRow({ submissionStatus: 'pending' }))
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      matchResultVoteService.voteMatchResult(
+        { submissionId: SUBMISSION_ID, vote: VoteValue.Approve },
+        baseCtx(),
+      ),
+    ).rejects.toThrow('Error al cargar la propuesta actualizada');
+  });
+});
+
+describe('matchResultVoteService.getMatchResultSubmissions', () => {
+  it('returns submissions and computes per-caller hasUserVoted/userVote', async () => {
+    repoMock.getSubmissionsByMatch.mockResolvedValueOnce([
+      buildSubmissionRow({
+        id: SUBMISSION_ID,
+        votes: [
+          { voterId: USER_ID, vote: 'approve' },
+          { voterId: OTHER_USER_ID, vote: 'reject' },
+        ],
+      }),
+    ]);
+
+    const submissions = await matchResultVoteService.getMatchResultSubmissions(MATCH_ID, baseCtx());
+
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0].approveCount).toBe(1);
+    expect(submissions[0].rejectCount).toBe(1);
+    expect(submissions[0].hasUserVoted).toBe(true);
+    expect(submissions[0].userVote).toBe(VoteValue.Approve);
+    expect(submissions[0].votes).toHaveLength(2);
+  });
+
+  it('returns hasUserVoted=false when caller has not voted', async () => {
+    repoMock.getSubmissionsByMatch.mockResolvedValueOnce([
+      buildSubmissionRow({
+        votes: [{ voterId: OTHER_USER_ID, vote: 'approve' }],
+      }),
+    ]);
+
+    const submissions = await matchResultVoteService.getMatchResultSubmissions(MATCH_ID, baseCtx());
+
+    expect(submissions[0].hasUserVoted).toBe(false);
+    expect(submissions[0].userVote).toBeNull();
+  });
+
+  it('uses the cache wrapper so repeated calls hit redis first', async () => {
+    repoMock.getSubmissionsByMatch.mockResolvedValueOnce([buildSubmissionRow()]);
+
+    await matchResultVoteService.getMatchResultSubmissions(MATCH_ID, baseCtx());
+
+    expect(cacheMock.cacheGetOrSet).toHaveBeenCalledWith(
+      `match:submissions:${MATCH_ID}`,
+      expect.any(Function),
+      300,
+    );
+  });
+
+  it('throws when caller is not authenticated', async () => {
+    await expect(
+      matchResultVoteService.getMatchResultSubmissions(MATCH_ID, {}),
+    ).rejects.toThrow('Se requiere autenticación');
+  });
+
+  it('rejects an invalid matchId via Zod', async () => {
+    await expect(
+      matchResultVoteService.getMatchResultSubmissions('not-a-uuid', baseCtx()),
+    ).rejects.toThrow();
+  });
+
+  it('throws when caller is not a participant', async () => {
+    repoMock.isParticipant.mockResolvedValueOnce(false);
+
+    await expect(
+      matchResultVoteService.getMatchResultSubmissions(MATCH_ID, baseCtx()),
+    ).rejects.toThrow('Solo los participantes del partido pueden ver los resultados propuestos');
+
+    expect(repoMock.getSubmissionsByMatch).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list when there are no submissions', async () => {
+    repoMock.getSubmissionsByMatch.mockResolvedValueOnce([]);
+
+    const submissions = await matchResultVoteService.getMatchResultSubmissions(MATCH_ID, baseCtx());
+
+    expect(submissions).toEqual([]);
+  });
+});

--- a/apps/backend/src/services/matchService.ts
+++ b/apps/backend/src/services/matchService.ts
@@ -26,6 +26,12 @@
  *   then past/cancelled below sorted DESC (most-recent first). Active matches must dominate
  *   the first screen.
  * - Uses generated GraphQL `Match` type so schema changes break this file at build time.
+ * - Geocoding backfill: clubs now store only the street address (lat/lng default to null).
+ *   `enrichWithCoords()` runs inside the cache fetcher of every read path that exposes the
+ *   club, geocoding missing addresses through Nominatim and persisting results back to the
+ *   `clubs` table so subsequent requests skip both the network call and the DB update. This
+ *   keeps the existing nullable lat/lng contract — failures (rate limits, unknown address)
+ *   leave coords null and the map filters them out, same as before.
  * - Previously fixed bugs: removed ad-hoc console.log debugging that ran on every request —
  *   those were left from initial scaffolding and polluted prod logs.
  */
@@ -55,8 +61,10 @@ import {
   type CompletedMatchRow,
 } from '../repositories/matchRepository.js';
 import { clubSlotRepository } from '../repositories/clubSlotRepository.js';
+import { clubRepository } from '../repositories/clubRepository.js';
 import { profileRepository } from '../repositories/profileRepository.js';
 import { dateToDayOfWeek } from './clubService.js';
+import { geocodeAddresses } from './geocodingService.js';
 import type { ServiceContext } from '../types/context.js';
 
 // =====================================================
@@ -152,9 +160,79 @@ function toMatch(row: MatchWithClub): Match {
 }
 
 /**
- * Convert GraphQL filters to repository filter options
+ * Backfill missing club coordinates by geocoding the stored address and persisting
+ * the result back to the `clubs` table.
+ *
+ * Decision Context:
+ * - Why here: the matches list is the canonical surface where pins are rendered. Doing
+ *   the lookup inside the cache fetcher means the enriched row is what gets cached, so
+ *   subsequent requests skip both the network call AND the DB update.
+ * - Why mutate in place: the rows are about to be cached and then mapped to GraphQL —
+ *   mutating `row.clubs.lat/lng` keeps the existing toMatch() pipeline unchanged.
+ * - Dedup: clubs that share an address (or appear in multiple matches in the same list)
+ *   resolve to one Nominatim call via geocodeAddresses().
+ * - Best-effort: any failure (network down, Nominatim 503, persist error) leaves
+ *   lat/lng null. The map already filters those clubs out, so the worst case is a
+ *   missing pin — never a 500 on the matches list.
+ * - Egress: we update at most once per club because we only call this when lat/lng are
+ *   null. After persistence, future cache misses fetch coords directly from Postgres.
+ * - Previously fixed bugs: none relevant.
  */
-function toFilterOptions(filters?: MatchFilters | null): MatchFilterOptions {
+async function enrichWithCoords<T extends { clubs: { id: string; address: string | null; lat: number | null; lng: number | null } | null }>(
+  rows: T[],
+): Promise<T[]> {
+  const targets = rows
+    .map((r) => r.clubs)
+    .filter(
+      (c): c is NonNullable<T['clubs']> =>
+        c !== null && c.lat == null && c.lng == null && !!c.address,
+    );
+
+  if (targets.length === 0) return rows;
+
+  const addresses = targets.map((c) => c.address as string);
+  const coordsByAddress = await geocodeAddresses(addresses);
+
+  // Track unique clubIds we've persisted in this call to avoid duplicate UPDATEs when
+  // the same club appears in many list rows.
+  const persisted = new Set<string>();
+
+  for (const row of rows) {
+    const club = row.clubs;
+    if (!club || club.lat != null || club.lng != null || !club.address) continue;
+
+    const coords = coordsByAddress.get(club.address);
+    if (!coords) continue;
+
+    club.lat = coords.lat;
+    club.lng = coords.lng;
+
+    if (!persisted.has(club.id)) {
+      persisted.add(club.id);
+      // Fire-and-await: we already have the coords; the persist is best-effort and
+      // logs internally on failure so it's safe to await without try/catch here.
+      await clubRepository.updateClubCoords(club.id, coords.lat, coords.lng);
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Convert GraphQL filters to repository filter options.
+ *
+ * Decision Context:
+ * - `onlyMine` (boolean) is resolved against the authenticated `userId` here so the
+ *   repository receives a concrete `participantUserId` string. This indirection ensures
+ *   anonymous callers cannot enumerate other players' history — the flag is silently
+ *   ignored when no userId is available.
+ * - We deliberately do NOT trust a client-supplied user id; the only source of truth is
+ *   the resolver's `requireAuth` / `ctx.user.id`.
+ */
+function toFilterOptions(
+  filters?: MatchFilters | null,
+  userId?: string,
+): MatchFilterOptions {
   if (!filters) return { status: 'open' };
 
   return {
@@ -164,11 +242,18 @@ function toFilterOptions(filters?: MatchFilters | null): MatchFilterOptions {
     dateFrom: filters.dateFrom ?? undefined,
     dateTo: filters.dateTo ?? undefined,
     search: filters.search ?? undefined,
+    participantUserId: filters.onlyMine && userId ? userId : undefined,
   };
 }
 
 /**
- * Generate cache key from filters
+ * Generate cache key from filters.
+ *
+ * Decision Context:
+ * - `participantUserId` enters the key when present so two users with different
+ *   "Solo los míos" results never collide on a shared cache slot. The non-mine path
+ *   keeps its previous global key, so the public listing still benefits from a single
+ *   shared cache entry across all anonymous and authenticated callers.
  */
 function getFiltersCacheKey(filters: MatchFilterOptions): string {
   const parts = [
@@ -178,6 +263,7 @@ function getFiltersCacheKey(filters: MatchFilterOptions): string {
     filters.dateFrom ? `from:${filters.dateFrom}` : '',
     filters.dateTo ? `to:${filters.dateTo}` : '',
     filters.search ? `search:${filters.search}` : '',
+    filters.participantUserId ? `mine:${filters.participantUserId}` : '',
   ].filter(Boolean);
 
   return `${CACHE_PREFIX.MATCHES_LIST}:${parts.join('|')}`;
@@ -196,15 +282,20 @@ function getFiltersCacheKey(filters: MatchFilterOptions): string {
  * - Previously fixed bugs: none relevant.
  */
 export async function listMatches(
-  _ctx: ServiceContext,
+  ctx: ServiceContext,
   filters?: MatchFilters | null,
 ): Promise<Match[]> {
-  const filterOptions = toFilterOptions(filters);
+  const filterOptions = toFilterOptions(filters, ctx.userId);
   const cacheKey = getFiltersCacheKey(filterOptions);
 
   const matches = await cacheGetOrSet<MatchWithClub[]>(
     cacheKey,
-    () => matchRepository.getMatchesWithFilters(filterOptions),
+    async () => {
+      const rows = await matchRepository.getMatchesWithFilters(filterOptions);
+      // Geocode + persist coords for clubs missing lat/lng so map pins render.
+      // Runs inside the cache fetcher so the enriched rows are what get cached.
+      return enrichWithCoords(rows);
+    },
     CACHE_TTL.DYNAMIC_DATA,
   );
 
@@ -251,7 +342,12 @@ export async function getMatchById(_ctx: ServiceContext, id: string): Promise<Ma
   const cacheKey = `${CACHE_PREFIX.MATCH_DETAIL}${id}`;
   const match = await cacheGetOrSet<MatchWithClub | null>(
     cacheKey,
-    () => matchRepository.getMatchById(id),
+    async () => {
+      const row = await matchRepository.getMatchById(id);
+      if (!row) return null;
+      const [enriched] = await enrichWithCoords([row]);
+      return enriched ?? row;
+    },
     CACHE_TTL.SINGLE_ENTITY,
   );
   return match ? toMatch(match) : null;
@@ -364,7 +460,12 @@ export async function getMatchDetail(ctx: ServiceContext, id: string): Promise<M
 
   const row = await cacheGetOrSet<MatchDetailRow | null>(
     cacheKey,
-    () => matchRepository.getMatchWithParticipants(id),
+    async () => {
+      const fetched = await matchRepository.getMatchWithParticipants(id);
+      if (!fetched) return null;
+      const [enriched] = await enrichWithCoords([fetched]);
+      return enriched ?? fetched;
+    },
     CACHE_TTL.DYNAMIC_DATA,
   );
 

--- a/apps/frontend/src/components/matches/MatchList.tsx
+++ b/apps/frontend/src/components/matches/MatchList.tsx
@@ -2,12 +2,23 @@
  * MatchList Component - Displays a grid of match cards with instant filtering.
  *
  * Decision Context:
- * - Loads the open match dataset once, then filters locally for immediate UX.
- * - Backend GraphQL filters remain available for larger datasets and map/list parity.
- * - Can render its own filters, or receive controlled filters from MatchesView.
- * - Empty state distinguishes "no open matches at all" (matches.length === 0) from
- *   "matches exist but all are hidden by filters" (visibleMatches.length === 0) so
- *   players know whether to wait or to adjust their search.
+ * - Loads the relevant match dataset once per server-side dimension (status / onlyMine),
+ *   then filters locally for immediate UX. The server-side dimensions live in
+ *   `toServerMatchFilters`; everything else is applied client-side via `filterMatches`.
+ * - The fetch effect re-runs whenever the server-side dimensions change (timeframe or
+ *   onlyMine), so switching tabs in MatchesView triggers a fresh request. Local filters
+ *   like search/format/zone do NOT cause a refetch — they apply to the cached dataset.
+ * - Empty state distinguishes three cases:
+ *   • no matches at all in the timeframe (matches.length === 0)
+ *   • matches exist but all hidden by local filters (visibleMatches.length === 0)
+ *   • Pasados + Solo los míos with zero results (handled by the empty timeframe path,
+ *     copy is generic enough to cover both cases without a third branch)
+ *   so players know whether to wait or to adjust their search.
+ * - Previously fixed bugs:
+ *   - The fetch effect originally hardcoded DEFAULT_MATCH_FILTERS, which made the list
+ *     ignore timeframe/onlyMine changes. Switching to "Pasados" appeared to do nothing
+ *     because the backing dataset never refreshed. Fixed by depending on the serialized
+ *     server filters in the effect.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -50,26 +61,37 @@ export function MatchList({
     useState<ClientMatchFilters>(DEFAULT_MATCH_FILTERS);
 
   const filters = controlledFilters ?? internalFilters;
-
-  const fetchMatches = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await executeQuery<{ matches: Match[] }>(GET_MATCHES, {
-        filters: toServerMatchFilters(DEFAULT_MATCH_FILTERS),
-      });
-      setMatches(data.matches);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Error al cargar partidos');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const serverFilters = useMemo(() => toServerMatchFilters(filters), [filters]);
+  // Stable fingerprint of the server-side dimensions; the fetch effect refreshes whenever
+  // this value changes (e.g. timeframe upcoming↔past or onlyMine on/off).
+  const serverFiltersKey = useMemo(() => JSON.stringify(serverFilters), [serverFilters]);
 
   useEffect(() => {
     if (initialMatches) return;
-    fetchMatches();
-  }, [initialMatches, fetchMatches]);
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    executeQuery<{ matches: Match[] }>(GET_MATCHES, { filters: serverFilters })
+      .then((data) => {
+        if (!cancelled) setMatches(data.matches);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Error al cargar partidos');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // serverFiltersKey carries the only inputs that should re-trigger a fetch; serverFilters
+    // itself is stable across renders thanks to useMemo, but using the JSON key keeps the
+    // dependency array primitive and avoids a new fetch per render even if the memo cache
+    // is invalidated for unrelated reasons.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialMatches, serverFiltersKey]);
 
   const handleFiltersChange = useCallback(
     (newFilters: ClientMatchFilters) => {
@@ -112,11 +134,17 @@ export function MatchList({
 
       {!loading && !error && visibleMatches.length === 0 && (
         <div className="text-center py-12">
-          <p className="text-xl font-medium">No hay partidos disponibles</p>
+          <p className="text-xl font-medium">
+            {filters.timeframe === 'past' ? 'No hay partidos pasados' : 'No hay partidos disponibles'}
+          </p>
           <p className="text-muted-foreground mt-2">
             {matches.length > 0
               ? 'Ningún partido coincide con los filtros. Probá ajustando la búsqueda.'
-              : 'No hay partidos abiertos por el momento. Volvé más tarde.'}
+              : filters.timeframe === 'past'
+                ? filters.onlyMine
+                  ? 'Todavía no jugaste partidos. Cuando juegues alguno aparecerá acá.'
+                  : 'No hay historial de partidos finalizados.'
+                : 'No hay partidos abiertos por el momento. Volvé más tarde.'}
           </p>
         </div>
       )}

--- a/apps/frontend/src/components/matches/MatchMap.tsx
+++ b/apps/frontend/src/components/matches/MatchMap.tsx
@@ -201,14 +201,34 @@ export function MatchMap({ filters = DEFAULT_MATCH_FILTERS }: MatchMapProps) {
   );
   const mapStyle = useMemo(() => ({ height: mapHeight, width: '100%' }), [mapHeight]);
 
+  // Re-fetch when the server-side filter dimensions (status / onlyMine) change so
+  // the map respects timeframe + "Solo los míos" toggles from MatchesView. Local-only
+  // filters (format, zone, search, time range) keep applying via filterMatches without
+  // hitting the network — same architecture as MatchList.
+  const serverFilters = useMemo(() => toServerMatchFilters(filters), [filters]);
+  const serverFiltersKey = useMemo(() => JSON.stringify(serverFilters), [serverFilters]);
+
   useEffect(() => {
-    executeQuery<{ matches: Match[] }>(GET_MATCHES_WITH_COORDS, {
-      filters: toServerMatchFilters(DEFAULT_MATCH_FILTERS),
-    })
-      .then((data) => setMatches(data.matches))
-      .catch((err) => setError(err instanceof Error ? err.message : 'Error al cargar el mapa'))
-      .finally(() => setLoading(false));
-  }, []);
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    executeQuery<{ matches: Match[] }>(GET_MATCHES_WITH_COORDS, { filters: serverFilters })
+      .then((data) => {
+        if (!cancelled) setMatches(data.matches);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Error al cargar el mapa');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serverFiltersKey]);
 
   const filteredMatches = useMemo(() => filterMatches(matches, filters), [matches, filters]);
 

--- a/apps/frontend/src/components/matches/MatchesView.tsx
+++ b/apps/frontend/src/components/matches/MatchesView.tsx
@@ -9,11 +9,19 @@
  *   are cached in Redis, re-fetching on toggle is fast (< 2-3 ms service layer).
  * - Conditional unmount is preferred over CSS hide/show to avoid mounting Leaflet's
  *   DOM on pages where the map is never viewed — consistent with `client:visible` goals.
+ * - Timeframe (Próximos / Pasados): rendered as a segmented toggle above the filter
+ *   bar so users see and can switch the dataset before drilling in. Selecting Pasados
+ *   maps to `status=COMPLETED` server-side (see match-filtering.toServerMatchFilters)
+ *   and changes the dataset MatchList re-fetches. Filters and Lista/Mapa toggle keep
+ *   working identically across both timeframes — the only timeframe-specific UI is
+ *   the "Solo mis partidos" checkbox, which is rendered ONLY on Pasados AND only when
+ *   the user is authenticated, because the backend silently ignores `onlyMine` for
+ *   anonymous callers and exposing the toggle would deliver confusing empty results.
  * - Previously fixed bugs: none relevant.
  */
 
 import { useCallback, useEffect, useState, lazy, Suspense } from 'react';
-import { List, Map as MapIcon } from 'lucide-react';
+import { List, Map as MapIcon, Calendar, History } from 'lucide-react';
 import { MatchList } from './MatchList';
 import { MatchFilters } from './MatchFilters';
 import {
@@ -22,6 +30,7 @@ import {
   parseMatchFiltersFromSearch,
   writeMatchFiltersToUrl,
   type ClientMatchFilters,
+  type MatchTimeframe,
 } from '@/lib/match-filtering';
 
 // Lazy import — Leaflet uses browser-only APIs (window/document) and crashes in Node SSR
@@ -59,8 +68,75 @@ export function MatchesView({ isAuthenticated = false }: MatchesViewProps) {
     [urlReady],
   );
 
+  const timeframe: MatchTimeframe = filters.timeframe ?? 'upcoming';
+  const onlyMine = !!filters.onlyMine;
+
+  const handleTimeframeChange = useCallback(
+    (next: MatchTimeframe) => {
+      if (next === timeframe) return;
+      // Switching back to "upcoming" must drop onlyMine — that flag only applies on
+      // the past timeframe, and leaving it set would silently filter the upcoming list
+      // by participation as soon as the user re-enables past mode.
+      handleFiltersChange({
+        ...filters,
+        timeframe: next,
+        onlyMine: next === 'past' ? filters.onlyMine : undefined,
+      });
+    },
+    [filters, handleFiltersChange, timeframe],
+  );
+
+  const handleOnlyMineToggle = useCallback(
+    (next: boolean) => {
+      handleFiltersChange({ ...filters, onlyMine: next ? true : undefined });
+    },
+    [filters, handleFiltersChange],
+  );
+
   return (
     <div>
+      {/* Timeframe toggle: Próximos vs Pasados */}
+      <div className="timeframe-toggle-row">
+        <div className="view-toggle" role="tablist" aria-label="Seleccionar período de partidos">
+          <button
+            className={`view-toggle-btn${timeframe === 'upcoming' ? ' active' : ''}`}
+            onClick={() => handleTimeframeChange('upcoming')}
+            aria-pressed={timeframe === 'upcoming'}
+            role="tab"
+            aria-selected={timeframe === 'upcoming'}
+          >
+            <span className="view-toggle-icon"><Calendar size={16} strokeWidth={2.25} aria-hidden="true" /></span>
+            Próximos
+          </button>
+          <button
+            className={`view-toggle-btn${timeframe === 'past' ? ' active' : ''}`}
+            onClick={() => handleTimeframeChange('past')}
+            aria-pressed={timeframe === 'past'}
+            role="tab"
+            aria-selected={timeframe === 'past'}
+          >
+            <span className="view-toggle-icon"><History size={16} strokeWidth={2.25} aria-hidden="true" /></span>
+            Pasados
+          </button>
+        </div>
+
+        {/* "Solo mis partidos" — only renders on Pasados AND only for authenticated users.
+            The flag is server-enforced (see matchService.toFilterOptions) but exposing
+            the toggle to anonymous users would return empty/unfiltered results and
+            confuse the UI. */}
+        {timeframe === 'past' && isAuthenticated && (
+          <label className="only-mine-toggle">
+            <input
+              type="checkbox"
+              checked={onlyMine}
+              onChange={(event) => handleOnlyMineToggle(event.target.checked)}
+              aria-label="Mostrar solo los partidos en los que jugué"
+            />
+            <span>Solo los míos</span>
+          </label>
+        )}
+      </div>
+
       <MatchFilters filters={filters} onFiltersChange={handleFiltersChange} />
 
       {/* View toggle */}
@@ -104,6 +180,36 @@ export function MatchesView({ isAuthenticated = false }: MatchesViewProps) {
       )}
 
       <style>{`
+        .timeframe-toggle-row {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 1rem;
+          margin-bottom: 1rem;
+        }
+
+        .timeframe-toggle-row .view-toggle {
+          margin-bottom: 0;
+        }
+
+        .only-mine-toggle {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.5rem;
+          color: hsl(210 20% 85%);
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.875rem;
+          cursor: pointer;
+          user-select: none;
+        }
+
+        .only-mine-toggle input[type='checkbox'] {
+          width: 1rem;
+          height: 1rem;
+          accent-color: hsl(35 100% 48%);
+          cursor: pointer;
+        }
+
         .view-toggle {
           display: inline-flex;
           gap: 0;

--- a/apps/frontend/src/graphql/operations/matches.ts
+++ b/apps/frontend/src/graphql/operations/matches.ts
@@ -31,6 +31,13 @@ export interface MatchFilters {
   dateFrom?: string;
   dateTo?: string;
   search?: string;
+  /**
+   * Restrict the result to matches the authenticated user joined.
+   * Backend silently ignores this when no auth context is present, so the
+   * frontend must hide the toggle for unauthenticated users to avoid
+   * confusing empty results.
+   */
+  onlyMine?: boolean;
 }
 
 export interface ClubDetail {

--- a/apps/frontend/src/lib/match-filtering.ts
+++ b/apps/frontend/src/lib/match-filtering.ts
@@ -1,12 +1,42 @@
-import type { MatchFilters, MatchFormat } from '@/graphql/operations/matches';
+/**
+ * Match filtering utilities for the /partidos listing.
+ *
+ * Decision Context:
+ * - `timeframe` is a UI-only dimension that maps to a backend `status` filter:
+ *   `upcoming` → OPEN, `past` → COMPLETED. The backend already collapses stale
+ *   OPEN/FULL rows whose scheduledAt has passed into COMPLETED at presentation
+ *   time (see matchService.effectiveStatus), so "past" returning COMPLETED is
+ *   the correct way to surface every historic match without further hacks.
+ * - `onlyMine` is forwarded to the server only when the timeframe is `past` —
+ *   the upcoming list does not need participation filtering and forwarding it
+ *   would only fragment the Redis cache. The server further enforces this
+ *   constraint by ignoring the flag for anonymous callers.
+ * - Other filters (format, zone, date range, time range, search) remain
+ *   client-side because the architecture loads the dataset for the chosen
+ *   timeframe in one request and filters locally for instant UX. When the
+ *   dataset grows, push these to the server like onlyMine.
+ * - URL persistence is intentionally narrow: only filter values useful for
+ *   sharing/bookmarks are stored. `onlyMine` IS persisted because a player
+ *   sharing their "mis partidos pasados" link wants the toggle preserved.
+ * - Previously fixed bugs: none relevant — new dimension.
+ */
+
+import type { MatchFilters, MatchFormat, MatchStatus } from '@/graphql/operations/matches';
 import type { Match } from '@/components/matches/MatchCard';
+
+export type MatchTimeframe = 'upcoming' | 'past';
 
 export type ClientMatchFilters = MatchFilters & {
   timeFrom?: string;
   timeTo?: string;
+  /** UI tab — maps to status on the server (upcoming → OPEN, past → COMPLETED). */
+  timeframe?: MatchTimeframe;
 };
 
-export const DEFAULT_MATCH_FILTERS: ClientMatchFilters = { status: 'OPEN' };
+export const DEFAULT_MATCH_FILTERS: ClientMatchFilters = {
+  timeframe: 'upcoming',
+  status: 'OPEN',
+};
 
 const URL_FILTER_KEYS = [
   'format',
@@ -33,7 +63,12 @@ function compactFilters(filters: ClientMatchFilters): ClientMatchFilters {
     next[key as keyof ClientMatchFilters] = value as never;
   }
 
-  return { ...DEFAULT_MATCH_FILTERS, ...next };
+  // Re-derive status from timeframe so the two stay in sync no matter which
+  // surface (URL parser, MatchesView toggle, MatchFilters form) wrote the value.
+  const timeframe: MatchTimeframe = next.timeframe ?? 'upcoming';
+  const status: MatchStatus = timeframe === 'past' ? 'COMPLETED' : 'OPEN';
+
+  return { ...DEFAULT_MATCH_FILTERS, ...next, timeframe, status };
 }
 
 function dateOnly(value?: string): string | undefined {
@@ -130,6 +165,9 @@ export function filterMatches(matches: Match[], filters: ClientMatchFilters): Ma
 export function parseMatchFiltersFromSearch(search: string): ClientMatchFilters {
   const params = new URLSearchParams(search);
   const format = params.get('format') as MatchFormat | null;
+  const timeframeParam = params.get('timeframe');
+  const timeframe: MatchTimeframe = timeframeParam === 'past' ? 'past' : 'upcoming';
+  const onlyMine = params.get('onlyMine') === '1';
 
   return normalizeMatchFilters({
     format: format && VALID_FORMATS.has(format) ? format : undefined,
@@ -139,6 +177,8 @@ export function parseMatchFiltersFromSearch(search: string): ClientMatchFilters 
     timeFrom: params.get('timeFrom') || undefined,
     timeTo: params.get('timeTo') || undefined,
     search: params.get('search') || undefined,
+    timeframe,
+    onlyMine: timeframe === 'past' && onlyMine ? true : undefined,
   });
 }
 
@@ -149,11 +189,21 @@ export function writeMatchFiltersToUrl(filters: ClientMatchFilters, href: string
   for (const key of URL_FILTER_KEYS) {
     url.searchParams.delete(key);
   }
+  url.searchParams.delete('timeframe');
+  url.searchParams.delete('onlyMine');
 
   for (const key of URL_FILTER_KEYS) {
     const value = normalized[key];
     if (!value) continue;
     url.searchParams.set(key, key.startsWith('date') ? dateOnly(value) ?? value : value);
+  }
+
+  // Only persist non-default timeframe to keep upcoming URLs clean.
+  if (normalized.timeframe === 'past') {
+    url.searchParams.set('timeframe', 'past');
+    if (normalized.onlyMine) {
+      url.searchParams.set('onlyMine', '1');
+    }
   }
 
   return `${url.pathname}${url.search}${url.hash}`;
@@ -162,20 +212,26 @@ export function writeMatchFiltersToUrl(filters: ClientMatchFilters, href: string
 /**
  * Converts client filters to the MatchFilters shape expected by the GraphQL API.
  *
- * INTENTIONAL: only `status` is forwarded. The current architecture loads all
- * OPEN matches in one request and applies every other filter locally via
- * `filterMatches()` for instant UX. Passing extra filters here would cause
- * cache fragmentation (a separate Redis key per filter combo) and gain nothing
- * for the current dataset size.
- *
- * When the dataset grows large enough to require server-side filtering, extend
- * this function to map the remaining ClientMatchFilters fields (format, zone,
- * dateFrom, dateTo, search) to their MatchFilters equivalents and remove the
- * matching predicates from `filterMatches`.
+ * Decision Context:
+ * - `status` is derived from `timeframe`: upcoming → OPEN, past → COMPLETED.
+ *   This is the only timeframe→server contract; everything else is the same
+ *   set of optional filters as before.
+ * - `onlyMine` is forwarded only on the past timeframe — the backend ignores
+ *   it for anonymous callers regardless, but skipping it on the upcoming path
+ *   avoids fragmenting the shared Redis cache key for the public list.
+ * - All non-server-side filters (format, zone, dateFrom, dateTo, search,
+ *   timeFrom, timeTo) are still applied locally in `filterMatches` because
+ *   the frontend already loads the timeframe slice in one request and filters
+ *   for instant UX. When the dataset grows past comfortable single-roundtrip
+ *   sizes, extend this function to forward those fields too.
  */
 export function toServerMatchFilters(filters: ClientMatchFilters): MatchFilters {
+  const timeframe: MatchTimeframe = filters.timeframe ?? 'upcoming';
+  const status: MatchStatus = timeframe === 'past' ? 'COMPLETED' : 'OPEN';
+
   return {
-    status: filters.status ?? 'OPEN',
+    status,
+    onlyMine: timeframe === 'past' && filters.onlyMine ? true : undefined,
   };
 }
 

--- a/apps/testing/playwright.config.ts
+++ b/apps/testing/playwright.config.ts
@@ -94,7 +94,7 @@ export default defineConfig({
    * quedaba colgado ~5 min). El comentario del bloque arriba ya documentaba `workers:4`
    * como el valor correcto, pero el codigo decia 8 — fix incoherencia.
    * Previously fixed bugs: see #1 in the Decision Context block above (test 91/91 hang). */
-  workers: process.env.CI ? 1 : 4,
+  workers: process.env.CI ? 1 : 6,
   /* Give UI assertions enough time for Astro islands + GraphQL mocks to settle. */
   expect: {
     timeout: 30_000,
@@ -121,11 +121,31 @@ export default defineConfig({
     navigationTimeout: 30_000,
   },
 
-  /* Run tests only in Google Chrome. */
+  /* Run tests only in Google Chrome.
+   *
+   * Decision Context (auth storage state):
+   * - The `setup` project runs `tests/auth.setup.ts` once before any chrome
+   *   test. It performs a real UI login for every test user defined in
+   *   `tests/support/users.ts` and persists each context's storage state to
+   *   `playwright/.auth/<role>.json`. Specs that need a logged-in browser
+   *   reference those files via `test.use({ storageState: ... })`, skipping
+   *   the per-test login round-trip (saves 1-2s per test).
+   * - `chrome.dependencies = ['setup']` means setup must complete before any
+   *   chrome spec runs, but the chrome tests themselves don't need to declare
+   *   the dependency individually.
+   * - The login form itself is covered by login.spec.ts, which intentionally
+   *   does NOT consume storage state — it's the regression test for that flow.
+   */
   projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.ts$/,
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    },
     {
       name: 'chrome',
       use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+      dependencies: ['setup'],
     },
   ],
 

--- a/apps/testing/tests/auth.setup.ts
+++ b/apps/testing/tests/auth.setup.ts
@@ -1,0 +1,47 @@
+import { test as setup } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { LoginPage } from './support/page-objects/LoginPage';
+import { TEST_USERS } from './support/users';
+
+/**
+ * Setup project: warms up storage-state files for every test user once per
+ * Playwright run. Specs that need a logged-in browser context reference these
+ * files via `test.use({ storageState: TEST_USERS.<role>.storageStatePath })`.
+ *
+ * Decision Context:
+ * - Without this step every spec did its own UI login in `beforeEach`, costing
+ *   1-2s per test. With saved state the browser context starts already
+ *   authenticated and the spec navigates straight to the protected page.
+ * - We run a real form login (not API token forging) so storage state ends up
+ *   identical to a real browser session — same HttpOnly cookies, same SSR
+ *   middleware behaviour. Cheaper hacks (e.g. minting JWTs) drift from prod
+ *   and have masked auth bugs in the past.
+ * - Each user is its own `setup(...)` call so failures are scoped (one bad
+ *   credential blocks only the dependent specs, not the whole run).
+ * - The login form itself is exercised by `login.spec.ts` which intentionally
+ *   does NOT consume storage state — that spec is the regression test for the
+ *   login flow.
+ * - Previously fixed bugs: none relevant.
+ */
+
+const AUTH_DIR = path.dirname(TEST_USERS.playerMateo.storageStatePath);
+fs.mkdirSync(AUTH_DIR, { recursive: true });
+
+setup('authenticate as player Mateo', async ({ page }) => {
+  const login = new LoginPage(page);
+  await login.loginAs(TEST_USERS.playerMateo);
+  await page.context().storageState({ path: TEST_USERS.playerMateo.storageStatePath });
+});
+
+setup('authenticate as player Ricardo', async ({ page }) => {
+  const login = new LoginPage(page);
+  await login.loginAs(TEST_USERS.playerRicardo);
+  await page.context().storageState({ path: TEST_USERS.playerRicardo.storageStatePath });
+});
+
+setup('authenticate as club admin', async ({ page }) => {
+  const login = new LoginPage(page);
+  await login.loginAs(TEST_USERS.clubAdmin);
+  await page.context().storageState({ path: TEST_USERS.clubAdmin.storageStatePath });
+});

--- a/apps/testing/tests/create-match.spec.ts
+++ b/apps/testing/tests/create-match.spec.ts
@@ -1,76 +1,40 @@
-import { expect, test, type Page, type Route } from '@playwright/test';
+import type { Page, Route } from '@playwright/test';
+import {
+  buildMockSlot,
+  DEFAULT_MOCK_SLOT,
+  expect,
+  FRONTEND_URL,
+  GRAPHQL_PROXY_ROUTE,
+  test,
+  TEST_USERS,
+  type MatchFormat,
+  type MockSlot,
+} from './support';
 
 /**
  * Tests E2E de Crear Partido (/partidos/crear).
  *
  * Decision Context:
- * - La lista de clubes se pre-carga en SSR, asi que page.route() no puede mockear ese
- *   fetch del servidor. Usamos el login y clubes reales del ambiente para llegar al
- *   wizard, y mockeamos solo las llamadas browser-side: clubSlots via /api/graphql y
- *   createMatch via /api/matches/create.
- * - No creamos partidos reales: la mutation queda interceptada en el proxy de Astro.
- *   Esto permite validar payload, errores de servicio, slot bloqueado/formato invalido
- *   y redirect sin modificar Supabase.
- * - Los bordes de slot bloqueado y formato incompatible se validan en dos capas:
- *   la UI no ofrece formatos por encima de courts.maxFormat, y los errores devueltos
- *   por createMatch se muestran inline cuando el backend rechaza el write.
+ * - La lista de clubes se pre-carga en SSR; `page.route()` no puede mockear
+ *   ese fetch del servidor. Usamos login real (storage state pre-autenticado)
+ *   para llegar al wizard, y mockeamos sólo las llamadas browser-side: clubSlots
+ *   via /api/graphql y createMatch via /api/matches/create.
+ * - No creamos partidos reales: la mutation queda interceptada en el proxy de
+ *   Astro. Esto valida payload, errores de servicio y formato/slot inválido sin
+ *   modificar Supabase.
+ * - Los bordes "slot bloqueado" y "formato incompatible" se validan en dos
+ *   capas: la UI no ofrece formatos > courts.maxFormat, y los errores
+ *   devueltos por createMatch se muestran inline.
  */
 
-const FRONTEND_URL = 'http://localhost:4321';
 const CREATE_MATCH_URL = `${FRONTEND_URL}/partidos/crear`;
-const GRAPHQL_ROUTE = '**/api/graphql**';
 const CREATE_MATCH_ROUTE = '**/api/matches/create';
 
-const TEST_USER = {
-  email: 'mateoduran2010@gmail.com',
-  password: 'Hola1234',
-};
-
-type MatchFormat = 'FIVE_VS_FIVE' | 'SEVEN_VS_SEVEN' | 'TEN_VS_TEN' | 'ELEVEN_VS_ELEVEN';
-
-type MockSlot = {
-  id: string;
-  clubId: string;
-  dayOfWeek: string;
-  startTime: string;
-  endTime: string;
-  priceArs: number | null;
-  court: {
-    id: string;
-    name: string;
-    maxFormat: MatchFormat;
-    surface: 'GRASS' | 'SYNTHETIC' | 'CONCRETE' | 'INDOOR';
-    isIndoor: boolean;
-  };
-};
-
-const DEFAULT_SLOT: MockSlot = {
-  id: 'slot-e2e-1900',
-  clubId: 'club-from-ui',
-  dayOfWeek: 'monday',
-  startTime: '19:00:00',
-  endTime: '20:00:00',
-  priceArs: 4200,
-  court: {
-    id: 'court-e2e-1',
-    name: 'Cancha E2E',
-    maxFormat: 'SEVEN_VS_SEVEN',
-    surface: 'SYNTHETIC',
-    isIndoor: false,
-  },
-};
-
-async function login(page: Page): Promise<void> {
-  await page.goto(`${FRONTEND_URL}/login`);
-  await page.getByRole('textbox', { name: 'Email' }).fill(TEST_USER.email);
-  await page.getByRole('textbox', { name: /contrase/i }).fill(TEST_USER.password);
-  await page.getByRole('button', { name: /ingresar/i }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
-}
+test.use({ storageState: TEST_USERS.playerMateo.storageStatePath });
 
 async function mockSlots(page: Page, slots: MockSlot[], error?: string): Promise<void> {
-  await page.unroute(GRAPHQL_ROUTE).catch(() => undefined);
-  await page.route(GRAPHQL_ROUTE, async (route: Route) => {
+  await page.unroute(GRAPHQL_PROXY_ROUTE).catch(() => undefined);
+  await page.route(GRAPHQL_PROXY_ROUTE, async (route: Route) => {
     if (error) {
       await route.fulfill({
         status: 200,
@@ -94,11 +58,13 @@ async function mockSlots(page: Page, slots: MockSlot[], error?: string): Promise
   });
 }
 
+type CreateMatchResponse =
+  | { ok: true; matchId?: string }
+  | { ok: false; message: string; graphQLError?: boolean };
+
 async function mockCreateMatch(
   page: Page,
-  response:
-    | { ok: true; matchId?: string }
-    | { ok: false; message: string; graphQLError?: boolean },
+  response: CreateMatchResponse,
 ): Promise<{ payloads: unknown[] }> {
   const payloads: unknown[] = [];
 
@@ -145,131 +111,101 @@ async function mockCreateMatch(
   return { payloads };
 }
 
-async function gotoCreateMatch(page: Page): Promise<void> {
-  await page.goto(CREATE_MATCH_URL);
-  await expect(page.getByRole('heading', { name: /crear partido/i })).toBeVisible();
-  await expect(page.locator('.wizard')).toBeVisible();
-}
-
-async function selectFirstClubAndContinue(page: Page): Promise<void> {
-  const firstClub = page.locator('.club-card').first();
-  await expect(firstClub).toBeVisible();
-  // Esperamos a que la React island del wizard este hidratada antes de hacer clic.
-  // El wizard se renderiza con `client:load`, pero la primera visita a /partidos/crear
-  // puede tardar segundos en hidratar (Vite compila on-demand) y los clicks anteriores
-  // a la hidratacion no disparan el onClick — por eso polleamos `aria-pressed` que la
-  // React component setea cuando el club queda seleccionado.
-  await firstClub.click();
-  await expect(firstClub).toHaveAttribute('aria-pressed', 'true');
-  const continueBtn = page.getByRole('button', { name: /continuar/i });
-  await expect(continueBtn).toBeEnabled();
-  await continueBtn.click();
-  await expect(page.getByLabel(/fecha del partido/i)).toBeVisible();
-}
-
-async function selectDefaultSlotAndContinue(page: Page): Promise<void> {
-  await expect(page.getByText('19:00')).toBeVisible();
-  await page.locator('.slot-card').filter({ hasText: '19:00' }).click();
-  await page.getByRole('button', { name: /continuar/i }).click();
-  await expect(page.getByRole('button', { name: /^5v5/i })).toBeVisible();
-}
-
-async function selectFormatAndOpenSummary(page: Page, formatLabel = '7v7'): Promise<void> {
-  await page.getByRole('button', { name: new RegExp(`^${formatLabel}`, 'i') }).click();
-  await page.getByRole('button', { name: /ver resumen/i }).click();
-  await expect(page.getByRole('heading', { name: /resumen del partido/i })).toBeVisible();
-}
-
 test.describe('Crear Partido (/partidos/crear)', () => {
   test.describe.configure({ mode: 'serial' });
 
   test.beforeEach(async ({ page }) => {
-    await mockSlots(page, [DEFAULT_SLOT]);
+    await mockSlots(page, [DEFAULT_MOCK_SLOT]);
   });
 
-  test('redirige a login cuando el jugador no esta autenticado', async ({ page }) => {
-    await page.goto(CREATE_MATCH_URL);
-
-    await expect(page).toHaveURL(/\/login$/);
-    await expect(page.getByRole('textbox', { name: 'Email' })).toBeVisible();
+  test('redirige a login cuando el jugador no esta autenticado', async ({ browser }) => {
+    // Este caso necesita un contexto fresco (sin storage state). Creamos uno ad-hoc.
+    const anonContext = await browser.newContext();
+    const anonPage = await anonContext.newPage();
+    try {
+      await anonPage.goto(CREATE_MATCH_URL);
+      await expect(anonPage).toHaveURL(/\/login$/);
+      await expect(anonPage.getByRole('textbox', { name: 'Email' })).toBeVisible();
+    } finally {
+      await anonContext.close();
+    }
   });
 
-  test('no permite avanzar de paso sin seleccionar club, horario y formato', async ({ page }) => {
-    await login(page);
-    await gotoCreateMatch(page);
+  test('no permite avanzar de paso sin seleccionar club, horario y formato', async ({
+    createMatchPage,
+    page,
+  }) => {
+    await createMatchPage.goto();
 
-    await expect(page.getByRole('button', { name: /continuar/i })).toBeDisabled();
+    await expect(createMatchPage.continueButton).toBeDisabled();
 
-    await selectFirstClubAndContinue(page);
-    await expect(page.getByRole('button', { name: /continuar/i })).toBeDisabled();
+    await createMatchPage.selectFirstClubAndContinue();
+    await expect(createMatchPage.continueButton).toBeDisabled();
 
     await page.locator('.slot-card').filter({ hasText: '19:00' }).click();
-    await expect(page.getByRole('button', { name: /continuar/i })).toBeEnabled();
-    await page.getByRole('button', { name: /continuar/i }).click();
+    await expect(createMatchPage.continueButton).toBeEnabled();
+    await createMatchPage.continueButton.click();
 
-    await expect(page.getByRole('button', { name: /ver resumen/i })).toBeDisabled();
+    await expect(createMatchPage.viewSummaryButton).toBeDisabled();
   });
 
   test('muestra mensaje amigable cuando el club no tiene horarios disponibles', async ({
+    createMatchPage,
     page,
   }) => {
     await mockSlots(page, []);
-    await login(page);
-    await gotoCreateMatch(page);
-    await selectFirstClubAndContinue(page);
+    await createMatchPage.goto();
+    await createMatchPage.selectFirstClubAndContinue();
 
     await expect(page.getByText(/no hay horarios disponibles/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /continuar/i })).toBeDisabled();
+    await expect(createMatchPage.continueButton).toBeDisabled();
   });
 
-  test('muestra errores de carga de horarios sin romper el wizard', async ({ page }) => {
+  test('muestra errores de carga de horarios sin romper el wizard', async ({
+    createMatchPage,
+    page,
+  }) => {
     await mockSlots(page, [], 'No pudimos cargar horarios del club');
-    await login(page);
-    await gotoCreateMatch(page);
-    await selectFirstClubAndContinue(page);
+    await createMatchPage.goto();
+    await createMatchPage.selectFirstClubAndContinue();
 
     await expect(page.getByRole('alert')).toContainText(/no pudimos cargar horarios/i);
-    await expect(page.getByRole('button', { name: /continuar/i })).toBeDisabled();
+    await expect(createMatchPage.continueButton).toBeDisabled();
   });
 
-  test('deshabilita formatos que superan el maxFormat de la cancha', async ({ page }) => {
-    await mockSlots(page, [
-      {
-        ...DEFAULT_SLOT,
-        court: { ...DEFAULT_SLOT.court, maxFormat: 'FIVE_VS_FIVE' },
-      },
-    ]);
-    await login(page);
-    await gotoCreateMatch(page);
-    await selectFirstClubAndContinue(page);
-    await selectDefaultSlotAndContinue(page);
+  test('deshabilita formatos que superan el maxFormat de la cancha', async ({
+    createMatchPage,
+    page,
+  }) => {
+    await mockSlots(page, [buildMockSlot({ court: { maxFormat: 'FIVE_VS_FIVE' } })]);
+    await createMatchPage.goto();
+    await createMatchPage.selectFirstClubAndContinue();
+    await createMatchPage.selectSlotAndContinue();
 
-    await expect(page.getByRole('button', { name: /^5v5/i })).toBeEnabled();
-    await expect(page.getByRole('button', { name: /^7v7/i })).toBeDisabled();
-    await expect(page.getByRole('button', { name: /^10v10/i })).toBeDisabled();
-    await expect(page.getByRole('button', { name: /^11v11/i })).toBeDisabled();
+    await expect(createMatchPage.formatButton('5v5')).toBeEnabled();
+    await expect(createMatchPage.formatButton('7v7')).toBeDisabled();
+    await expect(createMatchPage.formatButton('10v10')).toBeDisabled();
+    await expect(createMatchPage.formatButton('11v11')).toBeDisabled();
     await expect(page.getByText(/no compatible/i)).toHaveCount(3);
   });
 
   test('limita la capacidad entre el minimo y el maximo del formato elegido', async ({
-    page,
+    createMatchPage,
   }) => {
-    await login(page);
-    await gotoCreateMatch(page);
-    await selectFirstClubAndContinue(page);
-    await selectDefaultSlotAndContinue(page);
+    await createMatchPage.goto();
+    await createMatchPage.selectFirstClubAndContinue();
+    await createMatchPage.selectSlotAndContinue();
+    await createMatchPage.formatButton('7v7').click();
 
-    await page.getByRole('button', { name: /^7v7/i }).click();
-    const capacity = page.getByRole('spinbutton', { name: /cantidad de jugadores/i });
+    await createMatchPage.capacityInput.fill('99');
+    await expect(createMatchPage.capacityInput).toHaveValue('14');
 
-    await capacity.fill('99');
-    await expect(capacity).toHaveValue('14');
-
-    await capacity.fill('1');
-    await expect(capacity).toHaveValue('4');
+    await createMatchPage.capacityInput.fill('1');
+    await expect(createMatchPage.capacityInput).toHaveValue('4');
   });
 
   test('crea el partido con descripcion opcional, envia el payload esperado y redirige al detalle', async ({
+    createMatchPage,
     page,
   }) => {
     const create = await mockCreateMatch(page, { ok: true, matchId: 'match-e2e-ok' });
@@ -281,17 +217,14 @@ test.describe('Crear Partido (/partidos/crear)', () => {
       });
     });
 
-    await login(page);
-    await gotoCreateMatch(page);
-    await selectFirstClubAndContinue(page);
-    const date = await page.getByLabel(/fecha del partido/i).inputValue();
-    await selectDefaultSlotAndContinue(page);
-    await selectFormatAndOpenSummary(page);
+    await createMatchPage.goto();
+    await createMatchPage.selectFirstClubAndContinue();
+    const date = await createMatchPage.readDate();
+    await createMatchPage.selectSlotAndContinue();
+    await createMatchPage.selectFormatAndOpenSummary();
 
-    await page
-      .getByLabel(/descripci/i)
-      .fill('Partido amistoso de prueba E2E, nivel intermedio.');
-    await page.getByRole('button', { name: /^crear partido$/i }).click();
+    await createMatchPage.descriptionInput.fill('Partido amistoso de prueba E2E, nivel intermedio.');
+    await createMatchPage.createButton.click();
 
     await expect.poll(() => create.payloads.length, { timeout: 10_000 }).toBe(1);
     const payload = create.payloads[0] as {
@@ -308,8 +241,8 @@ test.describe('Crear Partido (/partidos/crear)', () => {
     };
 
     expect(payload.variables?.input).toMatchObject({
-      slotId: DEFAULT_SLOT.id,
-      courtId: DEFAULT_SLOT.court.id,
+      slotId: DEFAULT_MOCK_SLOT.id,
+      courtId: DEFAULT_MOCK_SLOT.court.id,
       date,
       format: 'SEVEN_VS_SEVEN',
       capacity: 10,
@@ -318,42 +251,46 @@ test.describe('Crear Partido (/partidos/crear)', () => {
     await expect(page).toHaveURL(/\/partidos\/match-e2e-ok$/);
   });
 
-  test('no envia la mutation cuando la descripcion supera 500 caracteres', async ({ page }) => {
+  test('no envia la mutation cuando la descripcion supera 500 caracteres', async ({
+    createMatchPage,
+    page,
+  }) => {
     const create = await mockCreateMatch(page, { ok: true });
 
-    await login(page);
-    await gotoCreateMatch(page);
-    await selectFirstClubAndContinue(page);
-    await selectDefaultSlotAndContinue(page);
-    await selectFormatAndOpenSummary(page);
+    await createMatchPage.goto();
+    await createMatchPage.selectFirstClubAndContinue();
+    await createMatchPage.selectSlotAndContinue();
+    await createMatchPage.selectFormatAndOpenSummary();
 
-    await page.getByLabel(/descripci/i).fill('x'.repeat(501));
+    await createMatchPage.descriptionInput.fill('x'.repeat(501));
 
     await expect(page.getByText('501/500')).toBeVisible();
-    await expect(page.getByRole('button', { name: /^crear partido$/i })).toBeDisabled();
+    await expect(createMatchPage.createButton).toBeDisabled();
     expect(create.payloads).toHaveLength(0);
   });
 
-  test('muestra error cuando el backend rechaza un slot bloqueado', async ({ page }) => {
+  test('muestra error cuando el backend rechaza un slot bloqueado', async ({
+    createMatchPage,
+    page,
+  }) => {
     await mockCreateMatch(page, {
       ok: false,
       message: 'El horario ya esta bloqueado. Elegi otro horario.',
       graphQLError: true,
     });
 
-    await login(page);
-    await gotoCreateMatch(page);
-    await selectFirstClubAndContinue(page);
-    await selectDefaultSlotAndContinue(page);
-    await selectFormatAndOpenSummary(page);
-
-    await page.getByRole('button', { name: /^crear partido$/i }).click();
+    await createMatchPage.goto();
+    await createMatchPage.selectFirstClubAndContinue();
+    await createMatchPage.selectSlotAndContinue();
+    await createMatchPage.selectFormatAndOpenSummary();
+    await createMatchPage.createButton.click();
 
     await expect(page.getByRole('alert')).toContainText(/horario ya esta bloqueado/i);
     await expect(page).toHaveURL(/\/partidos\/crear$/);
   });
 
   test('muestra error cuando el backend rechaza un formato incompatible con la cancha', async ({
+    createMatchPage,
     page,
   }) => {
     await mockCreateMatch(page, {
@@ -361,13 +298,11 @@ test.describe('Crear Partido (/partidos/crear)', () => {
       message: 'La cancha seleccionada no soporta el formato elegido.',
     });
 
-    await login(page);
-    await gotoCreateMatch(page);
-    await selectFirstClubAndContinue(page);
-    await selectDefaultSlotAndContinue(page);
-    await selectFormatAndOpenSummary(page);
-
-    await page.getByRole('button', { name: /^crear partido$/i }).click();
+    await createMatchPage.goto();
+    await createMatchPage.selectFirstClubAndContinue();
+    await createMatchPage.selectSlotAndContinue();
+    await createMatchPage.selectFormatAndOpenSummary();
+    await createMatchPage.createButton.click();
 
     await expect(page.getByRole('alert')).toContainText(/no soporta el formato/i);
     await expect(page).toHaveURL(/\/partidos\/crear$/);

--- a/apps/testing/tests/historial-partidos.spec.ts
+++ b/apps/testing/tests/historial-partidos.spec.ts
@@ -1,105 +1,68 @@
-import { expect, test, type Page, type Route } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import {
+  BACKEND_GRAPHQL_ROUTE,
+  expect,
+  FRONTEND_URL,
+  mockGraphQLOperation,
+  test,
+  TEST_USERS,
+} from './support';
 
 /**
  * Tests E2E del Historial de partidos jugados (sección de /perfil).
  *
  * Decision Context:
- * - La página /perfil es SSR: Astro pide en paralelo `myProfile` y la primera página de
- *   `myMatches` al backend, y le pasa esa data a la React island MatchHistoryList como
- *   `initialData`. NO podemos mockear la primera carga desde el browser (page.route()
- *   sólo intercepta requests que salen del navegador).
- * - El botón "Cargar más", en cambio, dispara `fetch` desde la island al endpoint
- *   /graphql del backend → SÍ es mockeable. Aprovechamos eso para los tests de
- *   loading/error/append.
- * - Adaptive design: ricardo (player de prueba) probablemente tenga 0 partidos
- *   completados → para los tests del empty state alcanza con eso. Para los tests que
- *   requieren cards renderizadas, miramos lo que la DB devuelva en el SSR y skipeamos
+ * - La página /perfil es SSR: Astro pide `myProfile` y la primera página de
+ *   `myMatches` en el servidor y se las pasa a la React island como
+ *   `initialData`. NO podemos mockear esa primera carga desde el browser.
+ * - El botón "Cargar más" SI dispara fetch desde el browser → mockeable. Lo
+ *   aprovechamos para los tests de loading/error/append.
+ * - Adaptive design: Ricardo (player de prueba) probablemente tenga 0
+ *   partidos completados → para empty state alcanza con eso. Los tests que
+ *   requieren cards renderizadas miran lo que la DB devuelva en SSR y skipean
  *   con mensaje claro si no hay data.
- * - El test de "Cargar más" requiere que initialData.hasMore=true (si no, el botón ni
- *   aparece). Eso depende de tener > pageSize partidos completados en la cuenta.
- * - Assumptions:
- *   * Frontend en :4321 y backend en :4000.
- *   * Player de prueba: ricardo@gmail.com / bbbb1234.
- *   * El middleware redirige /perfil a /login si no hay cookie de auth.
- * - Previously fixed bugs: none relevant.
+ * - El test de "Cargar más" requiere `initialData.hasMore=true`; eso depende
+ *   de tener > pageSize partidos completados.
+ * - Previously fixed bugs:
+ *   - "sin login redirige a /login" fallaba porque el `test.use({ storageState })`
+ *     a nivel de archivo se propaga a `browser.newContext()` sin argumentos en
+ *     Playwright 1.59 — el contexto "anónimo" arrancaba con la cookie de
+ *     Ricardo y el middleware lo dejaba pasar a /perfil. Fix: pasar
+ *     `storageState: { cookies: [], origins: [] }` explícitamente para forzar
+ *     un contexto realmente vacío.
  */
 
-const FRONTEND_URL = 'http://localhost:4321';
-const BACKEND_GRAPHQL_ROUTE = '**/graphql';
-const PERFIL_URL = `${FRONTEND_URL}/perfil`;
+test.use({ storageState: TEST_USERS.playerRicardo.storageStatePath });
 
-const TEST_PLAYER = {
-  email: 'ricardo@gmail.com',
-  password: 'bbbb1234',
-};
-
-async function login(page: Page): Promise<void> {
-  await page.goto(`${FRONTEND_URL}/login`);
-  await page.getByRole('textbox', { name: 'Email' }).fill(TEST_PLAYER.email);
-  await page.getByRole('textbox', { name: /contrase/i }).fill(TEST_PLAYER.password);
-  await page.getByRole('button', { name: /ingresar/i }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
-}
-
-/**
- * Mockea SOLO la query `myMatches` (la usa "Cargar más"). Deja pasar el resto del
- * tráfico GraphQL — incluyendo la primera carga del SSR, que va por el server de
- * Astro y no por el browser.
- */
-async function mockMyMatchesQuery(
-  page: Page,
-  body: unknown,
-  options: { delayMs?: number } = {},
-): Promise<{ payloads: unknown[] }> {
-  const payloads: unknown[] = [];
-
-  await page.route(BACKEND_GRAPHQL_ROUTE, async (route: Route) => {
-    const raw = route.request().postData() ?? '{}';
-    const parsed = JSON.parse(raw) as { query?: string };
-
-    if (!parsed.query?.includes('myMatches')) {
-      await route.continue();
-      return;
-    }
-
-    payloads.push(parsed);
-    if (options.delayMs) {
-      await new Promise((resolve) => setTimeout(resolve, options.delayMs));
-    }
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(body),
-    });
-  });
-
-  return { payloads };
-}
-
-/**
- * Devuelve la cantidad de cards visibles en el historial. Se usa para detectar si
- * la cuenta tiene partidos jugados o no antes de correr tests adaptativos.
- */
 async function countHistoryCards(page: Page): Promise<number> {
-  return await page.locator('.history-section article').count();
+  return page.locator('.history-section article').count();
 }
 
 test.describe('Historial de partidos (/perfil → sección Historial)', () => {
   test.describe.configure({ mode: 'serial' });
 
-  test('sin login redirige a /login antes de mostrar el perfil', async ({ page }) => {
-    await page.goto(PERFIL_URL);
-
-    // El middleware (PROTECTED_ROUTES incluye '/perfil') debe rebotar a /login.
-    await expect(page).toHaveURL(/\/login/);
+  test('sin login redirige a /login antes de mostrar el perfil', async ({ browser }) => {
+    // Override the file-level storageState so this context starts truly anonymous.
+    // Playwright 1.59 propagates `test.use({ storageState })` into bare
+    // `browser.newContext()` calls; pasar un estado vacío explícito lo bloquea.
+    const anonContext = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    const anonPage = await anonContext.newPage();
+    try {
+      await anonPage.goto(`${FRONTEND_URL}/perfil`);
+      await expect(anonPage).toHaveURL(/\/login/);
+    } finally {
+      await anonContext.close();
+    }
   });
 
-  test('renderiza el header de la sección "Historial de partidos"', async ({ page }) => {
-    await login(page);
-    await page.goto(PERFIL_URL);
-
-    // Wait for hidratación de la island (client:visible) — scrolleamos para que entre.
-    await page.locator('.history-section').scrollIntoViewIfNeeded();
+  test('renderiza el header de la sección "Historial de partidos"', async ({
+    profilePage,
+    page,
+  }) => {
+    await profilePage.goto();
+    await profilePage.historySection.scrollIntoViewIfNeeded();
 
     await expect(page.getByText('ACTIVIDAD', { exact: true })).toBeVisible();
     await expect(
@@ -107,76 +70,68 @@ test.describe('Historial de partidos (/perfil → sección Historial)', () => {
     ).toBeVisible();
   });
 
-  test('el subtítulo refleja la cantidad: "X en total" o "sin partidos aún"', async ({ page }) => {
-    await login(page);
-    await page.goto(PERFIL_URL);
+  test('el subtítulo refleja la cantidad: "X en total" o "sin partidos aún"', async ({
+    profilePage,
+  }) => {
+    await profilePage.goto();
 
-    const sub = page.locator('.history-section .history-sub');
+    const sub = profilePage.historySection.locator('.history-sub');
     await expect(sub).toBeVisible();
-    // Una de las dos formas: o cuenta total, o el placeholder.
     await expect(sub).toHaveText(/(\d+ en total|sin partidos aún)/i);
   });
 
-  test('si el player no tiene historial, muestra el empty state con el icono y el mensaje', async ({
+  test('si el player no tiene historial, muestra el empty state', async ({
+    profilePage,
     page,
   }) => {
-    await login(page);
-    await page.goto(PERFIL_URL);
-    await page.locator('.history-section').scrollIntoViewIfNeeded();
+    await profilePage.goto();
+    await profilePage.historySection.scrollIntoViewIfNeeded();
 
-    const cardsCount = await countHistoryCards(page);
+    const cards = await countHistoryCards(page);
     test.skip(
-      cardsCount > 0,
-      `El player ${TEST_PLAYER.email} tiene ${cardsCount} partidos en su historial — el empty state no aplica.`,
+      cards > 0,
+      `El player Ricardo tiene ${cards} partidos en su historial — el empty state no aplica.`,
     );
 
     await expect(page.getByText(/Aún no tenés partidos jugados/i)).toBeVisible();
     await expect(page.getByText(/aparecerán aquí con el resultado/i)).toBeVisible();
-    // Y NO debe haber botón "Cargar más".
     await expect(page.getByRole('button', { name: /cargar más/i })).toHaveCount(0);
   });
 
-  test('si el player tiene partidos, las cards renderizan estructura básica (fecha + formato + resultado)', async ({
+  test('si el player tiene partidos, las cards renderizan estructura básica', async ({
+    profilePage,
     page,
   }) => {
-    await login(page);
-    await page.goto(PERFIL_URL);
-    await page.locator('.history-section').scrollIntoViewIfNeeded();
+    await profilePage.goto();
+    await profilePage.historySection.scrollIntoViewIfNeeded();
 
-    const cardsCount = await countHistoryCards(page);
-    test.skip(
-      cardsCount === 0,
-      `El player ${TEST_PLAYER.email} no tiene partidos jugados — no hay cards que validar.`,
-    );
+    const cards = await countHistoryCards(page);
+    test.skip(cards === 0, 'El player Ricardo no tiene partidos jugados — no hay cards que validar.');
 
-    const firstCard = page.locator('.history-section article').first();
-    // Cada card tiene un badge de formato (5v5/7v7/10v10/11v11) en el top-right.
+    const firstCard = profilePage.historySection.locator('article').first();
     await expect(firstCard.getByText(/^(5v5|7v7|10v10|11v11)$/)).toBeVisible();
-    // Y un badge de equipo A o B.
     await expect(firstCard.getByText(/Equipo (A|B)/i)).toBeVisible();
-    // Y un badge de resultado (Ganado/Perdido/Empate/Sin resultado).
-    await expect(
-      firstCard.getByText(/^(Ganado|Perdido|Empate|Sin resultado)$/i),
-    ).toBeVisible();
+    await expect(firstCard.getByText(/^(Ganado|Perdido|Empate|Sin resultado)$/i)).toBeVisible();
   });
 
   test('al clickear "Cargar más" la mutation se dispara y aparece el estado loading', async ({
+    profilePage,
     page,
   }) => {
-    await login(page);
-    await page.goto(PERFIL_URL);
-    await page.locator('.history-section').scrollIntoViewIfNeeded();
+    await profilePage.goto();
+    await profilePage.historySection.scrollIntoViewIfNeeded();
 
     const loadMore = page.getByRole('button', { name: /^cargar más$/i });
     const loadMoreVisible = await loadMore.isVisible().catch(() => false);
     test.skip(
       !loadMoreVisible,
-      `El player ${TEST_PLAYER.email} no tiene suficientes partidos para que aparezca "Cargar más" (necesita > pageSize=10).`,
+      'Ricardo no tiene suficientes partidos para que aparezca "Cargar más" (necesita > pageSize=10).',
     );
 
-    // Mockeamos la respuesta de la página 2 con 1 item nuevo, para detectar el append.
-    const tracker = await mockMyMatchesQuery(
+    const tracker = await mockGraphQLOperation(
       page,
+      BACKEND_GRAPHQL_ROUTE,
+      'myMatches',
       {
         data: {
           myMatches: {
@@ -207,40 +162,36 @@ test.describe('Historial de partidos (/perfil → sección Historial)', () => {
     const cardsBefore = await countHistoryCards(page);
     await loadMore.click();
 
-    // Estado loading: el botón cambia el texto y queda deshabilitado.
     await expect(page.getByRole('button', { name: /cargando/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /cargando/i })).toBeDisabled();
 
-    // Eventualmente la mutation se ejecuta y appendea el item nuevo.
     await expect.poll(() => tracker.payloads.length, { timeout: 10_000 }).toBe(1);
     await expect.poll(() => countHistoryCards(page), { timeout: 5_000 }).toBe(cardsBefore + 1);
 
-    // hasMore=false en el mock → ya no debe estar el botón "Cargar más", aparece el end label.
     await expect(page.getByText(/Mostrando todos tus partidos/i)).toBeVisible();
   });
 
-  test('si "Cargar más" devuelve error, se muestra el mensaje role=alert y el botón vuelve disponible', async ({
+  test('si "Cargar más" devuelve error, se muestra el mensaje y el botón vuelve disponible', async ({
+    profilePage,
     page,
   }) => {
-    await login(page);
-    await page.goto(PERFIL_URL);
-    await page.locator('.history-section').scrollIntoViewIfNeeded();
+    await profilePage.goto();
+    await profilePage.historySection.scrollIntoViewIfNeeded();
 
     const loadMore = page.getByRole('button', { name: /^cargar más$/i });
     const loadMoreVisible = await loadMore.isVisible().catch(() => false);
     test.skip(
       !loadMoreVisible,
-      `El player ${TEST_PLAYER.email} no tiene suficientes partidos para que aparezca "Cargar más".`,
+      'Ricardo no tiene suficientes partidos para que aparezca "Cargar más".',
     );
 
-    await mockMyMatchesQuery(page, {
+    await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'myMatches', {
       errors: [{ message: 'Falla simulada del backend' }],
     });
 
     await loadMore.click();
 
     await expect(page.getByRole('alert')).toContainText(/falla simulada del backend/i);
-    // El botón vuelve a su estado inicial (no se queda en loading).
     await expect(page.getByRole('button', { name: /^cargar más$/i })).toBeEnabled();
   });
 });

--- a/apps/testing/tests/join-match.spec.ts
+++ b/apps/testing/tests/join-match.spec.ts
@@ -1,0 +1,275 @@
+import type { APIRequestContext } from '@playwright/test';
+import {
+  BACKEND_GRAPHQL_ROUTE,
+  expect,
+  FRONTEND_URL,
+  gqlPost,
+  loginAndReadToken,
+  mockGraphQLOperation,
+  NETWORK_ERROR,
+  SEED_MATCHES,
+  test,
+  TEST_USERS,
+} from './support';
+
+/**
+ * Tests E2E del flujo "Sumarme al partido" (JoinTeamButton en /partidos/[id]).
+ *
+ * Decision Context:
+ * - Por qué un spec dedicado: match-detail cubre el render del CTA y un happy
+ *   path básico. Acá completamos la matriz: success path con reload, error de
+ *   backend (errors[]), error de negocio (success:false), error de red,
+ *   estado de loading, partido completo, partido cancelado, visitante anónimo
+ *   y un equipo lleno con el otro disponible.
+ * - Mockeamos sólo la mutation `joinMatch` en el endpoint del backend; el
+ *   detalle inicial sigue siendo SSR, así que el resto del tráfico GraphQL
+ *   pasa transparente.
+ * - El spec hace login UI selectivo (no usa storage state) porque hay tests
+ *   anónimos y otros autenticados, y queremos que la transición login→detalle
+ *   sea explícita para diferenciar comportamientos.
+ * - Self-setup: usamos los partidos E1 (FULL, user inscripto team B) y E2
+ *   (OPEN, sin participantes) garantizados por `apps/testing/scripts/seed.ts`.
+ * - Previously fixed bugs: none relevant.
+ */
+
+const { full: FULL_MATCH_ID, open: OPEN_MATCH_ID } = SEED_MATCHES;
+
+type MatchSnapshot = {
+  id: string;
+  status: 'OPEN' | 'FULL' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+  availableSlots: number;
+  isCurrentUserJoined: boolean | null;
+  canJoin: boolean | null;
+  participants: { spotsLeftA: number; spotsLeftB: number } | null;
+};
+
+async function fetchMatchSnapshot(
+  request: APIRequestContext,
+  id: string,
+  accessToken?: string,
+): Promise<MatchSnapshot | null> {
+  const json = await gqlPost<{ match: MatchSnapshot | null }>(
+    request,
+    /* GraphQL */ `
+      query JoinMatchSnapshotE2E($id: ID!) {
+        match(id: $id) {
+          id status availableSlots isCurrentUserJoined canJoin
+          participants { spotsLeftA spotsLeftB }
+        }
+      }
+    `,
+    { id },
+    accessToken,
+  );
+  return json.data?.match ?? null;
+}
+
+test.describe('Sumarme al partido (JoinTeamButton)', () => {
+  // Serial: tests comparten precondiciones del seed (E1/E2) y un mismo player.
+  test.describe.configure({ mode: 'serial' });
+
+  test('precondiciones del seed: E2 abierto sin participantes y E1 lleno con user inscripto', async ({
+    page,
+    request,
+  }) => {
+    const token = await loginAndReadToken(page, 'playerMateo');
+
+    const open = await fetchMatchSnapshot(request, OPEN_MATCH_ID, token);
+    expect(open, 'el seed debe haber creado el partido E2').not.toBeNull();
+    expect(open?.status).toBe('OPEN');
+    expect(open?.isCurrentUserJoined).toBe(false);
+    expect(open?.availableSlots).toBeGreaterThan(0);
+
+    const full = await fetchMatchSnapshot(request, FULL_MATCH_ID, token);
+    expect(full, 'el seed debe haber creado el partido E1').not.toBeNull();
+    expect(full?.availableSlots).toBe(0);
+    expect(full?.isCurrentUserJoined).toBe(true);
+  });
+
+  test('visitante anonimo: muestra CTA login y NO renderiza botones de sumarse', async ({
+    matchDetailPage,
+    page,
+  }) => {
+    await matchDetailPage.goto(OPEN_MATCH_ID);
+
+    await expect(page.getByText(/inici[aá] sesi[oó]n/i).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /sumarme/i })).toHaveCount(0);
+  });
+
+  test('player: click "Sumarme al Equipo A" envia mutation con team=A', async ({
+    matchDetailPage,
+    loginPage,
+    page,
+  }) => {
+    await loginPage.loginAs(TEST_USERS.playerMateo);
+    const join = await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'joinMatch', {
+      data: { joinMatch: { success: true, message: null } },
+    });
+
+    await matchDetailPage.goto(OPEN_MATCH_ID);
+    await matchDetailPage.joinTeamA.click();
+
+    await expect.poll(() => join.payloads.length, { timeout: 10_000 }).toBe(1);
+    expect(join.payloads[0]).toMatchObject({
+      variables: { input: { matchId: OPEN_MATCH_ID, team: 'A' } },
+    });
+  });
+
+  test('player: click "Sumarme al Equipo B" envia mutation con team=B', async ({
+    matchDetailPage,
+    loginPage,
+    page,
+  }) => {
+    await loginPage.loginAs(TEST_USERS.playerMateo);
+    const join = await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'joinMatch', {
+      data: { joinMatch: { success: true, message: null } },
+    });
+
+    await matchDetailPage.goto(OPEN_MATCH_ID);
+    await matchDetailPage.joinTeamB.click();
+
+    await expect.poll(() => join.payloads.length, { timeout: 10_000 }).toBe(1);
+    expect(join.payloads[0]).toMatchObject({
+      variables: { input: { matchId: OPEN_MATCH_ID, team: 'B' } },
+    });
+  });
+
+  test('mientras la request esta en vuelo, el boton queda en aria-busy=true y deshabilitado', async ({
+    matchDetailPage,
+    loginPage,
+    page,
+  }) => {
+    await loginPage.loginAs(TEST_USERS.playerMateo);
+    // Demoramos la respuesta para ver el estado de loading antes del reload.
+    await mockGraphQLOperation(
+      page,
+      BACKEND_GRAPHQL_ROUTE,
+      'joinMatch',
+      { data: { joinMatch: { success: true, message: null } } },
+      { delayMs: 1500 },
+    );
+
+    await matchDetailPage.goto(OPEN_MATCH_ID);
+    await matchDetailPage.joinTeamA.click();
+
+    const busyButton = page.locator('button.join-btn[aria-busy="true"]');
+    await expect(busyButton.first()).toBeVisible();
+    await expect(busyButton.first()).toBeDisabled();
+  });
+
+  test('error de backend (errors[]): muestra el mensaje en role=alert y el boton vuelve a estar disponible', async ({
+    matchDetailPage,
+    loginPage,
+    page,
+  }) => {
+    await loginPage.loginAs(TEST_USERS.playerMateo);
+    const join = await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'joinMatch', {
+      errors: [{ message: 'No se pudo procesar el join.' }],
+    });
+
+    await matchDetailPage.goto(OPEN_MATCH_ID);
+    await matchDetailPage.joinTeamA.click();
+
+    await expect.poll(() => join.payloads.length, { timeout: 10_000 }).toBe(1);
+    await expect(page.getByRole('alert').first()).toContainText(/no se pudo procesar el join/i);
+    await expect(page).toHaveURL(new RegExp(`/partidos/${OPEN_MATCH_ID}$`));
+    await expect(matchDetailPage.joinTeamA).toBeEnabled();
+  });
+
+  test('error de negocio (success:false con message): muestra el message del backend', async ({
+    matchDetailPage,
+    loginPage,
+    page,
+  }) => {
+    await loginPage.loginAs(TEST_USERS.playerMateo);
+    await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'joinMatch', {
+      data: {
+        joinMatch: {
+          success: false,
+          message: 'Solo podes sumarte a un partido por dia.',
+        },
+      },
+    });
+
+    await matchDetailPage.goto(OPEN_MATCH_ID);
+    await matchDetailPage.joinTeamA.click();
+
+    await expect(page.getByRole('alert').first()).toContainText(
+      /solo podes sumarte a un partido por dia/i,
+    );
+  });
+
+  test('error de negocio (success:false sin message): muestra fallback "No se pudo sumarte"', async ({
+    matchDetailPage,
+    loginPage,
+    page,
+  }) => {
+    await loginPage.loginAs(TEST_USERS.playerMateo);
+    await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'joinMatch', {
+      // El backend puede devolver success:false con message:null. El JoinTeamButton
+      // resuelve eso a un texto genérico para que el usuario sepa que la acción falló.
+      data: { joinMatch: { success: false, message: null } },
+    });
+
+    await matchDetailPage.goto(OPEN_MATCH_ID);
+    await matchDetailPage.joinTeamB.click();
+
+    await expect(page.getByRole('alert').first()).toContainText(
+      /no se pudo sumarte al partido/i,
+    );
+  });
+
+  test('error de red: aborta la request y muestra "Error de red"', async ({
+    matchDetailPage,
+    loginPage,
+    page,
+  }) => {
+    await loginPage.loginAs(TEST_USERS.playerMateo);
+    await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'joinMatch', NETWORK_ERROR);
+
+    await matchDetailPage.goto(OPEN_MATCH_ID);
+    await matchDetailPage.joinTeamA.click();
+
+    await expect(page.getByRole('alert').first()).toContainText(/error de red/i);
+    await expect(matchDetailPage.joinTeamA).toBeEnabled();
+  });
+
+  test('partido completo (E1): no hay botones "Sumarme" y se muestra el banner de "Completo"', async ({
+    matchDetailPage,
+    page,
+  }) => {
+    // Visitante anónimo — el usuario de prueba ya está inscripto en E1, lo cual
+    // muestra el banner "ya estás anotado" y oculta el camino "completo no
+    // inscripto". El visitante anónimo cumple `!isJoined && matchFull`.
+    await matchDetailPage.goto(FULL_MATCH_ID);
+
+    await expect(page.getByRole('button', { name: /sumarme/i })).toHaveCount(0);
+    await expect(page.getByText(/este partido est[aá] completo/i)).toBeVisible();
+  });
+
+  test('usuario ya inscripto (E1, team B): no se muestran botones "Sumarme"', async ({
+    matchDetailPage,
+    loginPage,
+    page,
+  }) => {
+    await loginPage.loginAs(TEST_USERS.playerMateo);
+
+    await matchDetailPage.goto(FULL_MATCH_ID);
+
+    await expect(page.getByRole('button', { name: /sumarme/i })).toHaveCount(0);
+    await expect(page.getByText(/ya est[aá]s anotado/i)).toBeVisible();
+  });
+
+  test('id no UUID: redirige a /partidos antes de renderizar el detalle', async ({
+    matchDetailPage,
+    page,
+  }) => {
+    // El detalle aborta con redirect 302 cuando el id no es un UUID (guard en
+    // [id].astro). Sin ese guard el SSR haría un fetch al backend que tirara
+    // error y la React island intentaria hidratarse sobre HTML incompleto.
+    await page.goto(`${FRONTEND_URL}/partidos/no-es-uuid`);
+
+    await expect(page).toHaveURL(/\/partidos$/);
+    await expect(matchDetailPage.root).toHaveCount(0);
+  });
+});

--- a/apps/testing/tests/leave-match.spec.ts
+++ b/apps/testing/tests/leave-match.spec.ts
@@ -1,43 +1,32 @@
-import { expect, test, type APIRequestContext, type Page, type Route } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import {
+  BACKEND_GRAPHQL_ROUTE,
+  expect,
+  gqlPost,
+  loginAndReadToken,
+  mockGraphQLOperation,
+  test,
+} from './support';
 
 /**
- * Tests E2E del flujo "Salirme del partido" (LeaveMatchButton en /partidos/[id]).
+ * Tests E2E del flujo "Salirme del partido" (LeaveMatchButton).
  *
  * Decision Context:
- * - Por qué un spec dedicado en vez de extender match-detail.spec.ts: ese spec ya cubre
- *   el render del botón y el caso de error. Acá agregamos los huecos: diálogo de
- *   confirmación, cancelar, success con matchDeleted=false (reload), success con
- *   matchDeleted=true (redirect a /partidos), y el estado de loading.
- * - Pattern de mocking: el detalle del partido es SSR (no se puede interceptar desde el
- *   browser), pero la mutation `leaveMatch` la dispara la React island desde el browser
- *   con `fetch`, así que SÍ la mockeamos con `page.route('**\/graphql')`. Eso nos
- *   permite forzar las dos respuestas exitosas y el error sin depender del estado real
- *   de la DB.
- * - Self-setup: para tener un partido donde el usuario figure como inscripto, en el
- *   beforeEach buscamos uno donde ya esté joined; si no, hacemos `joinMatch` via GraphQL
- *   contra un partido OPEN cualquiera. Esto evita pedirle al dev que primero se inscriba
- *   manualmente desde la UI antes de correr la suite.
- * - Por qué NO testeamos el modal urgente (<60min): no podemos crear partidos que
- *   arranquen en <60min sin acceso de admin a la DB. La rama urgente queda cubierta por
- *   inspección visual / testing manual; el test de "diálogo normal" valida la rama
- *   ≥60min que es la habitual.
- * - Assumptions:
- *   * Frontend en :4321 y backend en :4000.
- *   * Existe al menos 1 partido OPEN con cupo en la cloud DB (de lo contrario, no
- *     podemos joined ni leave — los tests skipean con mensaje claro).
- *   * El usuario `ricardo@gmail.com` (player) puede unirse a partidos del listado.
+ * - Spec dedicado para cubrir los huecos que match-detail.spec.ts no toca:
+ *   diálogo de confirmación, cancelar, success con matchDeleted=false (reload),
+ *   success con matchDeleted=true (redirect a /partidos), y estado de loading.
+ * - Pattern de mocking: el detalle es SSR; mockeamos sólo `leaveMatch` que sí
+ *   sale del browser. Eso permite forzar las dos respuestas exitosas y el
+ *   error sin tocar la DB.
+ * - Self-setup: para tener un partido donde el player figure como inscripto,
+ *   intentamos joinMatch contra cualquier partido OPEN del listado. Si el
+ *   backend dice "ya estás inscripto", también nos sirve. Sin candidato,
+ *   `test.skip` con mensaje claro.
+ * - El modal urgente (<60min) no se testea porque no podemos crear partidos
+ *   con start <60min sin acceso de admin a la DB; queda cubierto por testing
+ *   manual / inspección visual.
  * - Previously fixed bugs: none relevant.
  */
-
-const FRONTEND_URL = 'http://localhost:4321';
-const BACKEND_GRAPHQL_URL = 'http://localhost:4000/graphql';
-const BACKEND_GRAPHQL_ROUTE = '**/graphql';
-const ACCESS_TOKEN_COOKIE = 'sumateya-access-token';
-
-const TEST_PLAYER = {
-  email: 'ricardo@gmail.com',
-  password: 'bbbb1234',
-};
 
 type MatchSummary = {
   id: string;
@@ -45,39 +34,6 @@ type MatchSummary = {
   availableSlots: number;
   isCurrentUserJoined: boolean | null;
 };
-
-// ─────────────────────────── Helpers ───────────────────────────
-
-async function login(page: Page): Promise<void> {
-  await page.goto(`${FRONTEND_URL}/login`);
-  await page.getByRole('textbox', { name: 'Email' }).fill(TEST_PLAYER.email);
-  await page.getByRole('textbox', { name: /contrase/i }).fill(TEST_PLAYER.password);
-  await page.getByRole('button', { name: /ingresar/i }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
-}
-
-async function readAccessToken(page: Page): Promise<string> {
-  const cookies = await page.context().cookies(FRONTEND_URL);
-  const token = cookies.find((c) => c.name === ACCESS_TOKEN_COOKIE)?.value;
-  expect(token, 'el login debe dejar cookie de access token').toBeTruthy();
-  return token as string;
-}
-
-async function gqlPost<T>(
-  request: APIRequestContext,
-  query: string,
-  variables: Record<string, unknown> | undefined,
-  accessToken: string,
-): Promise<{ data?: T; errors?: Array<{ message: string }> }> {
-  const response = await request.post(BACKEND_GRAPHQL_URL, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-    },
-    data: { query, variables },
-  });
-  return (await response.json()) as { data?: T; errors?: Array<{ message: string }> };
-}
 
 async function fetchMatchesForPlayer(
   request: APIRequestContext,
@@ -87,12 +43,7 @@ async function fetchMatchesForPlayer(
     request,
     /* GraphQL */ `
       query GetMatchesForLeaveE2E {
-        matches {
-          id
-          status
-          availableSlots
-          isCurrentUserJoined
-        }
+        matches { id status availableSlots isCurrentUserJoined }
       }
     `,
     undefined,
@@ -101,15 +52,6 @@ async function fetchMatchesForPlayer(
   return json.data?.matches ?? [];
 }
 
-/**
- * Garantiza que el player de test esté inscripto en algún partido OPEN.
- * Devuelve el `matchId` listo para navegar a `/partidos/<id>`. Si no hay partidos
- * candidatos, devuelve `null` y los tests deben skipearse.
- */
-/**
- * Intenta unirse a un partido al equipo `team`. Devuelve true si el join fue exitoso o
- * si el backend indica que ya estaba inscripto (ambos casos sirven para nuestra setup).
- */
 async function tryJoinTeam(
   request: APIRequestContext,
   accessToken: string,
@@ -120,10 +62,7 @@ async function tryJoinTeam(
     request,
     /* GraphQL */ `
       mutation JoinForLeaveE2E($input: JoinMatchInput!) {
-        joinMatch(input: $input) {
-          success
-          message
-        }
+        joinMatch(input: $input) { success message }
       }
     `,
     { input: { matchId, team } },
@@ -140,135 +79,79 @@ async function tryJoinTeam(
   return { ok: false, reason: msg || 'unknown error' };
 }
 
+/**
+ * Garantiza que el player de test esté inscripto en algún partido OPEN.
+ * Devuelve el `matchId` listo para navegar al detalle. Si no hay candidato,
+ * devuelve `null` y el test debe skipearse.
+ */
 async function ensureJoinedMatch(
   request: APIRequestContext,
   accessToken: string,
 ): Promise<string | null> {
   const matches = await fetchMatchesForPlayer(request, accessToken);
 
-  // El listado matches NO popula isCurrentUserJoined (solo el detalle lo hace), así
-  // que no podemos filtrar por "ya estoy inscripto" sin hacer un fetch por partido.
-  // En su lugar, intentamos joinMatch directo y dejamos que el backend nos diga
-  // "ya estás inscripto" — eso también cuenta como éxito para el setup.
+  // El listado matches NO popula isCurrentUserJoined (sólo el detalle lo hace), así
+  // que intentamos joinMatch directo: el backend nos dice si ya estábamos inscriptos.
   for (const match of matches) {
     if (match.status !== 'OPEN' || match.availableSlots <= 0) continue;
-
-    // joinMatch requiere `team: MatchTeam!` (A o B). Probamos A primero; si está
-    // lleno o falla por team-specific, probamos B.
-    const tryA = await tryJoinTeam(request, accessToken, match.id, 'A');
-    if (tryA.ok) return match.id;
-
-    const tryB = await tryJoinTeam(request, accessToken, match.id, 'B');
-    if (tryB.ok) return match.id;
+    if ((await tryJoinTeam(request, accessToken, match.id, 'A')).ok) return match.id;
+    if ((await tryJoinTeam(request, accessToken, match.id, 'B')).ok) return match.id;
   }
-
   return null;
 }
 
-/**
- * Mockea SOLO la mutation `leaveMatch` y deja pasar el resto del tráfico GraphQL.
- * Devuelve un objeto con `payloads` para verificar que la mutation efectivamente se
- * disparó (y con qué variables).
- */
-async function mockLeaveMatch(
-  page: Page,
-  body: unknown,
-  options: { delayMs?: number } = {},
-): Promise<{ payloads: unknown[] }> {
-  const payloads: unknown[] = [];
-
-  await page.route(BACKEND_GRAPHQL_ROUTE, async (route: Route) => {
-    const raw = route.request().postData() ?? '{}';
-    const parsed = JSON.parse(raw) as { query?: string };
-
-    if (!parsed.query?.includes('leaveMatch')) {
-      await route.continue();
-      return;
-    }
-
-    payloads.push(parsed);
-    if (options.delayMs) {
-      await new Promise((resolve) => setTimeout(resolve, options.delayMs));
-    }
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(body),
-    });
-  });
-
-  return { payloads };
-}
-
-async function gotoMatchDetail(page: Page, matchId: string): Promise<void> {
-  await page.goto(`${FRONTEND_URL}/partidos/${matchId}`);
-  await expect(page.locator('.match-detail')).toBeVisible();
-}
-
-// ─────────────────────────── Tests ───────────────────────────
-
 test.describe('Salirme del partido (LeaveMatchButton)', () => {
-  // Serial: todos comparten el mismo player y la setup de "estar inscripto"; correr en
-  // paralelo causaría que los tests se pisen entre sí (uno deja el partido y el otro
-  // ya no lo ve).
+  // Serial: tests comparten el mismo player y el setup de "estar inscripto".
   test.describe.configure({ mode: 'serial' });
 
   test('al hacer click en "Salirme del partido" aparece el diálogo de confirmación', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
-    await login(page);
-    const token = await readAccessToken(page);
+    const token = await loginAndReadToken(page, 'playerRicardo');
     const matchId = await ensureJoinedMatch(request, token);
     test.skip(!matchId, 'No hay partidos OPEN con cupo en la DB para inscribir al player.');
-    if (!matchId) return; // narrowing para TS — `test.skip` ya tiró arriba.
+    if (!matchId) return;
 
-    await gotoMatchDetail(page, matchId);
+    await matchDetailPage.goto(matchId);
+    await matchDetailPage.openLeaveDialog();
 
-    await page.getByRole('button', { name: /salirme del partido/i }).click();
-
-    const dialog = page.getByRole('dialog');
-    await expect(dialog).toBeVisible();
-    await expect(dialog.getByText(/¿(querés|estás seguro)/i)).toBeVisible();
-    await expect(dialog.getByRole('button', { name: /sí, salirme/i })).toBeVisible();
-    await expect(dialog.getByRole('button', { name: /cancelar/i })).toBeVisible();
+    await expect(matchDetailPage.confirmDialog.getByText(/¿(querés|estás seguro)/i)).toBeVisible();
+    await expect(matchDetailPage.confirmLeaveButton).toBeVisible();
+    await expect(matchDetailPage.cancelLeaveButton).toBeVisible();
   });
 
   test('click en "Cancelar" cierra el diálogo y vuelve al estado inicial', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
-    await login(page);
-    const token = await readAccessToken(page);
+    const token = await loginAndReadToken(page, 'playerRicardo');
     const matchId = await ensureJoinedMatch(request, token);
     test.skip(!matchId, 'No hay partidos OPEN con cupo en la DB para inscribir al player.');
-    if (!matchId) return; // narrowing para TS — `test.skip` ya tiró arriba.
+    if (!matchId) return;
 
-    await gotoMatchDetail(page, matchId);
+    await matchDetailPage.goto(matchId);
+    await matchDetailPage.openLeaveDialog();
+    await matchDetailPage.cancelLeaveButton.click();
 
-    await page.getByRole('button', { name: /salirme del partido/i }).click();
-    await expect(page.getByRole('dialog')).toBeVisible();
-
-    await page.getByRole('button', { name: /cancelar/i }).click();
-
-    await expect(page.getByRole('dialog')).toHaveCount(0);
-    // El botón principal vuelve a estar visible (estado idle).
-    await expect(page.getByRole('button', { name: /salirme del partido/i })).toBeVisible();
+    await expect(matchDetailPage.confirmDialog).toHaveCount(0);
+    await expect(matchDetailPage.leaveButton).toBeVisible();
   });
 
-  test('confirmar exitoso con matchDeleted=false → la página se recarga y queda en /partidos/[id]', async ({
+  test('confirmar exitoso con matchDeleted=false → la página recarga y queda en /partidos/[id]', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
-    await login(page);
-    const token = await readAccessToken(page);
+    const token = await loginAndReadToken(page, 'playerRicardo');
     const matchId = await ensureJoinedMatch(request, token);
     test.skip(!matchId, 'No hay partidos OPEN con cupo en la DB para inscribir al player.');
-    if (!matchId) return; // narrowing para TS — `test.skip` ya tiró arriba.
+    if (!matchId) return;
 
-    // El flujo real haría leave de verdad y se quedaría sin partido — para no romper
-    // el seed de la DB mockeamos la respuesta exitosa SIN borrar el partido.
-    const leave = await mockLeaveMatch(page, {
+    // Mockeamos el éxito SIN borrar el partido para no romper el seed.
+    const leave = await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'leaveMatch', {
       data: {
         leaveMatch: {
           matchDeleted: false,
@@ -282,87 +165,73 @@ test.describe('Salirme del partido (LeaveMatchButton)', () => {
       },
     });
 
-    await gotoMatchDetail(page, matchId);
+    await matchDetailPage.goto(matchId);
+    await matchDetailPage.openLeaveDialog();
+    await matchDetailPage.confirmLeaveButton.click();
 
-    await page.getByRole('button', { name: /salirme del partido/i }).click();
-    await page.getByRole('button', { name: /sí, salirme/i }).click();
-
-    // La mutation se disparó exactamente 1 vez.
     await expect.poll(() => leave.payloads.length, { timeout: 10_000 }).toBe(1);
-
-    // Tras el reload, sigue en la misma URL (no hubo redirect a /partidos).
     await expect(page).toHaveURL(new RegExp(`/partidos/${matchId}`));
   });
 
   test('confirmar exitoso con matchDeleted=true → redirige a /partidos', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
-    await login(page);
-    const token = await readAccessToken(page);
+    const token = await loginAndReadToken(page, 'playerRicardo');
     const matchId = await ensureJoinedMatch(request, token);
     test.skip(!matchId, 'No hay partidos OPEN con cupo en la DB para inscribir al player.');
-    if (!matchId) return; // narrowing para TS — `test.skip` ya tiró arriba.
+    if (!matchId) return;
 
-    const leave = await mockLeaveMatch(page, {
-      data: {
-        leaveMatch: {
-          matchDeleted: true,
-          match: null,
-        },
-      },
+    const leave = await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'leaveMatch', {
+      data: { leaveMatch: { matchDeleted: true, match: null } },
     });
 
-    await gotoMatchDetail(page, matchId);
-
-    await page.getByRole('button', { name: /salirme del partido/i }).click();
-    await page.getByRole('button', { name: /sí, salirme/i }).click();
+    await matchDetailPage.goto(matchId);
+    await matchDetailPage.openLeaveDialog();
+    await matchDetailPage.confirmLeaveButton.click();
 
     await expect.poll(() => leave.payloads.length, { timeout: 10_000 }).toBe(1);
-
-    // La página redirige al listado cuando el partido se autodestruyó (último jugador).
     await expect(page).toHaveURL(/\/partidos$/);
   });
 
   test('si el backend devuelve un error, se muestra el mensaje y el botón vuelve a estar disponible', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
-    await login(page);
-    const token = await readAccessToken(page);
+    const token = await loginAndReadToken(page, 'playerRicardo');
     const matchId = await ensureJoinedMatch(request, token);
     test.skip(!matchId, 'No hay partidos OPEN con cupo en la DB para inscribir al player.');
-    if (!matchId) return; // narrowing para TS — `test.skip` ya tiró arriba.
+    if (!matchId) return;
 
-    await mockLeaveMatch(page, {
+    await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'leaveMatch', {
       errors: [{ message: 'No se pudo procesar la solicitud.' }],
     });
 
-    await gotoMatchDetail(page, matchId);
+    await matchDetailPage.goto(matchId);
+    await matchDetailPage.openLeaveDialog();
+    await matchDetailPage.confirmLeaveButton.click();
 
-    await page.getByRole('button', { name: /salirme del partido/i }).click();
-    await page.getByRole('button', { name: /sí, salirme/i }).click();
-
-    // El error aparece en un role=alert. Sigue en la misma página.
     await expect(page.getByRole('alert')).toContainText(/no se pudo procesar/i);
     await expect(page).toHaveURL(new RegExp(`/partidos/${matchId}`));
-    // El botón de salirme vuelve a estar visible para que el user pueda reintentar.
-    await expect(page.getByRole('button', { name: /salirme del partido/i })).toBeVisible();
+    await expect(matchDetailPage.leaveButton).toBeVisible();
   });
 
   test('mientras la request está en vuelo, el botón muestra "Procesando…" y queda deshabilitado', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
-    await login(page);
-    const token = await readAccessToken(page);
+    const token = await loginAndReadToken(page, 'playerRicardo');
     const matchId = await ensureJoinedMatch(request, token);
     test.skip(!matchId, 'No hay partidos OPEN con cupo en la DB para inscribir al player.');
-    if (!matchId) return; // narrowing para TS — `test.skip` ya tiró arriba.
+    if (!matchId) return;
 
-    // Demoramos la respuesta 1.5s para poder ver el estado "loading".
-    await mockLeaveMatch(
+    await mockGraphQLOperation(
       page,
+      BACKEND_GRAPHQL_ROUTE,
+      'leaveMatch',
       {
         data: {
           leaveMatch: {
@@ -379,12 +248,10 @@ test.describe('Salirme del partido (LeaveMatchButton)', () => {
       { delayMs: 1500 },
     );
 
-    await gotoMatchDetail(page, matchId);
+    await matchDetailPage.goto(matchId);
+    await matchDetailPage.openLeaveDialog();
+    await matchDetailPage.confirmLeaveButton.click();
 
-    await page.getByRole('button', { name: /salirme del partido/i }).click();
-    await page.getByRole('button', { name: /sí, salirme/i }).click();
-
-    // Estado loading: aparece el botón con "Procesando…" deshabilitado y aria-busy.
     const loading = page.getByRole('button', { name: /procesando/i });
     await expect(loading).toBeVisible();
     await expect(loading).toBeDisabled();

--- a/apps/testing/tests/login.spec.ts
+++ b/apps/testing/tests/login.spec.ts
@@ -1,66 +1,42 @@
-import { test, expect, type Page } from '@playwright/test';
+import { expect, FRONTEND_URL, test, TEST_USERS } from './support';
 
 /**
  * Tests E2E del flujo de login (/login).
  *
  * Decision Context:
- * - Por qué la mayoría NO mockea: login.astro es SSR (`prerender = false`) y el POST se
- *   procesa en el servidor de Astro, que llama al backend Express via `loginWithBackend()`
- *   desde Node. Esa request nunca pasa por el browser, así que `page.route()` no la
- *   intercepta. Los tests se separan en dos grupos:
- *     1. Render + interacción client-side: siempre corren, no requieren nada.
- *     2. Submit real → redirect por rol: requieren backend en :4000 + Supabase
- *        autenticado. `playwright.config.ts` arranca `npm run dev` (turbo) antes de
- *        correr la suite, así que el backend siempre está disponible.
- * - Por qué hardcodeamos los seed users por defecto: los emails y contraseñas de
- *   `lucas@test.com` / `admin@clubsur.com` viven sin cifrar en
- *   `apps/backend/supabase/seed.sql` — no son secretos, son data de bootstrapping para
- *   cualquier dev que levanta el ambiente. Las env vars TEST_PLAYER_EMAIL etc. están
- *   por si alguien corre los tests contra una DB cloud con otros usuarios.
+ * - Por qué este spec NO usa `test.use({ storageState })`: estamos validando el
+ *   flujo de login en sí. Cualquier saved-state nos saltearía la página que
+ *   queremos probar.
+ * - Por qué la mayoría NO mockea: login.astro es SSR y el POST se procesa en el
+ *   servidor de Astro, que llama al backend Express via `loginWithBackend()`.
+ *   `page.route()` no intercepta esas requests; el playwright.config arranca
+ *   `npm run dev` (turbo) antes de la suite, así que el backend siempre está
+ *   disponible.
  * - Lo que validamos del role-based redirect: que después del POST exitoso, la URL
- *   final sea `/partidos` para player y `/panel-club` para club_admin (ver getRoleRedirect
- *   en lib/auth.ts).
- * - Assumptions:
- *   * Frontend en :4321 y backend en :4000 (`pnpm dev` en cada uno).
- *   * Para los tests con backend: el .env tiene SUPABASE_ANON_KEY válido y los usuarios
- *     existen en la DB con sus respectivos roles.
+ *   final sea `/partidos` para player y `/panel-club` para club_admin (ver
+ *   getRoleRedirect en lib/auth.ts).
  * - Previously fixed bugs: none relevant.
  */
 
-const FRONTEND_URL = 'http://localhost:4321';
-const LOGIN_URL = `${FRONTEND_URL}/login`;
-
-// Credenciales por defecto: cuentas de prueba registradas a mano en la cloud DB del
-// proyecto, exclusivas para E2E. Los usuarios seed del seed.sql (lucas@test.com etc.)
-// no existen en cloud — sólo se aplican al Supabase local. Estas cuentas son
-// "throwaway QA accounts": passwords débiles a propósito (corren contra una DB
-// de desarrollo, no producción), y commiteadas para que cualquier dev pueda correr
-// la suite sin setear env vars.
-// Las env vars permiten overridear si alguien corre contra otra DB.
-const PLAYER_EMAIL = process.env.TEST_PLAYER_EMAIL ?? 'ricardo@gmail.com';
-const PLAYER_PASSWORD = process.env.TEST_PLAYER_PASSWORD ?? 'bbbb1234';
-const CLUB_EMAIL = process.env.TEST_CLUB_EMAIL ?? 'frantestsumateya@gmail.com';
-const CLUB_PASSWORD = process.env.TEST_CLUB_PASSWORD ?? 'aaaa1234';
-
-async function gotoLogin(page: Page): Promise<void> {
-  await page.goto(LOGIN_URL);
-  await expect(page.locator('form.login-form')).toBeVisible();
-}
+const { playerMateo: PLAYER, clubAdmin: CLUB } = TEST_USERS;
 
 test.describe('Login (/login) — render y estructura', () => {
-  test('renderiza el header con el branding y el subtítulo', async ({ page }) => {
-    await gotoLogin(page);
+  test('renderiza el header con el branding y el subtítulo', async ({ loginPage, page }) => {
+    await loginPage.goto();
 
     await expect(page).toHaveTitle(/Iniciar sesión — Sumate Ya/);
     await expect(page.getByRole('heading', { name: /SUMATE YA/i })).toBeVisible();
     await expect(page.getByText(/Iniciá sesión para continuar/i)).toBeVisible();
   });
 
-  test('muestra los campos de email y contraseña con sus tipos correctos', async ({ page }) => {
-    await gotoLogin(page);
+  test('muestra los campos de email y contraseña con sus tipos correctos', async ({
+    loginPage,
+    page,
+  }) => {
+    await loginPage.goto();
 
-    await expect(page.getByLabel('Email')).toBeVisible();
-    await expect(page.getByLabel('Contraseña')).toBeVisible();
+    await expect(loginPage.emailInput).toBeVisible();
+    await expect(loginPage.passwordInput).toBeVisible();
 
     // type=email habilita validación nativa del browser; type=password oculta el valor.
     await expect(page.locator('input#email')).toHaveAttribute('type', 'email');
@@ -74,15 +50,15 @@ test.describe('Login (/login) — render y estructura', () => {
     );
   });
 
-  test('el form usa POST y tiene el botón "INGRESAR"', async ({ page }) => {
-    await gotoLogin(page);
+  test('el form usa POST y tiene el botón "INGRESAR"', async ({ loginPage }) => {
+    await loginPage.goto();
 
-    await expect(page.locator('form.login-form')).toHaveAttribute('method', /post/i);
-    await expect(page.getByRole('button', { name: 'INGRESAR' })).toBeVisible();
+    await expect(loginPage.form).toHaveAttribute('method', /post/i);
+    await expect(loginPage.submitButton).toBeVisible();
   });
 
-  test('muestra los links a registro de club y de jugador', async ({ page }) => {
-    await gotoLogin(page);
+  test('muestra los links a registro de club y de jugador', async ({ loginPage, page }) => {
+    await loginPage.goto();
 
     const clubLink = page.getByRole('link', { name: /Registrate acá/i }).first();
     const playerLink = page.getByRole('link', { name: /Registrate acá/i }).nth(1);
@@ -91,124 +67,100 @@ test.describe('Login (/login) — render y estructura', () => {
     await expect(playerLink).toHaveAttribute('href', '/registro-jugador');
   });
 
-  test('al venir desde registro exitoso muestra el banner de éxito', async ({ page }) => {
-    // El query param `?registered=1` lo setea registro-club.astro tras crear la cuenta.
-    await page.goto(`${LOGIN_URL}?registered=1`);
+  test('al venir desde registro exitoso muestra el banner de éxito', async ({ loginPage }) => {
+    await loginPage.goto('registered=1');
 
-    await expect(page.getByText(/Registro exitoso\. Ya podés iniciar sesión/i)).toBeVisible();
+    await expect(loginPage.registeredBanner).toBeVisible();
   });
 
-  test('por defecto (sin query param) NO muestra el banner de éxito', async ({ page }) => {
-    await gotoLogin(page);
+  test('por defecto (sin query param) NO muestra el banner de éxito', async ({ loginPage }) => {
+    await loginPage.goto();
 
-    await expect(page.getByText(/Registro exitoso/i)).not.toBeVisible();
+    await expect(loginPage.registeredBanner).not.toBeVisible();
   });
 });
 
 test.describe('Login — validación y errores (requiere backend)', () => {
-  test('submit con campos vacíos → mensaje "Completá todos los campos"', async ({ page }) => {
-    await gotoLogin(page);
-
-    // novalidate en el form deshabilita la validación HTML5, así que el POST llega al server.
-    await page.getByRole('button', { name: 'INGRESAR' }).click();
+  test('submit con campos vacíos → mensaje "Completá todos los campos"', async ({
+    loginPage,
+    page,
+  }) => {
+    await loginPage.goto();
+    await loginPage.submit();
 
     await expect(page).toHaveURL(/\/login/);
     await expect(page.getByText(/Completá todos los campos/i)).toBeVisible();
   });
 
   test('credenciales inválidas → mensaje genérico "Email o contraseña incorrectos"', async ({
+    loginPage,
     page,
   }) => {
-    await gotoLogin(page);
+    await loginPage.goto();
+    await loginPage.fillCredentials('noexiste@example.test', 'contraseña-incorrecta-123');
+    await loginPage.submit();
 
-    await page.getByLabel('Email').fill('noexiste@example.test');
-    await page.getByLabel('Contraseña').fill('contraseña-incorrecta-123');
-    await page.getByRole('button', { name: 'INGRESAR' }).click();
-
-    // El mensaje debe ser genérico — no debe revelar si el email existe (anti enumeration).
+    // Mensaje genérico — no debe revelar si el email existe (anti enumeration).
     await expect(page).toHaveURL(/\/login/);
     await expect(page.getByText(/Email o contraseña incorrectos/i)).toBeVisible();
   });
 
-  test('después de un error fallido, el campo email retiene el valor (UX)', async ({ page }) => {
-    await gotoLogin(page);
-
+  test('después de un error fallido, el campo email retiene el valor (UX)', async ({
+    loginPage,
+  }) => {
+    await loginPage.goto();
     const email = 'tester@example.test';
-    await page.getByLabel('Email').fill(email);
-    await page.getByLabel('Contraseña').fill('mal');
-    await page.getByRole('button', { name: 'INGRESAR' }).click();
+    await loginPage.fillCredentials(email, 'mal');
+    await loginPage.submit();
 
     // El SSR re-renderiza con `emailValue` para no obligar al usuario a re-tipearlo.
-    await expect(page.getByLabel('Email')).toHaveValue(email);
+    await expect(loginPage.emailInput).toHaveValue(email);
     // La contraseña, en cambio, NO se retiene (no se hace eco de credenciales).
-    await expect(page.getByLabel('Contraseña')).toHaveValue('');
+    await expect(loginPage.passwordInput).toHaveValue('');
   });
 });
 
 test.describe('Login — redirect por rol (requiere backend + credenciales válidas)', () => {
-  test('login exitoso como player → redirige a /partidos', async ({ page }) => {
-    await gotoLogin(page);
+  test('login exitoso como player → redirige a /partidos', async ({ loginPage, page }) => {
+    await loginPage.loginAs(PLAYER);
 
-    await page.getByLabel('Email').fill(PLAYER_EMAIL);
-    await page.getByLabel('Contraseña').fill(PLAYER_PASSWORD);
-    await page.getByRole('button', { name: 'INGRESAR' }).click();
-
-    await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
     await expect(page).toHaveURL(/\/partidos/);
   });
 
-  test('login exitoso como club_admin → redirige a /panel-club', async ({ page }) => {
-    await gotoLogin(page);
+  test('login exitoso como club_admin → redirige a /panel-club', async ({ loginPage, page }) => {
+    await loginPage.loginAs(CLUB);
 
-    await page.getByLabel('Email').fill(CLUB_EMAIL);
-    await page.getByLabel('Contraseña').fill(CLUB_PASSWORD);
-    await page.getByRole('button', { name: 'INGRESAR' }).click();
-
-    await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
     await expect(page).toHaveURL(/\/panel-club/);
   });
 
-  test('sesión persiste tras refresh de la página', async ({ page }) => {
-    // Loguearse
-    await gotoLogin(page);
-    await page.getByLabel('Email').fill(PLAYER_EMAIL);
-    await page.getByLabel('Contraseña').fill(PLAYER_PASSWORD);
-    await page.getByRole('button', { name: 'INGRESAR' }).click();
-    await page.waitForURL(/\/partidos/, { timeout: 10_000 });
+  test('sesión persiste tras refresh de la página', async ({ loginPage, page }) => {
+    await loginPage.loginAs(PLAYER);
 
-    // Reload — la cookie HttpOnly debe mantener la sesión y el middleware no debe rebotar.
+    // Reload — la cookie HttpOnly debe mantener la sesión.
     await page.reload();
     await expect(page).toHaveURL(/\/partidos/);
 
     // Re-visitar /login con sesión activa debe redirigir al home del rol.
-    await page.goto(LOGIN_URL);
+    await page.goto(`${FRONTEND_URL}/login`);
     await expect(page).toHaveURL(/\/partidos/);
   });
 
-  test('player intentando entrar a /panel-club → es rebotado a /partidos', async ({ page }) => {
-    // Login como player primero.
-    await gotoLogin(page);
-    await page.getByLabel('Email').fill(PLAYER_EMAIL);
-    await page.getByLabel('Contraseña').fill(PLAYER_PASSWORD);
-    await page.getByRole('button', { name: 'INGRESAR' }).click();
-    await page.waitForURL(/\/partidos/, { timeout: 10_000 });
+  test('player intentando entrar a /panel-club → es rebotado a /partidos', async ({
+    loginPage,
+    page,
+  }) => {
+    await loginPage.loginAs(PLAYER);
 
-    // Intentar entrar a la ruta exclusiva del club_admin.
-    // El middleware (ROLE_RESTRICTED) debe rebotarlo via getRoleRedirect.
     await page.goto(`${FRONTEND_URL}/panel-club`);
     await expect(page).toHaveURL(/\/partidos/);
   });
 
   test('club_admin intentando entrar a /partidos/crear → es rebotado a /panel-club', async ({
+    loginPage,
     page,
   }) => {
-    await gotoLogin(page);
-    await page.getByLabel('Email').fill(CLUB_EMAIL);
-    await page.getByLabel('Contraseña').fill(CLUB_PASSWORD);
-    await page.getByRole('button', { name: 'INGRESAR' }).click();
-    await page.waitForURL(/\/panel-club/, { timeout: 10_000 });
+    await loginPage.loginAs(CLUB);
 
-    // /partidos/crear es player-only en ROLE_RESTRICTED → debe rebotar al home del rol.
     await page.goto(`${FRONTEND_URL}/partidos/crear`);
     await expect(page).toHaveURL(/\/panel-club/);
   });

--- a/apps/testing/tests/match-detail.spec.ts
+++ b/apps/testing/tests/match-detail.spec.ts
@@ -1,29 +1,31 @@
-import { expect, test, type APIRequestContext, type Page, type Route } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import {
+  BACKEND_GRAPHQL_ROUTE,
+  expect,
+  FRONTEND_URL,
+  gqlPostOrThrow,
+  loginAndReadToken,
+  mockGraphQLOperation,
+  test,
+} from './support';
 
 /**
  * Tests E2E de Detalle de Partido (/partidos/[id]).
  *
  * Decision Context:
- * - Esta pagina es SSR: Astro consulta match(id) en el servidor antes de enviar HTML.
- *   Por eso page.route() no puede mockear el detalle inicial como si fuera un fetch del
- *   browser. Los tests buscan fixtures reales via GraphQL y validan la UI contra ese
- *   contrato.
- * - Los casos que dependen del estado del seed (partido full, usuario ya anotado,
- *   partido abierto con cupos) usan test.skip cuando no existe un partido compatible.
- *   Asi la suite no inventa datos falsos ni modifica Supabase para forzar bordes.
- * - Las acciones client-side de sumarse/salirse si se mockean, porque esos botones
- *   hacen fetch desde el browser al backend GraphQL y ahi page.route() si aplica.
+ * - Esta página es SSR: Astro consulta `match(id)` en el servidor antes de
+ *   enviar HTML. Por eso `page.route()` no puede mockear el detalle inicial
+ *   como si fuera un fetch del browser. Los tests buscan fixtures reales via
+ *   GraphQL y validan la UI contra ese contrato.
+ * - Los casos que dependen del estado del seed (full, ya inscripto, abierto
+ *   con cupos) usan `test.skip` cuando no existe un partido compatible. Así
+ *   la suite no inventa datos falsos ni modifica Supabase para forzar bordes.
+ * - Las acciones client-side de sumarse/salirse SI se mockean: esos botones
+ *   hacen fetch desde el browser al backend GraphQL → `page.route()` aplica.
+ * - Este spec hace login UI (no usa storage state) porque algunos tests son
+ *   anónimos y otros requieren un token explícito para hacer queries directas
+ *   contra el backend; mantener un solo flujo de login es más legible.
  */
-
-const FRONTEND_URL = 'http://localhost:4321';
-const BACKEND_GRAPHQL_URL = 'http://localhost:4000/graphql';
-const BACKEND_GRAPHQL_ROUTE = '**/graphql';
-const ACCESS_TOKEN_COOKIE = 'sumateya-access-token';
-
-const TEST_USER = {
-  email: 'mateoduran2010@gmail.com',
-  password: 'Hola1234',
-};
 
 type MatchFormat = 'FIVE_VS_FIVE' | 'SEVEN_VS_SEVEN' | 'TEN_VS_TEN' | 'ELEVEN_VS_ELEVEN';
 type MatchStatus = 'OPEN' | 'FULL' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
@@ -76,54 +78,16 @@ const FORMAT_LABEL: Record<MatchFormat, string> = {
   ELEVEN_VS_ELEVEN: '11v11',
 };
 
-async function login(page: Page): Promise<void> {
-  await page.goto(`${FRONTEND_URL}/login`);
-  await page.getByRole('textbox', { name: 'Email' }).fill(TEST_USER.email);
-  await page.getByRole('textbox', { name: /contrase/i }).fill(TEST_USER.password);
-  await page.getByRole('button', { name: /ingresar/i }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
-}
-
-async function readAccessToken(page: Page): Promise<string> {
-  const cookies = await page.context().cookies(FRONTEND_URL);
-  const token = cookies.find((cookie) => cookie.name === ACCESS_TOKEN_COOKIE)?.value;
-  expect(token, 'el login debe dejar cookie de access token').toBeTruthy();
-  return token as string;
-}
-
-async function graphql<T>(
-  request: APIRequestContext,
-  query: string,
-  variables?: Record<string, unknown>,
-  accessToken?: string,
-): Promise<T> {
-  const response = await request.post(BACKEND_GRAPHQL_URL, {
-    headers: {
-      'Content-Type': 'application/json',
-      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-    },
-    data: { query, variables },
-  });
-  expect(response.ok()).toBe(true);
-
-  const payload = (await response.json()) as { data?: T; errors?: Array<{ message: string }> };
-  expect(payload.errors ?? []).toHaveLength(0);
-  expect(payload.data).toBeTruthy();
-  return payload.data as T;
-}
-
 async function fetchMatchIds(request: APIRequestContext): Promise<string[]> {
-  const data = await graphql<{ matches: Array<{ id: string }> }>(
+  const data = await gqlPostOrThrow<{ matches: Array<{ id: string }> }>(
     request,
     /* GraphQL */ `
       query GetMatchesForDetailE2E {
-        matches {
-          id
-        }
+        matches { id }
       }
     `,
   );
-  return data.matches.map((match) => match.id);
+  return data.matches.map((m) => m.id);
 }
 
 async function fetchMatchDetail(
@@ -131,41 +95,20 @@ async function fetchMatchDetail(
   id: string,
   accessToken?: string,
 ): Promise<MatchDetail | null> {
-  const data = await graphql<{ match: MatchDetail | null }>(
+  const data = await gqlPostOrThrow<{ match: MatchDetail | null }>(
     request,
     /* GraphQL */ `
       query GetMatchDetailForE2E($id: ID!) {
         match(id: $id) {
-          id
-          title
-          startTime
-          format
-          totalSlots
-          availableSlots
-          status
-          description
-          organizerId
+          id title startTime format totalSlots availableSlots status description organizerId
           currentUserTeam
-          club {
-            id
-            name
-            zone
-            address
-            lat
-            lng
-            phone
-          }
+          club { id name zone address lat lng phone }
           participants {
             teamA { id displayName avatarUrl preferredPosition }
             teamB { id displayName avatarUrl preferredPosition }
-            teamACount
-            teamBCount
-            totalCount
-            spotsLeftA
-            spotsLeftB
+            teamACount teamBCount totalCount spotsLeftA spotsLeftB
           }
-          isCurrentUserJoined
-          canJoin
+          isCurrentUserJoined canJoin
         }
       }
     `,
@@ -187,73 +130,8 @@ async function findMatch(
   return null;
 }
 
-async function gotoMatchDetail(page: Page, matchId: string): Promise<void> {
-  await page.goto(`${FRONTEND_URL}/partidos/${matchId}`);
-  await expect(page.locator('.match-detail')).toBeVisible();
-  await waitForIslandsHydrated(page);
-}
-
-// Decision Context: las React islands del detalle (JoinTeamButton, LeaveMatchButton)
-// usan client:load. Astro renderiza el HTML del boton en el SSR pero el handler
-// onClick recien se attachea cuando la island termina de hidratar. Si Playwright
-// hace click antes de la hidratacion, el evento se dispatchea sobre un boton sin
-// listener y la mutation no se ejecuta nunca, fallando el `expect.poll(payloads.length)`
-// con timeout. El web component <astro-island> trackea su estado: mientras hidrata
-// expone el atributo `ssr` y/o `await-children`; al completar la hidratacion los
-// remueve.
-// IMPORTANTE: filtramos SOLO las islands con `client="load"`. Las que usan
-// `client:visible` (ej: MatchResultsSection en el bottom de la pagina) nunca pierden
-// el atributo `ssr` hasta que el usuario las scrollea a la vista — esperar por ellas
-// hace timeoutear el helper. Para nuestros tests solo importan los CTAs above the
-// fold (JoinTeamButton, LeaveMatchButton).
-// Previously fixed bugs:
-//   1. Tests "Sumarme por equipo" y "error inline al salir" fallaban con
-//      `expected 1, received 0` porque el click se hacia antes de la hidratacion.
-//   2. Despues de agregarse MatchResultsSection con client:visible, el helper
-//      timeouteaba a los 10s porque esa island nunca hidrata sin scroll —
-//      filtrado por client="load" lo arregla.
-async function waitForIslandsHydrated(page: Page): Promise<void> {
-  // Astro 6 marca cada island hidratada agregando el atributo `client-render-time`
-  // (que registra cuántos ms tardó React en montar). En cambio `await-children`
-  // queda pegado al elemento incluso después de hidratar — por eso NO sirve como
-  // señal negativa. Usamos la presencia de `client-render-time` como indicador
-  // positivo: si está, el handler onClick ya está enganchado.
-  await page.waitForFunction(() => {
-    const islands = Array.from(document.querySelectorAll('astro-island[client="load"]'));
-    if (islands.length === 0) return true;
-    return islands.every((island) => island.hasAttribute('client-render-time'));
-  }, { timeout: 10_000 });
-}
-
 function allPlayers(match: MatchDetail): TeamMember[] {
   return [...(match.participants?.teamA ?? []), ...(match.participants?.teamB ?? [])];
-}
-
-async function mockGraphQLMutation(
-  page: Page,
-  operationName: 'JoinMatch' | 'LeaveMatch',
-  body: unknown,
-): Promise<{ payloads: unknown[] }> {
-  const payloads: unknown[] = [];
-
-  await page.route(BACKEND_GRAPHQL_ROUTE, async (route: Route) => {
-    const raw = route.request().postData() ?? '{}';
-    const parsed = JSON.parse(raw) as { query?: string };
-
-    if (!parsed.query?.includes(operationName === 'JoinMatch' ? 'joinMatch' : 'leaveMatch')) {
-      await route.continue();
-      return;
-    }
-
-    payloads.push(parsed);
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(body),
-    });
-  });
-
-  return { payloads };
 }
 
 test.describe('Detalle de Partido (/partidos/[id])', () => {
@@ -266,24 +144,28 @@ test.describe('Detalle de Partido (/partidos/[id])', () => {
   });
 
   test('muestra datos completos del partido, club, ubicacion y equipos', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
     const match = await findMatch(request, () => true);
     test.skip(!match, 'No hay partidos disponibles en el backend para validar el detalle.');
+    if (!match) return;
 
-    await gotoMatchDetail(page, match.id);
+    await matchDetailPage.goto(match.id);
 
     await expect(page.getByRole('heading', { name: match.title })).toBeVisible();
     await expect(page.getByText(FORMAT_LABEL[match.format], { exact: true }).first()).toBeVisible();
-    await expect(page.getByText(new RegExp(`${match.participants?.totalCount ?? 0} / ${match.totalSlots}`))).toBeVisible();
+    await expect(
+      page.getByText(new RegExp(`${match.participants?.totalCount ?? 0} / ${match.totalSlots}`)),
+    ).toBeVisible();
 
     if (match.description) {
       await expect(page.locator('.match-desc')).toContainText(match.description);
     }
 
     const organizer = match.organizerId
-      ? allPlayers(match).find((player) => player.id === match.organizerId)
+      ? allPlayers(match).find((p) => p.id === match.organizerId)
       : null;
     if (organizer) {
       await expect(page.getByText('Organizador').first()).toBeVisible();
@@ -293,22 +175,24 @@ test.describe('Detalle de Partido (/partidos/[id])', () => {
     if (match.club) {
       await expect(page.getByRole('heading', { name: match.club.name })).toBeVisible();
       if (match.club.address) {
-        await expect(page.locator('.location-card').getByText(match.club.address, { exact: true })).toBeVisible();
+        await expect(
+          page.locator('.location-card').getByText(match.club.address, { exact: true }),
+        ).toBeVisible();
       }
       if (match.club.zone) {
-        await expect(page.locator('.location-card').getByText(match.club.zone, { exact: true })).toBeVisible();
+        await expect(
+          page.locator('.location-card').getByText(match.club.zone, { exact: true }),
+        ).toBeVisible();
       }
-
       if (match.club.lat != null && match.club.lng != null) {
-        await expect(page.getByRole('link', { name: /ver .*google maps|ver en mapa/i })).toHaveAttribute(
-          'href',
-          `https://www.google.com/maps?q=${match.club.lat},${match.club.lng}`,
-        );
+        await expect(
+          page.getByRole('link', { name: /ver .*google maps|ver en mapa/i }),
+        ).toHaveAttribute('href', `https://www.google.com/maps?q=${match.club.lat},${match.club.lng}`);
       }
     }
 
-    await expect(page.getByText(`EQUIPO A`)).toBeVisible();
-    await expect(page.getByText(`EQUIPO B`)).toBeVisible();
+    await expect(page.getByText('EQUIPO A')).toBeVisible();
+    await expect(page.getByText('EQUIPO B')).toBeVisible();
     // Scope a cada `.team-card` para evitar strict-mode violations cuando ambos
     // equipos comparten el mismo conteo (p.ej. partido lleno con teams balanceados).
     const spotsPerTeam = Math.floor(match.totalSlots / 2);
@@ -327,110 +211,115 @@ test.describe('Detalle de Partido (/partidos/[id])', () => {
   });
 
   test('muestra CTA de login para sumarse cuando el visitante no esta autenticado', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
-    const match = await findMatch(
-      request,
-      (candidate) => candidate.status === 'OPEN' && candidate.availableSlots > 0,
+    const match = await findMatch(request, (c) => c.status === 'OPEN' && c.availableSlots > 0);
+    test.skip(!match, 'No hay partido abierto con cupos para validar CTA anónima.');
+    if (!match) return;
+
+    await matchDetailPage.goto(match.id);
+
+    await expect(page.getByRole('link', { name: /inici/i }).first()).toHaveAttribute(
+      'href',
+      '/login',
     );
-    test.skip(!match, 'No hay partido abierto con cupos para validar CTA anonima.');
-
-    await gotoMatchDetail(page, match.id);
-
-    await expect(page.getByRole('link', { name: /inici/i }).first()).toHaveAttribute('href', '/login');
     await expect(page.getByText(/para sumarte a este partido/i)).toBeVisible();
   });
 
   test('muestra botones "Sumarme" por equipo y envia la mutation correcta', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
-    await login(page);
-    const token = await readAccessToken(page);
+    const token = await loginAndReadToken(page, 'playerMateo');
     const match = await findMatch(
       request,
-      (candidate) => candidate.status === 'OPEN' && candidate.canJoin === true && candidate.isCurrentUserJoined === false,
+      (c) => c.status === 'OPEN' && c.canJoin === true && c.isCurrentUserJoined === false,
       token,
     );
     test.skip(!match, 'No hay partido abierto con cupos para un usuario no inscripto.');
+    if (!match) return;
 
-    const join = await mockGraphQLMutation(page, 'JoinMatch', {
+    const join = await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'joinMatch', {
       data: { joinMatch: { success: true, message: null } },
     });
 
-    await gotoMatchDetail(page, match.id);
-
-    const teamAButton = page.getByRole('button', { name: /sumarme al equipo a/i });
-    const teamBButton = page.getByRole('button', { name: /sumarme al equipo b/i });
+    await matchDetailPage.goto(match.id);
 
     if ((match.participants?.spotsLeftA ?? 0) > 0) {
-      await expect(teamAButton).toBeVisible();
-      await teamAButton.click();
+      await expect(matchDetailPage.joinTeamA).toBeVisible();
+      await matchDetailPage.joinTeamA.click();
       await expect.poll(() => join.payloads.length, { timeout: 10_000 }).toBe(1);
       expect(join.payloads[0]).toMatchObject({
         variables: { input: { matchId: match.id, team: 'A' } },
       });
     } else {
       await expect(page.getByRole('button', { name: /equipo completo/i }).first()).toBeDisabled();
-      await expect(teamBButton).toBeVisible();
+      await expect(matchDetailPage.joinTeamB).toBeVisible();
     }
   });
 
   test('si el partido esta completo muestra badge "Completo" y no ofrece sumarse', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
     const match = await findMatch(
       request,
-      (candidate) => candidate.status === 'FULL' || candidate.availableSlots === 0,
+      (c) => c.status === 'FULL' || c.availableSlots === 0,
     );
     test.skip(!match, 'No hay partido completo en el backend para validar el borde FULL.');
+    if (!match) return;
 
-    await gotoMatchDetail(page, match.id);
+    await matchDetailPage.goto(match.id);
 
     await expect(page.getByText(/completo/i).first()).toBeVisible();
     await expect(page.getByRole('button', { name: /sumarme/i })).toHaveCount(0);
   });
 
   test('si el usuario ya esta inscripto muestra estado y opcion para salir', async ({
+    matchDetailPage,
     page,
     request,
   }) => {
-    await login(page);
-    const token = await readAccessToken(page);
+    const token = await loginAndReadToken(page, 'playerMateo');
     const match = await findMatch(
       request,
-      (candidate) => candidate.isCurrentUserJoined === true && candidate.status !== 'CANCELLED',
+      (c) => c.isCurrentUserJoined === true && c.status !== 'CANCELLED',
       token,
     );
-    test.skip(!match, 'El usuario de prueba no esta inscripto en ningun partido activo.');
+    test.skip(!match, 'El usuario de prueba no está inscripto en ningún partido activo.');
+    if (!match) return;
 
-    await gotoMatchDetail(page, match.id);
+    await matchDetailPage.goto(match.id);
 
     await expect(page.getByText(/ya est/i).first()).toBeVisible();
-    await expect(page.getByRole('button', { name: /salirme del partido/i })).toBeVisible();
+    await expect(matchDetailPage.leaveButton).toBeVisible();
     await expect(page.getByRole('button', { name: /sumarme/i })).toHaveCount(0);
   });
 
-  test('muestra error inline si falla la salida del partido', async ({ page, request }) => {
-    await login(page);
-    const token = await readAccessToken(page);
+  test('muestra error inline si falla la salida del partido', async ({
+    matchDetailPage,
+    page,
+    request,
+  }) => {
+    const token = await loginAndReadToken(page, 'playerMateo');
     const match = await findMatch(
       request,
-      (candidate) => candidate.isCurrentUserJoined === true && candidate.status !== 'CANCELLED',
+      (c) => c.isCurrentUserJoined === true && c.status !== 'CANCELLED',
       token,
     );
-    test.skip(!match, 'El usuario de prueba no esta inscripto en ningun partido activo.');
+    test.skip(!match, 'El usuario de prueba no está inscripto en ningún partido activo.');
+    if (!match) return;
 
-    const leave = await mockGraphQLMutation(page, 'LeaveMatch', {
+    const leave = await mockGraphQLOperation(page, BACKEND_GRAPHQL_ROUTE, 'leaveMatch', {
       errors: [{ message: 'No se pudo salir del partido.' }],
     });
 
-    await gotoMatchDetail(page, match.id);
-
-    await page.getByRole('button', { name: /salirme del partido/i }).click();
-    await expect(page.getByRole('dialog')).toBeVisible();
+    await matchDetailPage.goto(match.id);
+    await matchDetailPage.openLeaveDialog();
     await page.getByRole('button', { name: /salirme/i }).click();
 
     await expect.poll(() => leave.payloads.length, { timeout: 10_000 }).toBe(1);

--- a/apps/testing/tests/match-filters.spec.ts
+++ b/apps/testing/tests/match-filters.spec.ts
@@ -1,49 +1,28 @@
-import { expect, test, type Page, type Route } from '@playwright/test';
+import {
+  buildMatch,
+  expect,
+  FRONTEND_URL,
+  GRAPHQL_ANY_ROUTE,
+  mockGraphQLAll,
+  test,
+  type MockMatch,
+} from './support';
 
 /**
  * Tests E2E de Filtrar Partidos (/partidos).
  *
  * Decision Context:
- * - MatchFilters hidrata client-side dentro de MatchesView (client:visible). Por eso
- *   los tests esperan a que el listado deje de cargar antes de interactuar con selects.
- * - Mockeamos /api/graphql para controlar un dataset amplio y validar que zona,
- *   formato, horario, rango de fecha y busqueda se aplican localmente sobre datos ya
- *   cargados, sin depender del seed de Supabase.
- * - Capturamos el payload GraphQL para confirmar que la carga inicial usa matches con
- *   filtros server-side minimos (status OPEN); los demas filtros son instantaneos en UI
- *   y se persisten en URL para compartir.
+ * - MatchFilters hidrata client-side dentro de MatchesView (`client:visible`).
+ *   Por eso esperamos a que el listado deje de cargar (`expectListSettled`)
+ *   antes de interactuar con selects.
+ * - Mockeamos `/api/graphql` (proxy o backend directo) para validar que zona,
+ *   formato, horario, rango de fecha y búsqueda se aplican localmente sobre
+ *   datos ya cargados, sin depender del seed.
+ * - Verificamos que la carga inicial use el filtro server-side mínimo
+ *   (`status=OPEN`); los demás se aplican client-side y se persisten en URL.
  */
 
-const FRONTEND_URL = 'http://localhost:4321';
 const MATCHES_URL = `${FRONTEND_URL}/partidos`;
-// Cubre tanto el proxy del frontend (/api/graphql) como PUBLIC_GRAPHQL_URL directo
-// al backend (/graphql), segun como este configurado el ambiente local.
-const GRAPHQL_ROUTE = /https?:\/\/[^/]+\/(?:api\/)?graphql(?:\?.*)?$/;
-
-type MatchFormat = 'FIVE_VS_FIVE' | 'SEVEN_VS_SEVEN' | 'TEN_VS_TEN' | 'ELEVEN_VS_ELEVEN';
-type MatchStatus = 'OPEN' | 'FULL' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
-
-type MockMatch = {
-  __typename?: string;
-  id: string;
-  title: string;
-  startTime: string;
-  format: MatchFormat;
-  totalSlots: number;
-  availableSlots: number;
-  status: MatchStatus;
-  club: {
-    __typename?: string;
-    name: string;
-    zone: string | null;
-    address?: string | null;
-  } | null;
-};
-
-type GraphQLRequest = {
-  query?: string;
-  variables?: Record<string, unknown>;
-};
 
 const MATCHES: MockMatch[] = [
   buildMatch({
@@ -98,73 +77,12 @@ const MATCHES: MockMatch[] = [
   }),
 ];
 
-function buildMatch(overrides: Partial<MockMatch> = {}): MockMatch {
-  return {
-    __typename: 'Match',
-    id: 'match-default',
-    title: 'Partido de prueba',
-    startTime: '2026-05-10T20:00:00-03:00',
-    format: 'FIVE_VS_FIVE',
-    totalSlots: 10,
-    availableSlots: 5,
-    status: 'OPEN',
-    club: { __typename: 'Club', name: 'Club Test', zone: 'Norte', address: 'Test 123' },
-    ...overrides,
-  };
-}
-
-async function mockMatchesQuery(
-  page: Page,
-  matches: MockMatch[] = MATCHES,
-): Promise<{ requests: GraphQLRequest[] }> {
-  const requests: GraphQLRequest[] = [];
-
-  await page.unroute(GRAPHQL_ROUTE).catch(() => undefined);
-  await page.route(GRAPHQL_ROUTE, async (route: Route) => {
-    const rawBody = route.request().postData() ?? '{}';
-    const body = JSON.parse(rawBody) as GraphQLRequest;
-    const url = new URL(route.request().url());
-    const variablesParam = url.searchParams.get('variables');
-    const queryParam = url.searchParams.get('query');
-
-    requests.push({
-      query: body.query ?? queryParam ?? undefined,
-      variables:
-        body.variables ??
-        (variablesParam ? (JSON.parse(variablesParam) as Record<string, unknown>) : undefined),
-    });
-
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ data: { matches } }),
-    });
-  });
-
-  return { requests };
-}
-
-async function gotoMatchesPage(
-  page: Page,
-  path = '/partidos',
-  waitForTitle = 'F5 temprano en Norte',
-): Promise<void> {
-  await page.goto(`${FRONTEND_URL}${path}`);
-  await page.locator('.matches-section').scrollIntoViewIfNeeded();
-  await expect(page.getByRole('heading', { name: /partidos disponibles/i })).toBeVisible();
-  await expect(page.getByText(waitForTitle)).toBeVisible();
-}
-
-async function expectVisibleMatches(page: Page, titles: string[]): Promise<void> {
+async function expectVisibleMatches(matchesPage: { card(t: string): import('@playwright/test').Locator }, titles: string[]): Promise<void> {
   for (const title of titles) {
-    await expect(page.getByText(title)).toBeVisible();
+    await expect(matchesPage.card(title)).toBeVisible();
   }
-
-  const hiddenTitles = MATCHES.map((match) => match.title).filter(
-    (title) => !titles.includes(title),
-  );
-  for (const title of hiddenTitles) {
-    await expect(page.getByText(title)).toHaveCount(0);
+  for (const title of MATCHES.map((m) => m.title).filter((t) => !titles.includes(t))) {
+    await expect(matchesPage.card(title)).toHaveCount(0);
   }
 }
 
@@ -172,129 +90,144 @@ test.describe('Filtrar Partidos (/partidos)', () => {
   test.describe.configure({ mode: 'serial' });
 
   test.beforeEach(async ({ page }) => {
-    await mockMatchesQuery(page);
+    await mockGraphQLAll(page, GRAPHQL_ANY_ROUTE, { data: { matches: MATCHES } });
   });
 
-  test('carga partidos abiertos y muestra controles de filtros principales', async ({ page }) => {
-    const graphQL = await mockMatchesQuery(page);
+  test('carga partidos abiertos y muestra controles de filtros principales', async ({
+    matchesPage,
+    page,
+  }) => {
+    const tracker = await mockGraphQLAll(page, GRAPHQL_ANY_ROUTE, { data: { matches: MATCHES } });
 
-    await gotoMatchesPage(page);
+    await matchesPage.goto();
+    await matchesPage.expectListSettled('F5 temprano en Norte');
 
     await expect(page.getByLabel(/buscar partidos/i)).toBeVisible();
-    await expect(page.getByLabel('Formato')).toBeVisible();
-    await expect(page.getByLabel('Zona')).toBeVisible();
-    await expect(page.getByLabel('Horario')).toBeVisible();
-    await expect(page.getByLabel(/fecha desde/i)).toBeVisible();
-    await expect(page.getByLabel(/fecha hasta/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /limpiar/i })).toBeDisabled();
+    await expect(matchesPage.formatSelect).toBeVisible();
+    await expect(matchesPage.zoneSelect).toBeVisible();
+    await expect(matchesPage.scheduleSelect).toBeVisible();
+    await expect(matchesPage.dateFromInput).toBeVisible();
+    await expect(matchesPage.dateToInput).toBeVisible();
+    await expect(matchesPage.clearButton).toBeDisabled();
 
-    expect(graphQL.requests[0]?.variables).toMatchObject({
-      filters: { status: 'OPEN' },
-    });
-    await expect(page.getByText('Partido cancelado oculto')).toHaveCount(0);
+    expect(tracker.requests[0]?.variables).toMatchObject({ filters: { status: 'OPEN' } });
+    await expect(matchesPage.card('Partido cancelado oculto')).toHaveCount(0);
   });
 
-  test('filtra por formato y persiste el filtro en la URL', async ({ page }) => {
-    await gotoMatchesPage(page);
+  test('filtra por formato y persiste el filtro en la URL', async ({ matchesPage, page }) => {
+    await matchesPage.goto();
+    await matchesPage.expectListSettled('F5 temprano en Norte');
 
-    await page.getByLabel('Formato').selectOption('SEVEN_VS_SEVEN');
+    await matchesPage.formatSelect.selectOption('SEVEN_VS_SEVEN');
 
-    await expectVisibleMatches(page, ['F7 noche en Sur', 'F7 madrugada este']);
+    await expectVisibleMatches(matchesPage, ['F7 noche en Sur', 'F7 madrugada este']);
     await expect(page).toHaveURL(/format=SEVEN_VS_SEVEN/);
   });
 
-  test('filtra por zona y permite compartir el estado desde URL params', async ({ page }) => {
-    await gotoMatchesPage(page);
+  test('filtra por zona y permite compartir el estado desde URL params', async ({
+    matchesPage,
+    page,
+  }) => {
+    await matchesPage.goto();
+    await matchesPage.expectListSettled('F5 temprano en Norte');
 
-    await page.getByLabel('Zona').selectOption('Sur');
+    await matchesPage.zoneSelect.selectOption('Sur');
 
-    await expectVisibleMatches(page, ['F7 noche en Sur']);
+    await expectVisibleMatches(matchesPage, ['F7 noche en Sur']);
     await expect(page).toHaveURL(/zone=Sur/);
 
     await page.reload();
-    await expectVisibleMatches(page, ['F7 noche en Sur']);
-    await expect(page.getByLabel('Zona')).toHaveValue('Sur');
+    await expectVisibleMatches(matchesPage, ['F7 noche en Sur']);
+    await expect(matchesPage.zoneSelect).toHaveValue('Sur');
   });
 
   test('combina zona, formato y busqueda sin volver a pedir datos al backend', async ({
+    matchesPage,
     page,
   }) => {
-    const graphQL = await mockMatchesQuery(page);
-    await gotoMatchesPage(page);
+    const tracker = await mockGraphQLAll(page, GRAPHQL_ANY_ROUTE, { data: { matches: MATCHES } });
 
-    await page.getByLabel('Formato').selectOption('SEVEN_VS_SEVEN');
-    await page.getByLabel('Zona').selectOption('Sur');
-    await page.getByLabel(/buscar partidos/i).fill('bravo');
+    await matchesPage.goto();
+    await matchesPage.expectListSettled('F5 temprano en Norte');
 
-    await expectVisibleMatches(page, ['F7 noche en Sur']);
+    await matchesPage.formatSelect.selectOption('SEVEN_VS_SEVEN');
+    await matchesPage.zoneSelect.selectOption('Sur');
+    await matchesPage.searchInput.fill('bravo');
+
+    await expectVisibleMatches(matchesPage, ['F7 noche en Sur']);
     await expect(page).toHaveURL(/format=SEVEN_VS_SEVEN/);
     await expect(page).toHaveURL(/zone=Sur/);
     await expect(page).toHaveURL(/search=bravo/);
-    expect(graphQL.requests).toHaveLength(1);
+    expect(tracker.requests).toHaveLength(1);
   });
 
   test('filtra por horario de noche y por rango nocturno cruzando medianoche', async ({
+    matchesPage,
     page,
   }) => {
-    await gotoMatchesPage(page);
+    await matchesPage.goto();
+    await matchesPage.expectListSettled('F5 temprano en Norte');
 
-    await page.getByLabel('Horario').selectOption('18:00|23:59');
-    await expectVisibleMatches(page, ['F7 noche en Sur', 'F11 nocturno oeste']);
+    await matchesPage.scheduleSelect.selectOption('18:00|23:59');
+    await expectVisibleMatches(matchesPage, ['F7 noche en Sur', 'F11 nocturno oeste']);
     await expect(page).toHaveURL(/timeFrom=18%3A00/);
     await expect(page).toHaveURL(/timeTo=23%3A59/);
 
-    await page.getByLabel('Horario').selectOption('20:00|02:00');
-    await expectVisibleMatches(page, [
+    await matchesPage.scheduleSelect.selectOption('20:00|02:00');
+    await expectVisibleMatches(matchesPage, [
       'F7 noche en Sur',
       'F11 nocturno oeste',
       'F7 madrugada este',
     ]);
   });
 
-  test('filtra por rango de fecha inclusivo', async ({ page }) => {
-    await gotoMatchesPage(page);
+  test('filtra por rango de fecha inclusivo', async ({ matchesPage, page }) => {
+    await matchesPage.goto();
+    await matchesPage.expectListSettled('F5 temprano en Norte');
 
-    await page.getByLabel(/fecha desde/i).fill('2026-05-11');
-    await page.getByLabel(/fecha hasta/i).fill('2026-05-12');
+    await matchesPage.dateFromInput.fill('2026-05-11');
+    await matchesPage.dateToInput.fill('2026-05-12');
 
-    await expectVisibleMatches(page, ['F7 noche en Sur', 'F10 tarde centro']);
+    await expectVisibleMatches(matchesPage, ['F7 noche en Sur', 'F10 tarde centro']);
     await expect(page).toHaveURL(/dateFrom=2026-05-11/);
     await expect(page).toHaveURL(/dateTo=2026-05-12/);
   });
 
   test('muestra empty-state cuando ningun partido coincide con los filtros', async ({
+    matchesPage,
     page,
   }) => {
-    await gotoMatchesPage(page);
+    await matchesPage.goto();
+    await matchesPage.expectListSettled('F5 temprano en Norte');
 
-    await page.getByLabel('Zona').selectOption('Norte');
-    await page.getByLabel('Formato').selectOption('ELEVEN_VS_ELEVEN');
+    await matchesPage.zoneSelect.selectOption('Norte');
+    await matchesPage.formatSelect.selectOption('ELEVEN_VS_ELEVEN');
 
-    await expect(page.getByText('No hay partidos disponibles')).toBeVisible();
+    await expect(matchesPage.emptyState).toBeVisible();
     await expect(page.getByText(/ningun partido coincide|ningún partido coincide/i)).toBeVisible();
   });
 
-  test('limpiar resetea filtros, controles y URL params', async ({ page }) => {
-    await gotoMatchesPage(page);
+  test('limpiar resetea filtros, controles y URL params', async ({ matchesPage, page }) => {
+    await matchesPage.goto();
+    await matchesPage.expectListSettled('F5 temprano en Norte');
 
-    await page.getByLabel('Formato').selectOption('SEVEN_VS_SEVEN');
-    await page.getByLabel('Zona').selectOption('Sur');
-    await page.getByLabel('Horario').selectOption('18:00|23:59');
-    await page.getByLabel(/fecha desde/i).fill('2026-05-11');
-    await page.getByLabel(/buscar partidos/i).fill('bravo');
+    await matchesPage.formatSelect.selectOption('SEVEN_VS_SEVEN');
+    await matchesPage.zoneSelect.selectOption('Sur');
+    await matchesPage.scheduleSelect.selectOption('18:00|23:59');
+    await matchesPage.dateFromInput.fill('2026-05-11');
+    await matchesPage.searchInput.fill('bravo');
 
-    const clearButton = page.getByRole('button', { name: /limpiar/i });
-    await expect(clearButton).toBeEnabled();
-    await clearButton.click();
+    await expect(matchesPage.clearButton).toBeEnabled();
+    await matchesPage.clearButton.click();
 
-    await expect(page.getByLabel('Formato')).toHaveValue('');
-    await expect(page.getByLabel('Zona')).toHaveValue('');
-    await expect(page.getByLabel('Horario')).toHaveValue('');
-    await expect(page.getByLabel(/fecha desde/i)).toHaveValue('');
-    await expect(page.getByLabel(/buscar partidos/i)).toHaveValue('');
-    await expect(clearButton).toBeDisabled();
+    await expect(matchesPage.formatSelect).toHaveValue('');
+    await expect(matchesPage.zoneSelect).toHaveValue('');
+    await expect(matchesPage.scheduleSelect).toHaveValue('');
+    await expect(matchesPage.dateFromInput).toHaveValue('');
+    await expect(matchesPage.searchInput).toHaveValue('');
+    await expect(matchesPage.clearButton).toBeDisabled();
     await expect(page).toHaveURL(MATCHES_URL);
-    await expectVisibleMatches(page, [
+    await expectVisibleMatches(matchesPage, [
       'F5 temprano en Norte',
       'F7 noche en Sur',
       'F10 tarde centro',
@@ -303,11 +236,14 @@ test.describe('Filtrar Partidos (/partidos)', () => {
     ]);
   });
 
-  test('ignora formato invalido en URL y conserva resultados abiertos', async ({ page }) => {
-    await gotoMatchesPage(page, '/partidos?format=INVALIDO&zone=Sur', 'F7 noche en Sur');
+  test('ignora formato invalido en URL y conserva resultados abiertos', async ({
+    matchesPage,
+  }) => {
+    await matchesPage.goto('/partidos?format=INVALIDO&zone=Sur');
+    await matchesPage.expectListSettled('F7 noche en Sur');
 
-    await expect(page.getByLabel('Formato')).toHaveValue('');
-    await expect(page.getByLabel('Zona')).toHaveValue('Sur');
-    await expectVisibleMatches(page, ['F7 noche en Sur']);
+    await expect(matchesPage.formatSelect).toHaveValue('');
+    await expect(matchesPage.zoneSelect).toHaveValue('Sur');
+    await expectVisibleMatches(matchesPage, ['F7 noche en Sur']);
   });
 });

--- a/apps/testing/tests/matches-list.spec.ts
+++ b/apps/testing/tests/matches-list.spec.ts
@@ -1,152 +1,61 @@
-import { test, expect, type Page, type Route } from '@playwright/test';
+import {
+  buildMatch,
+  expect,
+  GRAPHQL_PROXY_ROUTE,
+  mockGraphQLAll,
+  test,
+  TEST_USERS,
+} from './support';
 
 /**
  * Tests E2E del listado de partidos (/partidos).
  *
  * Decision Context:
- * - Por qué mockeamos el endpoint GraphQL con `page.route()`: el ambiente de dev puede
- *   no tener datos seed en la DB de Supabase. Interceptando la respuesta del endpoint
- *   GraphQL dejamos los tests deterministas y los desacoplamos del estado del backend.
- * - El login NO va por GraphQL sino por POST a /login (SSR que golpea la REST del backend),
- *   así que el route de `**\/graphql` no interfiere con la autenticación.
- * - Usamos cookies HttpOnly (set por el flujo SSR de login) — Playwright las persiste entre
- *   navegaciones del mismo `page`, por lo que una vez logueados podemos ir directo a /partidos.
- * - Por qué usamos el glob `**\/graphql` en lugar de la URL absoluta: el endpoint puede
- *   cambiar de `http://localhost:4000/...` a `http://127.0.0.1:...` (o a un proxy del dev
- *   server) y el matching literal por URL falla silenciosamente. El glob por path cubre
- *   cualquier host/puerto.
- * - Scope `main` en selectors: el Astro dev toolbar inyecta controles (incluyendo un
- *   `<select>`) dentro del body que contaminan conteos globales. Restringir a `main`
- *   garantiza que sólo contemos elementos de la página real.
- * - Assumptions:
- *   * El usuario `mateoduran2010@gmail.com` tiene role != 'club_admin' → redirect a /partidos.
- *   * El backend corre en :4000 y el frontend en :4321 (pnpm dev levantado a mano).
- * - Previously fixed bugs:
- *   * Mock no interceptaba: el suite ahora responde todo request a `/api/graphql`
- *     porque estas pruebas sólo validan el listado y el login no usa GraphQL.
- *   * Mock URL literal `http://localhost:4000/graphql` era frágil por diferencias de
- *     host/puerto. Se cambió al proxy del frontend con glob `**\/api/graphql**`.
- *   * `page.locator('select')` contaba 4 elementos por el Astro dev toolbar. Se restringe
- *     a `main select`.
- *   * Interacciones con el filtro "Limpiar" fallaban porque React no había hidratado
- *     todavía. Se espera a que la lista termine el loading antes de escribir en la búsqueda.
+ * - Mockeamos `/api/graphql` para no depender del seed de Supabase y mantener
+ *   los tests deterministas — interceptamos toda la query `matches`.
+ * - Usamos storage state pre-autenticado (player Mateo) producido por
+ *   `auth.setup.ts` en lugar de hacer login real en el `beforeEach`. Eso
+ *   evita el costo de un POST SSR + redirect por cada test del describe.
+ * - Scope `main` en selectores: el Astro dev toolbar inyecta un `<select>` que
+ *   contamina el conteo global; la PO `MatchesListPage` ya scopea por `main`.
+ * - Previously fixed bugs: ver MatchesListPage decision context (strict-mode
+ *   con "Ver detalle", conteos de selects).
  */
 
-const FRONTEND_URL = 'http://localhost:4321';
-// Glob path-only: catches the frontend GraphQL proxy, including urql querystrings.
-const GRAPHQL_ROUTE = '**/api/graphql**';
-
-const TEST_USER = {
-  email: 'mateoduran2010@gmail.com',
-  password: 'Hola1234',
-};
-
-type MockMatch = {
-  __typename?: string;
-  id: string;
-  title: string;
-  startTime: string;
-  format: 'FIVE_VS_FIVE' | 'SEVEN_VS_SEVEN' | 'TEN_VS_TEN' | 'ELEVEN_VS_ELEVEN';
-  totalSlots: number;
-  availableSlots: number;
-  status: 'OPEN' | 'FULL' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
-  club: { __typename?: string; name: string; zone: string | null } | null;
-};
-
-function buildMatch(overrides: Partial<MockMatch> = {}): MockMatch {
-  return {
-    __typename: 'Match',
-    id: 'match-default',
-    title: 'Partido de prueba',
-    startTime: '2026-05-01T20:00:00Z',
-    format: 'FIVE_VS_FIVE',
-    totalSlots: 10,
-    availableSlots: 5,
-    status: 'OPEN',
-    club: { __typename: 'Club', name: 'Club Test', zone: 'Norte' },
-    ...overrides,
-  };
-}
-
-/**
- * Intercepta el endpoint GraphQL del frontend y responde con la lista provista.
- */
-async function mockMatchesQuery(page: Page, matches: MockMatch[]): Promise<void> {
-  await page.unroute(GRAPHQL_ROUTE).catch(() => undefined);
-  await page.route(GRAPHQL_ROUTE, async (route: Route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ data: { matches } }),
-    });
-  });
-}
-
-/** Mockea un error de servidor para el listado. */
-async function mockMatchesError(page: Page, message = 'Backend caído'): Promise<void> {
-  await page.unroute(GRAPHQL_ROUTE).catch(() => undefined);
-  await page.route(GRAPHQL_ROUTE, async (route: Route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ errors: [{ message }] }),
-    });
-  });
-}
-
-/**
- * Helper de login — completa el form y espera a que el SSR redirija fuera de /login.
- * Replica el flujo validado por login.spec.ts.
- */
-async function login(page: Page): Promise<void> {
-  await page.goto(`${FRONTEND_URL}/login`);
-  await page.getByRole('textbox', { name: 'Email' }).fill(TEST_USER.email);
-  await page.getByRole('textbox', { name: 'Contraseña' }).fill(TEST_USER.password);
-  await page.getByRole('button', { name: 'Ingresar' }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
-}
-
-async function gotoMatchesPage(page: Page): Promise<void> {
-  await page.goto(`${FRONTEND_URL}/partidos`);
-  await page.locator('.matches-section').scrollIntoViewIfNeeded();
-}
+test.use({ storageState: TEST_USERS.playerMateo.storageStatePath });
 
 test.describe('Listado de partidos (/partidos)', () => {
   test.describe.configure({ mode: 'serial' });
 
   test.beforeEach(async ({ page }) => {
-    // Mock por defecto: lista vacía. Los tests que necesiten data la re-mockean antes de navegar.
-    await mockMatchesQuery(page, []);
-    await login(page);
+    // Mock por defecto: lista vacía. Tests que necesiten data lo re-mockean antes de navegar.
+    await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, { data: { matches: [] } });
   });
 
-  test('renderiza el header y sale del estado de loading', async ({ page }) => {
-    await gotoMatchesPage(page);
+  test('renderiza el header y sale del estado de loading', async ({ matchesPage }) => {
+    await matchesPage.goto();
 
-    await expect(page.getByRole('heading', { name: /Partidos Disponibles/i })).toBeVisible();
-    // Con la lista mockeada vacía, debe aparecer el empty-state (no quedarse en skeleton).
-    await expect(page.getByText('No hay partidos disponibles')).toBeVisible();
+    await expect(matchesPage.heading).toBeVisible();
+    await expect(matchesPage.emptyState).toBeVisible();
   });
 
-  test('muestra los controles de filtros principales', async ({ page }) => {
-    await gotoMatchesPage(page);
+  test('muestra los controles de filtros principales', async ({ matchesPage, page }) => {
+    await matchesPage.goto();
 
-    await expect(page.getByPlaceholder(/Buscar partido o club/i)).toBeVisible();
-    // 3 selects (formato, zona, horario) + 2 date pickers (desde, hasta) + boton "Limpiar".
-    // Scope a `main` para ignorar el Astro dev toolbar (que puede inyectar un <select>).
+    await expect(matchesPage.searchInput).toBeVisible();
     await expect(page.locator('main select')).toHaveCount(3);
     await expect(page.locator('main input[type="date"]')).toHaveCount(2);
-    await expect(page.getByRole('button', { name: /Limpiar/i })).toBeVisible();
+    await expect(matchesPage.clearButton).toBeVisible();
   });
 
-  test('los date pickers de rango de fecha estan visibles por defecto', async ({ page }) => {
-    await gotoMatchesPage(page);
-
-    // Esperar a que MatchList termine el fetch y hidrate antes de validar inputs —
-    // de lo contrario los handlers todavia no estan enganchados.
-    // Decision Context: el filtro avanzado dejo de estar oculto detras de "Mas filtros";
-    // ahora los date pickers se renderizan junto al boton "Limpiar" en una segunda fila.
-    await expect(page.getByText('No hay partidos disponibles')).toBeVisible();
+  test('los date pickers de rango de fecha estan visibles por defecto', async ({
+    matchesPage,
+    page,
+  }) => {
+    // Decision Context: el filtro avanzado dejó de estar oculto detrás de "Más filtros";
+    // los date pickers ahora viven junto al botón "Limpiar".
+    await matchesPage.goto();
+    await matchesPage.expectListSettled();
 
     const dateInputs = page.locator('main input[type="date"]');
     await expect(dateInputs).toHaveCount(2);
@@ -154,136 +63,124 @@ test.describe('Listado de partidos (/partidos)', () => {
     await expect(dateInputs.nth(1)).toBeVisible();
   });
 
-  test('al aplicar un filtro aparece "Limpiar" y al clickearlo se resetea la búsqueda', async ({ page }) => {
-    await gotoMatchesPage(page);
+  test('al aplicar un filtro aparece "Limpiar" y al clickearlo se resetea la búsqueda', async ({
+    matchesPage,
+  }) => {
+    await matchesPage.goto();
+    await matchesPage.expectListSettled();
 
-    // Esperamos a que el empty-state (lista vacía mockeada) se renderice — garantiza
-    // que MatchList hidrató y los handlers onChange ya están enganchados. Sin esto,
-    // el fill() dispara antes de la hidratación y React no actualiza el estado.
-    await expect(page.getByText('No hay partidos disponibles')).toBeVisible();
+    await matchesPage.searchInput.fill('river');
+    await matchesPage.expectClearState('enabled');
 
-    const search = page.getByPlaceholder(/Buscar partido o club/i);
-    await search.fill('river');
-
-    const clearBtn = page.getByRole('button', { name: /Limpiar/i });
-    await expect(clearBtn).toBeVisible();
-    await expect(clearBtn).toBeEnabled();
-
-    await clearBtn.click();
-    await expect(search).toHaveValue('');
-    // El boton "Limpiar" siempre esta renderizado (vive junto a los filtros), pero
-    // se deshabilita cuando no hay filtros activos. Antes asertabamos `not.toBeVisible()`
-    // asumiendo que desaparecia, pero el componente nunca tuvo ese comportamiento.
-    await expect(clearBtn).toBeDisabled();
+    await matchesPage.clearButton.click();
+    await expect(matchesPage.searchInput).toHaveValue('');
+    await matchesPage.expectClearState('disabled');
   });
 
-  test('renderiza cards cuando la query devuelve partidos', async ({ page }) => {
-    await mockMatchesQuery(page, [
-      buildMatch({ id: '1', title: 'Pickup F5 en Palermo', format: 'FIVE_VS_FIVE' }),
-      buildMatch({
-        id: '2',
-        title: 'F7 nocturno en Núñez',
-        format: 'SEVEN_VS_SEVEN',
-        club: { name: 'Club Núñez', zone: 'Norte' },
-      }),
-    ]);
+  test('renderiza cards cuando la query devuelve partidos', async ({ matchesPage, page }) => {
+    await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, {
+      data: {
+        matches: [
+          buildMatch({ id: '1', title: 'Pickup F5 en Palermo', format: 'FIVE_VS_FIVE' }),
+          buildMatch({
+            id: '2',
+            title: 'F7 nocturno en Núñez',
+            format: 'SEVEN_VS_SEVEN',
+            club: { name: 'Club Núñez', zone: 'Norte' },
+          }),
+        ],
+      },
+    });
 
-    await gotoMatchesPage(page);
+    await matchesPage.goto();
 
-    await expect(page.getByText('Pickup F5 en Palermo')).toBeVisible();
-    await expect(page.getByText('F7 nocturno en Núñez')).toBeVisible();
+    await expect(matchesPage.card('Pickup F5 en Palermo')).toBeVisible();
+    await expect(matchesPage.card('F7 nocturno en Núñez')).toBeVisible();
     await expect(page.getByText('5v5')).toBeVisible();
     await expect(page.getByText('7v7')).toBeVisible();
     await expect(page.getByText('Club Núñez')).toBeVisible();
-    // Hay al menos un botón "Sumarme" habilitado
     await expect(page.getByRole('button', { name: /Sumarme/i }).first()).toBeEnabled();
   });
 
-  test('partido lleno muestra badge "Completo" y CTA "Ver detalle" que navega al detalle', async ({ page }) => {
-    // Decision Context: para partidos llenos el card debe seguir siendo accionable.
-    // El badge "Completo" comunica el estado y el CTA inferior pasa a "Ver detalle"
-    // (en vez de un botón "Completo" deshabilitado e inservible) para que el usuario
-    // pueda clickear y ver quiénes están anotados antes de decidir si esperar un cupo.
+  test('partido lleno muestra badge "Completo" y CTA "Ver detalle" navega al detalle', async ({
+    matchesPage,
+    page,
+  }) => {
+    // Decision Context: para partidos llenos el card sigue siendo accionable. El CTA
+    // pasa a "Ver detalle" para que el usuario pueda abrir el detalle y ver quiénes
+    // están anotados antes de decidir si esperar un cupo.
     // Previously fixed bugs: el CTA anterior era un botón disabled "Completo" — los
-    // usuarios no tenían forma de abrir el detalle de un partido 10/10 desde el listado.
+    // usuarios no podían abrir el detalle de un partido 10/10 desde el listado.
     // Decision Context: el id DEBE ser un UUID válido. El SSR de /partidos/[id]
-    // valida el formato con UUID_REGEX (ver matchResolver.match) y redirige a
-    // /partidos cuando el id no matchea — eso hacía que este test fallara con
-    // "Expected /partidos/full-1, Received /partidos".
-    // Previously fixed bugs: el id era 'full-1' (no UUID) → el detalle redirigía
-    // al listado y la assertion de URL fallaba. Cambiado a un UUID memorable.
+    // valida el formato y redirige a /partidos cuando no matchea — usar 'full-1'
+    // hacía que la assertion de URL fallara.
     const FULL_MATCH_ID = '00000000-0000-0000-0000-00000000fff1';
-    await mockMatchesQuery(page, [
-      buildMatch({
-        id: FULL_MATCH_ID,
-        title: 'Partido lleno',
-        totalSlots: 10,
-        availableSlots: 0,
-      }),
-    ]);
+    await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, {
+      data: {
+        matches: [
+          buildMatch({
+            id: FULL_MATCH_ID,
+            title: 'Partido lleno',
+            totalSlots: 10,
+            availableSlots: 0,
+          }),
+        ],
+      },
+    });
 
-    await gotoMatchesPage(page);
+    await matchesPage.goto();
 
-    // El status sigue comunicándose mediante el badge en el header del card
     await expect(page.getByText('Completo').first()).toBeVisible();
     await expect(page.getByText('10/10 jugadores')).toBeVisible();
 
-    // Decision Context: usamos `name: 'Ver detalle', exact: true` (no regex /Ver detalle/i)
-    // porque la card tiene aria-label="Ver detalle del partido Partido lleno" y matchearia
-    // tambien al contenedor role="button" de la propia card, generando strict-mode
-    // violations. El boton CTA es el unico elemento con accesible name exactamente
-    // "Ver detalle", asi que el matcher exact deja la query sin ambiguedad.
-    // Previously fixed bugs: el test fallaba por strict-mode violation entre el boton
-    // y la card cuyo aria-label arranca con "Ver detalle del partido ...".
-    const detailBtn = page.getByRole('button', { name: 'Ver detalle', exact: true });
+    const detailBtn = matchesPage.detailButton();
     await expect(detailBtn).toBeVisible();
-    await expect(detailBtn).toBeEnabled();
-
-    // Click en el CTA navega al detalle
     await detailBtn.click();
     await expect(page).toHaveURL(new RegExp(`/partidos/${FULL_MATCH_ID}$`));
   });
 
-  test('partido lleno: clickear el card también navega al detalle', async ({ page }) => {
-    // UUID válido — el SSR del detalle valida el formato y redirige al listado
-    // si el id no es un UUID. Ver decision context del test anterior.
+  test('partido lleno: clickear el card también navega al detalle', async ({
+    matchesPage,
+    page,
+  }) => {
     const FULL_MATCH_ID = '00000000-0000-0000-0000-00000000fff2';
-    await mockMatchesQuery(page, [
-      buildMatch({
-        id: FULL_MATCH_ID,
-        title: 'Otro partido lleno',
-        totalSlots: 10,
-        availableSlots: 0,
-      }),
-    ]);
+    await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, {
+      data: {
+        matches: [
+          buildMatch({
+            id: FULL_MATCH_ID,
+            title: 'Otro partido lleno',
+            totalSlots: 10,
+            availableSlots: 0,
+          }),
+        ],
+      },
+    });
 
-    await gotoMatchesPage(page);
-
-    // Clickear el título (parte de la card, fuera del botón) navega al detalle
-    await page.getByText('Otro partido lleno').click();
+    await matchesPage.goto();
+    await matchesPage.card('Otro partido lleno').click();
     await expect(page).toHaveURL(new RegExp(`/partidos/${FULL_MATCH_ID}$`));
   });
 
-  test('empty-state muestra mensaje amigable cuando no hay partidos', async ({ page }) => {
-    await gotoMatchesPage(page);
+  test('empty-state muestra mensaje amigable cuando no hay partidos', async ({
+    matchesPage,
+    page,
+  }) => {
+    await matchesPage.goto();
 
-    await expect(page.getByText('No hay partidos disponibles')).toBeVisible();
-    // El subtítulo varía según haya filtros activos o no:
-    // - sin filtros: "No hay partidos abiertos por el momento. Volvé más tarde."
-    // - con filtros: "Ningún partido coincide con los filtros. Probá ajustando la búsqueda."
-    // El test no aplica filtros → matcheamos el copy del caso sin filtros, pero dejamos
-    // el regex flexible por si en el futuro se unifica el wording.
-    // Previously fixed bugs: el copy original "Probá con otros filtros" fue reemplazado
-    // por dos variantes contextuales — el test fallaba con el wording viejo.
+    await expect(matchesPage.emptyState).toBeVisible();
+    // Subtítulo varía con/sin filtros activos; matcheamos las dos variantes.
     await expect(
       page.getByText(/Volvé más tarde|ajustando la búsqueda|otros filtros/i),
     ).toBeVisible();
   });
 
-  test('muestra mensaje de error cuando la query falla', async ({ page }) => {
-    await mockMatchesError(page, 'Server on fire');
+  test('muestra mensaje de error cuando la query falla', async ({ matchesPage, page }) => {
+    await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, {
+      errors: [{ message: 'Server on fire' }],
+    });
 
-    await gotoMatchesPage(page);
+    await matchesPage.goto();
 
     await expect(page.getByText('Error').first()).toBeVisible();
     await expect(page.getByText('Server on fire')).toBeVisible();

--- a/apps/testing/tests/matches-map.spec.ts
+++ b/apps/testing/tests/matches-map.spec.ts
@@ -1,173 +1,28 @@
-import { expect, test, type Page, type Route } from '@playwright/test';
+import {
+  buildMatch,
+  expect,
+  FRONTEND_URL,
+  GRAPHQL_ANY_ROUTE,
+  mockGraphQLAll,
+  mockLeafletAssets,
+  test,
+} from './support';
 
 /**
  * Tests E2E de la vista de partidos en mapa (/partidos).
  *
  * Decision Context:
- * - Mockeamos /api/graphql para desacoplar los tests del seed de Supabase y poder
- *   cubrir bordes: lista vacia, partidos sin coordenadas, FULL devuelto por error
- *   del backend y errores GraphQL.
- * - Mockeamos tiles/iconos externos de Leaflet con un PNG minimo. Estos tests no
- *   validan OpenStreetMap/CDN, solo que nuestra UI monte Leaflet, cree marcadores y
+ * - Mockeamos `/api/graphql` (proxy y backend directo) para desacoplar los tests
+ *   del seed de Supabase y cubrir bordes (lista vacía, sin coordenadas, FULL,
+ *   errores GraphQL).
+ * - Mockeamos tiles/iconos externos de Leaflet con un PNG mínimo. Estos tests no
+ *   validan OpenStreetMap/CDN, sólo que la UI monte Leaflet, cree marcadores y
  *   popups con el contrato correcto.
- * - No hacemos login: /partidos es publico y la historia de mapa no depende de
- *   autenticacion. Esto evita acoplar los tests a credenciales reales.
- * - Capturamos las queries GraphQL para comprobar que GetMatchesWithCoords no se
- *   dispara hasta elegir la vista Mapa, cubriendo el lazy-load esperado.
+ * - No hacemos login: /partidos es público y la historia de mapa no depende de
+ *   autenticación. Esto evita acoplar los tests a credenciales.
+ * - Capturamos las queries GraphQL para comprobar que `GetMatchesWithCoords`
+ *   no se dispara hasta elegir la vista Mapa (lazy-load esperado).
  */
-
-const FRONTEND_URL = 'http://localhost:4321';
-const MATCHES_URL = `${FRONTEND_URL}/partidos`;
-// Cubre tanto el proxy del frontend (/api/graphql) como PUBLIC_GRAPHQL_URL directo
-// al backend (/graphql), sin interceptar imports de Vite como /src/graphql/...
-const GRAPHQL_ROUTE = /https?:\/\/[^/]+\/(?:api\/)?graphql(?:\?.*)?$/;
-const TRANSPARENT_PNG = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
-  'base64',
-);
-
-type MockMatch = {
-  __typename?: 'Match';
-  id: string;
-  title: string;
-  startTime: string;
-  format: 'FIVE_VS_FIVE' | 'SEVEN_VS_SEVEN' | 'TEN_VS_TEN' | 'ELEVEN_VS_ELEVEN';
-  totalSlots: number;
-  availableSlots: number;
-  status: 'OPEN' | 'FULL' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
-  club: {
-    __typename?: 'Club';
-    name: string;
-    zone: string | null;
-    address?: string | null;
-    lat?: number | null;
-    lng?: number | null;
-  } | null;
-};
-
-type GraphQLRequest = {
-  operationName?: string | null;
-  query?: string | null;
-  variables?: unknown;
-};
-
-function buildMatch(overrides: Partial<MockMatch> = {}): MockMatch {
-  return {
-    __typename: 'Match',
-    id: 'match-default',
-    title: 'F5 en Montevideo',
-    startTime: '2026-05-02T20:00:00Z',
-    format: 'FIVE_VS_FIVE',
-    totalSlots: 10,
-    availableSlots: 4,
-    status: 'OPEN',
-    club: {
-      __typename: 'Club',
-      name: 'Club Centro',
-      zone: 'Centro',
-      address: '18 de Julio 1234',
-      lat: -34.905,
-      lng: -56.191,
-    },
-    ...overrides,
-  };
-}
-
-function readGraphQLRequest(route: Route): GraphQLRequest {
-  const request = route.request();
-  const postData = request.postData();
-
-  if (postData) {
-    try {
-      return JSON.parse(postData) as GraphQLRequest;
-    } catch {
-      return { query: postData };
-    }
-  }
-
-  const url = new URL(request.url());
-  const variables = url.searchParams.get('variables');
-
-  return {
-    operationName: url.searchParams.get('operationName'),
-    query: url.searchParams.get('query'),
-    variables: variables ? JSON.parse(variables) : undefined,
-  };
-}
-
-async function mockLeafletAssets(page: Page): Promise<void> {
-  const fulfillImage = async (route: Route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'image/png',
-      body: TRANSPARENT_PNG,
-    });
-  };
-
-  await page.route(/https:\/\/[abc]\.tile\.openstreetmap\.org\/.*/, fulfillImage);
-  await page.route(
-    /https:\/\/cdnjs\.cloudflare\.com\/ajax\/libs\/leaflet\/1\.9\.4\/images\/.*/,
-    fulfillImage,
-  );
-}
-
-async function mockMatchesQuery(
-  page: Page,
-  matches: MockMatch[],
-  requests: GraphQLRequest[] = [],
-): Promise<GraphQLRequest[]> {
-  await page.unroute(GRAPHQL_ROUTE).catch(() => undefined);
-  await page.route(GRAPHQL_ROUTE, async (route: Route) => {
-    requests.push(readGraphQLRequest(route));
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ data: { matches } }),
-    });
-  });
-
-  return requests;
-}
-
-async function mockMatchesError(page: Page, message = 'Error al cargar partidos'): Promise<void> {
-  await page.unroute(GRAPHQL_ROUTE).catch(() => undefined);
-  await page.route(GRAPHQL_ROUTE, async (route: Route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ errors: [{ message }] }),
-    });
-  });
-}
-
-async function gotoMatchesPage(page: Page): Promise<void> {
-  await page.goto(MATCHES_URL);
-  await page.locator('.matches-section').scrollIntoViewIfNeeded();
-  await expect(page.getByRole('button', { name: 'Lista', exact: true })).toBeVisible();
-}
-
-async function waitForListToHydrate(page: Page): Promise<void> {
-  await expect
-    .poll(async () => {
-      const text = await page.locator('main').innerText();
-      return /No hay partidos disponibles|Error|jugadores/i.test(text);
-    })
-    .toBe(true);
-}
-
-// Decision Context: usamos `name: 'Mapa', exact: true` (no regex) porque el accesible
-// name "Mapa" tambien matchea cards con aria-label como "Ver detalle del partido F5
-// sin mapa", produciendo strict-mode violations. El toggle es el unico boton con
-// nombre exactamente "Mapa", asi que el matcher exact deja la query sin ambiguedad.
-// Previously fixed bugs: switchToMap fallaba por strict-mode violation cuando el
-// listado incluia un partido con la palabra "mapa" en el titulo.
-async function switchToMap(page: Page): Promise<void> {
-  await page.getByRole('button', { name: 'Mapa', exact: true }).click();
-  await expect(page.getByRole('button', { name: 'Mapa', exact: true })).toHaveAttribute(
-    'aria-pressed',
-    'true',
-  );
-}
 
 test.describe('Vista mapa de partidos (/partidos)', () => {
   test.beforeEach(async ({ page }) => {
@@ -175,235 +30,233 @@ test.describe('Vista mapa de partidos (/partidos)', () => {
   });
 
   test('arranca en lista y carga la query con coordenadas recien al elegir Mapa', async ({
+    matchesMapPage,
     page,
   }) => {
-    const requests: GraphQLRequest[] = [];
-    await mockMatchesQuery(page, [buildMatch()], requests);
+    const tracker = await mockGraphQLAll(page, GRAPHQL_ANY_ROUTE, {
+      data: { matches: [buildMatch()] },
+    });
 
-    await gotoMatchesPage(page);
-    await waitForListToHydrate(page);
+    await matchesMapPage.goto();
+    await matchesMapPage.waitForListHydration();
 
-    await expect(page.getByRole('button', { name: 'Lista', exact: true })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
-    await expect(page.locator('.leaflet-container')).toHaveCount(0);
-    expect(requests.some((request) => request.query?.includes('GetMatchesWithCoords'))).toBe(
-      false,
-    );
+    await expect(matchesMapPage.listToggle).toHaveAttribute('aria-pressed', 'true');
+    await expect(matchesMapPage.mapContainer).toHaveCount(0);
+    expect(tracker.requests.some((r) => r.query?.includes('GetMatchesWithCoords'))).toBe(false);
 
-    await switchToMap(page);
+    await matchesMapPage.switchToMap();
 
-    await expect(page.locator('.leaflet-container')).toBeVisible();
-    await expect(page.locator('.leaflet-marker-icon')).toHaveCount(1);
+    await expect(matchesMapPage.mapContainer).toBeVisible();
+    await expect(matchesMapPage.markers).toHaveCount(1);
     await expect
-      .poll(() => requests.some((request) => request.query?.includes('GetMatchesWithCoords')))
+      .poll(() => tracker.requests.some((r) => r.query?.includes('GetMatchesWithCoords')))
       .toBe(true);
     expect(
-      requests.some((request) =>
-        JSON.stringify(request.variables ?? {}).includes('"status":"OPEN"'),
-      ),
+      tracker.requests.some((r) => JSON.stringify(r.variables ?? {}).includes('"status":"OPEN"')),
     ).toBe(true);
   });
 
   test('muestra un marcador por partido abierto con coordenadas y popup de detalle', async ({
+    matchesMapPage,
     page,
   }) => {
-    await mockMatchesQuery(page, [
-      buildMatch({
-        id: 'open-parque-rodo',
-        title: 'F7 en Parque Rodo',
-        format: 'SEVEN_VS_SEVEN',
-        totalSlots: 14,
-        availableSlots: 6,
-        club: {
-          name: 'Club Parque Rodo',
-          zone: 'Centro',
-          address: 'Bulevar Artigas 1000',
-          lat: -34.913,
-          lng: -56.164,
-        },
-      }),
-      buildMatch({
-        id: 'open-prado',
-        title: 'F5 en Prado',
-        club: {
-          name: 'Club Prado',
-          zone: 'Norte',
-          address: 'Agraciada 3000',
-          lat: -34.865,
-          lng: -56.215,
-        },
-      }),
-      buildMatch({
-        id: 'full-con-coords',
-        title: 'Partido lleno con coordenadas',
-        status: 'FULL',
-        availableSlots: 0,
-        club: {
-          name: 'Club Completo',
-          zone: 'Sur',
-          address: 'Rambla 1',
-          lat: -34.92,
-          lng: -56.17,
-        },
-      }),
-      buildMatch({
-        id: 'open-sin-coords',
-        title: 'F5 sin mapa',
-        club: {
-          name: 'Club Sin Coordenadas',
-          zone: 'Este',
-          address: 'Camino sin numero',
-          lat: null,
-          lng: null,
-        },
-      }),
-    ]);
+    await mockGraphQLAll(page, GRAPHQL_ANY_ROUTE, {
+      data: {
+        matches: [
+          buildMatch({
+            id: 'open-parque-rodo',
+            title: 'F7 en Parque Rodo',
+            format: 'SEVEN_VS_SEVEN',
+            totalSlots: 14,
+            availableSlots: 6,
+            club: {
+              name: 'Club Parque Rodo',
+              zone: 'Centro',
+              address: 'Bulevar Artigas 1000',
+              lat: -34.913,
+              lng: -56.164,
+            },
+          }),
+          buildMatch({
+            id: 'open-prado',
+            title: 'F5 en Prado',
+            club: {
+              name: 'Club Prado',
+              zone: 'Norte',
+              address: 'Agraciada 3000',
+              lat: -34.865,
+              lng: -56.215,
+            },
+          }),
+          buildMatch({
+            id: 'full-con-coords',
+            title: 'Partido lleno con coordenadas',
+            status: 'FULL',
+            availableSlots: 0,
+            club: {
+              name: 'Club Completo',
+              zone: 'Sur',
+              address: 'Rambla 1',
+              lat: -34.92,
+              lng: -56.17,
+            },
+          }),
+          buildMatch({
+            id: 'open-sin-coords',
+            title: 'F5 sin mapa',
+            club: {
+              name: 'Club Sin Coordenadas',
+              zone: 'Este',
+              address: 'Camino sin numero',
+              lat: null,
+              lng: null,
+            },
+          }),
+        ],
+      },
+    });
 
-    await gotoMatchesPage(page);
-    await waitForListToHydrate(page);
-    await switchToMap(page);
+    await matchesMapPage.goto();
+    await matchesMapPage.waitForListHydration();
+    await matchesMapPage.switchToMap();
 
-    const markers = page.locator('.leaflet-marker-icon');
-    await expect(markers).toHaveCount(2);
+    await expect(matchesMapPage.markers).toHaveCount(2);
 
-    await markers.first().click();
-    const popup = page.locator('.leaflet-popup');
-
-    await expect(popup).toContainText('Club Parque Rodo');
-    await expect(popup).toContainText('Bulevar Artigas 1000');
-    await expect(popup).toContainText('7v7');
-    await expect(popup).toContainText('8/14 jugadores');
-    await expect(popup.getByRole('link', { name: /ver detalle/i })).toHaveAttribute(
+    await matchesMapPage.markers.first().click();
+    await expect(matchesMapPage.popup).toContainText('Club Parque Rodo');
+    await expect(matchesMapPage.popup).toContainText('Bulevar Artigas 1000');
+    await expect(matchesMapPage.popup).toContainText('7v7');
+    await expect(matchesMapPage.popup).toContainText('8/14 jugadores');
+    await expect(matchesMapPage.popup.getByRole('link', { name: /ver detalle/i })).toHaveAttribute(
       'href',
       '/partidos/open-parque-rodo',
     );
   });
 
-  test('muestra empty-state cuando no hay partidos abiertos', async ({ page }) => {
-    await mockMatchesQuery(page, []);
+  test('muestra empty-state cuando no hay partidos abiertos', async ({ matchesMapPage, page }) => {
+    await mockGraphQLAll(page, GRAPHQL_ANY_ROUTE, { data: { matches: [] } });
 
-    await gotoMatchesPage(page);
-    await waitForListToHydrate(page);
-    await switchToMap(page);
+    await matchesMapPage.goto();
+    await matchesMapPage.waitForListHydration();
+    await matchesMapPage.switchToMap();
 
-    await expect(page.locator('.leaflet-container')).toBeVisible();
-    await expect(page.locator('.leaflet-marker-icon')).toHaveCount(0);
-    await expect(page.locator('.match-map-empty-msg')).toHaveText(/No hay partidos disponibles/i);
+    await expect(matchesMapPage.mapContainer).toBeVisible();
+    await expect(matchesMapPage.markers).toHaveCount(0);
+    await expect(matchesMapPage.emptyMessage).toHaveText(/No hay partidos disponibles/i);
   });
 
-  test('si hay partidos pero ninguno tiene coordenadas, no crea marcadores', async ({ page }) => {
+  test('si hay partidos pero ninguno tiene coordenadas, no crea marcadores', async ({
+    matchesMapPage,
+    page,
+  }) => {
     const warnings: string[] = [];
     page.on('console', (message) => {
       if (message.type() === 'warning') warnings.push(message.text());
     });
 
-    await mockMatchesQuery(page, [
-      buildMatch({
-        id: 'sin-lat',
-        title: 'F5 sin latitud',
-        club: {
-          name: 'Club Sin Latitud',
-          zone: 'Centro',
-          address: 'Direccion 1',
-          lat: null,
-          lng: -56.19,
-        },
-      }),
-      buildMatch({
-        id: 'sin-lng',
-        title: 'F5 sin longitud',
-        club: {
-          name: 'Club Sin Longitud',
-          zone: 'Norte',
-          address: 'Direccion 2',
-          lat: -34.9,
-          lng: null,
-        },
-      }),
-    ]);
+    await mockGraphQLAll(page, GRAPHQL_ANY_ROUTE, {
+      data: {
+        matches: [
+          buildMatch({
+            id: 'sin-lat',
+            title: 'F5 sin latitud',
+            club: { name: 'Club Sin Latitud', zone: 'Centro', lat: null, lng: -56.19 },
+          }),
+          buildMatch({
+            id: 'sin-lng',
+            title: 'F5 sin longitud',
+            club: { name: 'Club Sin Longitud', zone: 'Norte', lat: -34.9, lng: null },
+          }),
+        ],
+      },
+    });
 
-    await gotoMatchesPage(page);
-    await waitForListToHydrate(page);
-    await switchToMap(page);
+    await matchesMapPage.goto();
+    await matchesMapPage.waitForListHydration();
+    await matchesMapPage.switchToMap();
 
-    await expect(page.locator('.leaflet-container')).toBeVisible();
-    await expect(page.locator('.leaflet-marker-icon')).toHaveCount(0);
-    await expect(page.locator('.match-map-empty-msg')).toHaveText(
+    await expect(matchesMapPage.mapContainer).toBeVisible();
+    await expect(matchesMapPage.markers).toHaveCount(0);
+    await expect(matchesMapPage.emptyMessage).toHaveText(
       /No hay partidos con ubicaci.n disponible/i,
     );
     await expect
-      .poll(() => warnings.filter((warning) => warning.includes('Club sin coordenadas')).length)
+      .poll(() => warnings.filter((w) => w.includes('Club sin coordenadas')).length)
       .toBeGreaterThanOrEqual(2);
   });
 
-  test('aplica los filtros compartidos al mapa', async ({ page }) => {
-    await mockMatchesQuery(page, [
-      buildMatch({
-        id: 'centro',
-        title: 'F5 en Montevideo',
-        club: {
-          name: 'Club Centro',
-          zone: 'Centro',
-          address: '18 de Julio 1234',
-          lat: -34.905,
-          lng: -56.191,
-        },
-      }),
-      buildMatch({
-        id: 'lagomar',
-        title: 'F7 cerca de la costa',
-        format: 'SEVEN_VS_SEVEN',
-        club: {
-          name: 'Club Lagomar',
-          zone: 'Este',
-          address: 'Av. Giannattasio km 21',
-          lat: -34.839,
-          lng: -55.978,
-        },
-      }),
-    ]);
+  test('aplica los filtros compartidos al mapa', async ({ matchesMapPage, page }) => {
+    await mockGraphQLAll(page, GRAPHQL_ANY_ROUTE, {
+      data: {
+        matches: [
+          buildMatch({
+            id: 'centro',
+            title: 'F5 en Montevideo',
+            club: {
+              name: 'Club Centro',
+              zone: 'Centro',
+              address: '18 de Julio 1234',
+              lat: -34.905,
+              lng: -56.191,
+            },
+          }),
+          buildMatch({
+            id: 'lagomar',
+            title: 'F7 cerca de la costa',
+            format: 'SEVEN_VS_SEVEN',
+            club: {
+              name: 'Club Lagomar',
+              zone: 'Este',
+              address: 'Av. Giannattasio km 21',
+              lat: -34.839,
+              lng: -55.978,
+            },
+          }),
+        ],
+      },
+    });
 
-    await gotoMatchesPage(page);
+    await matchesMapPage.goto();
     await expect(page.getByText('F5 en Montevideo')).toBeVisible();
     await expect(page.getByText('F7 cerca de la costa')).toBeVisible();
 
-    await page.getByPlaceholder(/buscar partido o club/i).fill('Lagomar');
+    await matchesMapPage.searchInput.fill('Lagomar');
     await expect(page.getByText('F7 cerca de la costa')).toBeVisible();
     await expect(page.getByText('F5 en Montevideo')).not.toBeVisible();
 
-    await switchToMap(page);
+    await matchesMapPage.switchToMap();
 
-    const markers = page.locator('.leaflet-marker-icon');
-    await expect(markers).toHaveCount(1);
-    await markers.first().click();
-    await expect(page.locator('.leaflet-popup')).toContainText('Club Lagomar');
+    await expect(matchesMapPage.markers).toHaveCount(1);
+    await matchesMapPage.markers.first().click();
+    await expect(matchesMapPage.popup).toContainText('Club Lagomar');
     await expect(page).toHaveURL(/search=Lagomar/);
   });
 
-  test('muestra el error GraphQL dentro de la vista mapa', async ({ page }) => {
-    await mockMatchesError(page, 'Server on fire');
+  test('muestra el error GraphQL dentro de la vista mapa', async ({ matchesMapPage, page }) => {
+    await mockGraphQLAll(page, GRAPHQL_ANY_ROUTE, {
+      errors: [{ message: 'Server on fire' }],
+    });
 
-    await gotoMatchesPage(page);
-    await waitForListToHydrate(page);
-    await switchToMap(page);
+    await matchesMapPage.goto();
+    await matchesMapPage.waitForListHydration();
+    await matchesMapPage.switchToMap();
 
     await expect(page.locator('.match-map-loading')).toContainText('Server on fire');
-    await expect(page.locator('.leaflet-container')).toHaveCount(0);
+    await expect(matchesMapPage.mapContainer).toHaveCount(0);
   });
 
   test('expone el control de geolocalizacion cuando el navegador lo soporta', async ({
-    page,
+    matchesMapPage,
     context,
+    page,
   }) => {
     await context.setGeolocation({ latitude: -34.9011, longitude: -56.1645 });
     await context.grantPermissions(['geolocation'], { origin: FRONTEND_URL });
-    await mockMatchesQuery(page, [buildMatch()]);
+    await mockGraphQLAll(page, GRAPHQL_ANY_ROUTE, { data: { matches: [buildMatch()] } });
 
-    await gotoMatchesPage(page);
-    await waitForListToHydrate(page);
-    await switchToMap(page);
+    await matchesMapPage.goto();
+    await matchesMapPage.waitForListHydration();
+    await matchesMapPage.switchToMap();
 
     const locationButton = page.getByTitle(/centrar en mi ubicaci.n/i);
     await expect(locationButton).toBeVisible();

--- a/apps/testing/tests/menu-overview.spec.ts
+++ b/apps/testing/tests/menu-overview.spec.ts
@@ -1,91 +1,52 @@
-import { expect, test, type Page, type Route } from '@playwright/test';
+import { expect, GRAPHQL_PROXY_ROUTE, mockGraphQLAll, test } from './support';
 
 /**
- * Tests E2E del menu/vistazo rapido de la app en la home (/).
+ * Tests E2E del menu/vistazo rápido en la home (/).
  *
  * Decision Context:
- * - La historia pide que el usuario pueda ver un menu con un vistazo rapido de
- *   que trata la app. En el producto actual esa experiencia vive en la home:
- *   hero + CTA, partidos disponibles, metricas, "Como funciona" y CTA final.
- * - Mockeamos /api/graphql porque la home hidrata MatchList y dispara una query
- *   publica. El objetivo de estos tests es validar navegacion/contenido del menu,
- *   no el estado de Supabase ni del backend.
- * - El mock acepta GET y POST para cubrir el comportamiento de urql/fetchExchange.
+ * - La home hidrata MatchList y dispara una query pública. Mockeamos
+ *   `/api/graphql` con una lista vacía para que la home rinda contra un
+ *   contrato controlado y los tests no dependan del estado de Supabase.
+ * - El objetivo de estos tests es navegación y contenido del menu, no el
+ *   estado del backend.
+ * - Previously fixed bugs: none relevant.
  */
-
-const FRONTEND_URL = 'http://localhost:4321';
-
-async function mockHomeGraphQL(page: Page): Promise<void> {
-  await page.route('**/api/graphql**', async (route: Route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ data: { matches: [] } }),
-    });
-  });
-}
 
 test.describe('Menu de vistazo rapido (/)', () => {
   test.beforeEach(async ({ page }) => {
-    await mockHomeGraphQL(page);
+    await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, { data: { matches: [] } });
   });
 
-  test('muestra el resumen principal de la app y sus acciones para visitantes', async ({
+  test('muestra el resumen principal y CTAs para visitantes', async ({ homePage }) => {
+    await homePage.goto();
+
+    await expect(homePage.hero).toBeVisible();
+    await expect(homePage.loginLink).toHaveAttribute('href', '/login');
+    await expect(homePage.registerLink).toHaveAttribute('href', '/registro-jugador');
+  });
+
+  test('incluye accesos y contenido para explorar partidos disponibles', async ({
+    homePage,
     page,
   }) => {
-    await page.goto(FRONTEND_URL);
+    await homePage.goto();
 
-    await expect(page.getByRole('heading', { name: /sumate\s+al juego/i })).toBeVisible();
-    await expect(
-      page.getByText(/plataforma para conectar jugadores de f.tbol/i),
-    ).toBeVisible();
-
-    const loginLink = page.getByRole('link', { name: /iniciar sesi/i }).first();
-    const registerLink = page.getByRole('link', { name: /registrarse/i }).first();
-
-    await expect(loginLink).toHaveAttribute('href', '/login');
-    await expect(registerLink).toHaveAttribute('href', '/registro-jugador');
-  });
-
-  test('incluye accesos y contenido para explorar partidos disponibles', async ({ page }) => {
-    await page.goto(FRONTEND_URL);
-
-    await expect(
-      page.getByRole('heading', { name: /partidos disponibles/i }),
-    ).toBeVisible();
-    await expect(page.getByRole('link', { name: /ver todos/i })).toHaveAttribute(
-      'href',
-      '/partidos',
-    );
-    await expect(page.getByPlaceholder(/buscar partido o club/i)).toBeVisible();
+    await expect(page.getByRole('heading', { name: /partidos disponibles/i })).toBeVisible();
+    await expect(homePage.viewAllMatchesLink).toHaveAttribute('href', '/partidos');
+    await expect(homePage.searchInput).toBeVisible();
     await expect(page.locator('main select')).toHaveCount(3);
     await expect(page.getByText(/no hay partidos disponibles/i)).toBeVisible();
   });
 
   test('presenta metricas y pasos que explican rapidamente como funciona', async ({
+    homePage,
     page,
   }) => {
-    await page.goto(FRONTEND_URL);
+    await homePage.goto();
 
-    // Las metricas viven en cards con label visible (Jugadores/Partidos activos/Clubes).
-    // Localizamos cada card por su label y validamos el numero adentro — `500+` aparece
-    // tambien en el ticker del hero, asi que hay que scopear o el selector es ambiguo.
-    const playersCard = page
-      .locator('div', { has: page.getByText('Jugadores', { exact: true }) })
-      .filter({ hasText: '500+' })
-      .first();
-    const matchesCard = page
-      .locator('div', { has: page.getByText('Partidos activos', { exact: true }) })
-      .filter({ hasText: '120+' })
-      .first();
-    const clubsCard = page
-      .locator('div', { has: page.getByText('Clubes', { exact: true }) })
-      .filter({ hasText: '30+' })
-      .first();
-
-    await expect(playersCard).toBeVisible();
-    await expect(matchesCard).toBeVisible();
-    await expect(clubsCard).toBeVisible();
+    await expect(homePage.metricCard('Jugadores', '500+')).toBeVisible();
+    await expect(homePage.metricCard('Partidos activos', '120+')).toBeVisible();
+    await expect(homePage.metricCard('Clubes', '30+')).toBeVisible();
 
     await expect(page.getByRole('heading', { name: /c.mo funciona/i })).toBeVisible();
     await expect(page.getByRole('heading', { name: /crea tu perfil/i })).toBeVisible();
@@ -94,24 +55,23 @@ test.describe('Menu de vistazo rapido (/)', () => {
   });
 
   test('permite navegar desde el vistazo rapido hacia login, registro y partidos', async ({
+    homePage,
     page,
   }) => {
-    await page.goto(FRONTEND_URL);
+    await homePage.goto();
 
-    await page.getByRole('link', { name: /registrarse/i }).first().click();
+    await homePage.registerLink.click();
     await expect(page).toHaveURL(/\/registro-jugador$/);
     await expect(page.locator('#displayName')).toBeVisible();
 
-    await page.goto(FRONTEND_URL);
-    await page.getByRole('link', { name: /iniciar sesi/i }).first().click();
+    await homePage.goto();
+    await homePage.loginLink.click();
     await expect(page).toHaveURL(/\/login$/);
     await expect(page.locator('#email')).toBeVisible();
 
-    await page.goto(FRONTEND_URL);
-    await page.getByRole('link', { name: /ver todos/i }).click();
+    await homePage.goto();
+    await homePage.viewAllMatchesLink.click();
     await expect(page).toHaveURL(/\/partidos$/);
-    await expect(
-      page.getByRole('heading', { name: /partidos disponibles/i }),
-    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: /partidos disponibles/i })).toBeVisible();
   });
 });

--- a/apps/testing/tests/profile-avatar-upload.spec.ts
+++ b/apps/testing/tests/profile-avatar-upload.spec.ts
@@ -1,153 +1,83 @@
-import { expect, test, type Page, type Route } from '@playwright/test';
+import { expect, FRONTEND_URL, mockJsonRoute, test, TEST_USERS } from './support';
 
 /**
  * Tests E2E de subida de foto de perfil (/perfil).
  *
  * Decision Context:
- * - /perfil es SSR y requiere sesion real; usamos el mismo usuario de prueba que
- *   los specs de login/listado. El upload en si se mockea en /api/profile/avatar
- *   para no escribir en Supabase Storage ni modificar profiles.avatarUrl.
- * - El componente comprime client-side antes de enviar un data URL JSON al proxy de
- *   Astro. Los tests validan el contrato visible: preview, estados, formato/tamano,
- *   payload enviado, errores del backend y que no haya llamadas cuando falla la
- *   validacion cliente.
- * - Los casos de bucket inexistente y limite 2MB se simulan como respuestas del proxy:
- *   la verificacion real del bucket y la validacion autoritativa viven en el backend,
- *   pero el E2E asegura que el jugador ve el mensaje correcto sin quedar bloqueado.
+ * - /perfil es SSR y requiere sesión real; usamos storage state pre-autenticado
+ *   del player Mateo. El upload se mockea en `/api/profile/avatar` para no
+ *   escribir en Supabase Storage ni modificar profiles.avatarUrl.
+ * - El componente comprime client-side antes de enviar un data URL JSON al
+ *   proxy de Astro. Validamos el contrato visible: preview, estados,
+ *   formato/tamaño, payload enviado, errores del backend y la ausencia de
+ *   llamadas cuando falla la validación cliente.
+ * - Los casos "bucket no disponible" y "límite 2MB" se simulan como respuestas
+ *   del proxy: la verificación real vive en el backend, pero el E2E asegura
+ *   que el jugador ve el mensaje correcto.
  */
 
-const FRONTEND_URL = 'http://localhost:4321';
-const PROFILE_URL = `${FRONTEND_URL}/perfil`;
 const AVATAR_UPLOAD_ROUTE = '**/api/profile/avatar';
-
-const TEST_USER = {
-  email: 'mateoduran2010@gmail.com',
-  password: 'Hola1234',
-};
-
-const ONE_PIXEL_PNG = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
-  'base64',
-);
-
-type UploadResponse = {
-  status?: number;
-  body?: { avatarUrl?: string; error?: string };
-  delayMs?: number;
-};
-
-async function login(page: Page): Promise<void> {
-  await page.goto(`${FRONTEND_URL}/login`);
-  await page.getByRole('textbox', { name: 'Email' }).fill(TEST_USER.email);
-  await page.getByRole('textbox', { name: /contrase/i }).fill(TEST_USER.password);
-  await page.getByRole('button', { name: /ingresar/i }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
-}
-
-async function gotoProfile(page: Page): Promise<void> {
-  await page.goto(PROFILE_URL);
-  await expect(page.getByRole('heading', { name: /mi perfil/i })).toBeVisible();
-  await expect(page.locator('.profile-card')).toBeVisible();
-}
-
-async function openAvatarModal(page: Page): Promise<void> {
-  await page.locator('.profile-card-wrapper').hover();
-  await page.getByTitle(/cambiar foto de perfil/i).click();
-  await expect(page.getByRole('dialog')).toBeVisible();
-  await expect(page.getByRole('heading', { name: /actualizar foto de perfil/i })).toBeVisible();
-  await expect(page.locator('input[type="file"]')).toHaveAttribute(
-    'accept',
-    'image/jpeg,image/png,image/webp',
-  );
-}
-
-async function chooseFile(
-  page: Page,
-  file: { name: string; mimeType: string; buffer: Buffer },
-): Promise<void> {
-  await page.locator('input[type="file"]').setInputFiles(file);
-}
-
-async function chooseValidPng(page: Page): Promise<void> {
-  await chooseFile(page, {
-    name: 'avatar.png',
-    mimeType: 'image/png',
-    buffer: ONE_PIXEL_PNG,
-  });
-}
-
-async function mockAvatarUpload(
-  page: Page,
-  response: UploadResponse = {},
-): Promise<{ getPayloads: () => unknown[] }> {
-  const payloads: unknown[] = [];
-
-  await page.unroute(AVATAR_UPLOAD_ROUTE).catch(() => undefined);
-  await page.route(AVATAR_UPLOAD_ROUTE, async (route: Route) => {
-    const rawBody = route.request().postData() ?? '{}';
-    payloads.push(JSON.parse(rawBody) as unknown);
-
-    if (response.delayMs) {
-      await new Promise((resolve) => setTimeout(resolve, response.delayMs));
-    }
-
-    await route.fulfill({
-      status: response.status ?? 200,
-      contentType: 'application/json',
-      body: JSON.stringify(
-        response.body ?? {
-          avatarUrl:
-            'https://example.supabase.co/storage/v1/object/public/avatars/test-user/avatar.png',
-        },
-      ),
-    });
-  });
-
-  return { getPayloads: () => payloads };
-}
 
 test.describe('Subida de foto de perfil (/perfil)', () => {
   test.describe.configure({ mode: 'serial' });
 
-  test('redirige a login si el jugador no esta autenticado', async ({ page }) => {
-    await page.goto(PROFILE_URL);
-
-    await expect(page).toHaveURL(/\/login$/);
-    await expect(page.getByRole('textbox', { name: 'Email' })).toBeVisible();
+  test('redirige a login si el jugador no esta autenticado', async ({ browser }) => {
+    // Caso anónimo: contexto fresco sin storage state.
+    const anonContext = await browser.newContext();
+    const anonPage = await anonContext.newPage();
+    try {
+      await anonPage.goto(`${FRONTEND_URL}/perfil`);
+      await expect(anonPage).toHaveURL(/\/login$/);
+      await expect(anonPage.getByRole('textbox', { name: 'Email' })).toBeVisible();
+    } finally {
+      await anonContext.close();
+    }
   });
 
   test.describe('con sesion de jugador', () => {
-    test.beforeEach(async ({ page }) => {
-      await login(page);
-      await gotoProfile(page);
-      await openAvatarModal(page);
+    test.use({ storageState: TEST_USERS.playerMateo.storageStatePath });
+
+    test.beforeEach(async ({ profilePage }) => {
+      await profilePage.goto();
+      await profilePage.openAvatarModal();
     });
 
     test('abre el modal, selecciona una imagen valida y muestra preview antes de subir', async ({
+      profilePage,
       page,
     }) => {
-      const upload = await mockAvatarUpload(page);
+      const upload = await mockJsonRoute(page, AVATAR_UPLOAD_ROUTE, {
+        body: {
+          avatarUrl:
+            'https://example.supabase.co/storage/v1/object/public/avatars/test-user/avatar.png',
+        },
+      });
 
-      await expect(page.getByRole('button', { name: /subir foto/i })).toBeDisabled();
-      await chooseValidPng(page);
+      await expect(profilePage.submitAvatarButton).toBeDisabled();
+      await profilePage.chooseValidPng();
 
       await expect(page.getByAltText(/vista previa de tu nueva foto/i)).toBeVisible();
-      await expect(page.getByRole('button', { name: /subir foto/i })).toBeEnabled();
+      await expect(profilePage.submitAvatarButton).toBeEnabled();
       expect(upload.getPayloads()).toHaveLength(0);
     });
 
     test('comprime y envia la imagen como data URL JSON al proxy de avatar', async ({
+      profilePage,
       page,
     }) => {
-      const upload = await mockAvatarUpload(page, { delayMs: 1_000 });
+      const upload = await mockJsonRoute(page, AVATAR_UPLOAD_ROUTE, {
+        delayMs: 1_000,
+        body: {
+          avatarUrl:
+            'https://example.supabase.co/storage/v1/object/public/avatars/test-user/avatar.png',
+        },
+      });
 
-      await chooseValidPng(page);
-      await page.getByRole('button', { name: /subir foto/i }).click();
+      await profilePage.chooseValidPng();
+      await profilePage.submitAvatarButton.click();
 
       await expect(page.getByRole('button', { name: /procesando/i })).toBeVisible();
-      await expect
-        .poll(() => upload.getPayloads().length, { timeout: 30_000 })
-        .toBe(1);
+      await expect.poll(() => upload.getPayloads().length, { timeout: 30_000 }).toBe(1);
 
       const payload = upload.getPayloads()[0] as { dataUrl?: string };
       expect(payload.dataUrl).toMatch(/^data:image\/png;base64,/);
@@ -155,86 +85,87 @@ test.describe('Subida de foto de perfil (/perfil)', () => {
       await expect(page.getByText(/foto actualizada/i)).toBeVisible();
     });
 
-    test('rechaza formatos no permitidos antes de llamar al backend', async ({ page }) => {
-      const upload = await mockAvatarUpload(page);
+    test('rechaza formatos no permitidos antes de llamar al backend', async ({
+      profilePage,
+      page,
+    }) => {
+      const upload = await mockJsonRoute(page, AVATAR_UPLOAD_ROUTE);
 
-      await chooseFile(page, {
+      await profilePage.chooseFile({
         name: 'avatar.gif',
         mimeType: 'image/gif',
         buffer: Buffer.from('not-an-allowed-image'),
       });
 
       await expect(page.getByRole('alert')).toContainText(/formato no permitido/i);
-      await expect(page.getByRole('button', { name: /subir foto/i })).toBeDisabled();
+      await expect(profilePage.submitAvatarButton).toBeDisabled();
       await expect(page.getByAltText(/vista previa/i)).toHaveCount(0);
       expect(upload.getPayloads()).toHaveLength(0);
     });
 
     test('rechaza archivos demasiado grandes en el cliente sin hacer upload', async ({
+      profilePage,
       page,
     }) => {
-      const upload = await mockAvatarUpload(page);
+      const upload = await mockJsonRoute(page, AVATAR_UPLOAD_ROUTE);
 
-      await chooseFile(page, {
+      await profilePage.chooseFile({
         name: 'avatar-grande.png',
         mimeType: 'image/png',
         buffer: Buffer.alloc(6 * 1024 * 1024 + 1, 1),
       });
 
       await expect(page.getByRole('alert')).toContainText(/archivo es demasiado grande/i);
-      await expect(page.getByRole('button', { name: /subir foto/i })).toBeDisabled();
+      await expect(profilePage.submitAvatarButton).toBeDisabled();
       expect(upload.getPayloads()).toHaveLength(0);
     });
 
     test('muestra el error autoritativo de tamano maximo 2MB devuelto por el backend', async ({
+      profilePage,
       page,
     }) => {
-      await mockAvatarUpload(page, {
+      await mockJsonRoute(page, AVATAR_UPLOAD_ROUTE, {
         status: 400,
         body: {
           error: 'La imagen supera el limite de 2MB. Reducí el tamaño e intentá de nuevo.',
         },
       });
 
-      await chooseValidPng(page);
-      await page.getByRole('button', { name: /subir foto/i }).click();
+      await profilePage.chooseValidPng();
+      await profilePage.submitAvatarButton.click();
 
       await expect(page.getByRole('alert')).toContainText(/limite de 2MB/i);
-      await expect(page.getByRole('button', { name: /subir foto/i })).toBeEnabled();
+      await expect(profilePage.submitAvatarButton).toBeEnabled();
     });
 
-    test('muestra error si el bucket avatars no esta disponible', async ({ page }) => {
-      await mockAvatarUpload(page, {
+    test('muestra error si el bucket avatars no esta disponible', async ({
+      profilePage,
+      page,
+    }) => {
+      await mockJsonRoute(page, AVATAR_UPLOAD_ROUTE, {
         status: 500,
         body: {
           error: 'El bucket de almacenamiento no esta disponible. Contacta al administrador.',
         },
       });
 
-      await chooseValidPng(page);
-      await page.getByRole('button', { name: /subir foto/i }).click();
+      await profilePage.chooseValidPng();
+      await profilePage.submitAvatarButton.click();
 
       await expect(page.getByRole('alert')).toContainText(/bucket de almacenamiento/i);
-      await expect(page.getByRole('button', { name: /subir foto/i })).toBeEnabled();
+      await expect(profilePage.submitAvatarButton).toBeEnabled();
     });
 
-    /**
-     * Decision Context:
-     * - This test only verifies the close affordance works. The "select file +
-     *   preview" path is already exhaustively covered by the first test in this
-     *   describe block, so re-running it here was pure setup cost (canvas
-     *   compression for the data-URL preview, plus a `toBeVisible()` poll) on a
-     *   test that does not assert anything about the preview.
-     * - We assert `toBeHidden()` against `#close-modal-btn` (a stable id) instead
-     *   of double-checking `dialog.not.toBeVisible()` AND `toHaveClass(/hidden/)`.
-     *   The CSS rule `.modal-overlay.hidden { visibility: hidden }` is what
-     *   actually hides the dialog, so a single visibility-aware assertion is the
-     *   behavioral truth — class-name checking was an implementation detail.
-     * - Previously fixed bugs: none relevant.
-     */
-    test('permite cerrar el modal sin subir imagen', async ({ page }) => {
-      await page.locator('#close-modal-btn').click();
-      await expect(page.locator('#avatar-upload-modal')).toBeHidden();
+    test('permite cerrar el modal sin subir imagen', async ({ profilePage }) => {
+      // Decision Context: sólo verificamos el cierre. La selección de archivo +
+      // preview ya está cubierta exhaustivamente arriba — re-correrlo acá era
+      // setup puro (canvas compression para el data-URL preview) sobre un test
+      // que no asserta nada del preview. Asertamos `toBeHidden()` contra
+      // `#avatar-upload-modal` (id estable); la visibility-aware assertion es
+      // la verdad de comportamiento — chequear class-name era detalle interno.
+      await profilePage.closeAvatarButton.click();
+      await expect(profilePage.avatarModal).toBeHidden();
     });
   });
 });
+

--- a/apps/testing/tests/profile-view.spec.ts
+++ b/apps/testing/tests/profile-view.spec.ts
@@ -1,30 +1,27 @@
-import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import {
+  ACCESS_TOKEN_COOKIE,
+  expect,
+  FRONTEND_URL,
+  gqlPostOrThrow,
+  loginAndReadToken,
+  REFRESH_TOKEN_COOKIE,
+  test,
+} from './support';
 
 /**
- * Tests E2E de visualizacion de perfil (/perfil).
+ * Tests E2E de visualización de perfil (/perfil).
  *
  * Decision Context:
- * - /perfil es SSR y requiere auth: el fetch de myProfile ocurre en el servidor de
- *   Astro, por lo que page.route() no puede interceptarlo desde el browser. Para que
- *   el test sea determinista respecto al usuario autenticado, hacemos login real y
- *   consultamos el mismo contrato GraphQL con el access token de la cookie HttpOnly.
+ * - /perfil es SSR y requiere auth: el fetch de `myProfile` ocurre en el
+ *   servidor de Astro, por lo que `page.route()` no lo intercepta. Para que el
+ *   test sea determinista respecto al usuario autenticado, hacemos login real
+ *   y consultamos el mismo contrato GraphQL con el access token.
  * - Validamos la UI contra la respuesta de myProfile: nombre, avatar/fallback,
- *   division, posicion preferida, partidos jugados/ganados y winrate.
- * - Edge cases cubiertos: usuario anonimo redirigido, token invalido sin refresh,
- *   avatar ausente, posicion preferida ausente y winrate null cuando no hay partidos.
- *   Los valores concretos dependen del perfil seed usado por el ambiente.
+ *   división, posición preferida, partidos jugados/ganados y winrate.
+ * - Edge cases: visitante anónimo redirigido, token inválido sin refresh,
+ *   avatar ausente, posición preferida ausente, winrate null.
  */
-
-const FRONTEND_URL = 'http://localhost:4321';
-const BACKEND_GRAPHQL_URL = 'http://localhost:4000/graphql';
-const PROFILE_URL = `${FRONTEND_URL}/perfil`;
-const ACCESS_TOKEN_COOKIE = 'sumateya-access-token';
-const REFRESH_TOKEN_COOKIE = 'sumateya-refresh-token';
-
-const TEST_USER = {
-  email: 'mateoduran2010@gmail.com',
-  password: 'Hola1234',
-};
 
 type Profile = {
   id: string;
@@ -45,90 +42,31 @@ const POSITION_LABEL: Record<NonNullable<Profile['preferredPosition']>, string> 
   FORWARD: 'Delantero',
 };
 
-async function login(page: Page): Promise<void> {
-  await page.goto(`${FRONTEND_URL}/login`);
-  await page.getByRole('textbox', { name: 'Email' }).fill(TEST_USER.email);
-  await page.getByRole('textbox', { name: /contrase/i }).fill(TEST_USER.password);
-  await page.getByRole('button', { name: /ingresar/i }).click();
-  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
-}
-
-async function readAccessToken(page: Page): Promise<string> {
-  const cookies = await page.context().cookies(FRONTEND_URL);
-  const accessToken = cookies.find((cookie) => cookie.name === ACCESS_TOKEN_COOKIE)?.value;
-
-  expect(accessToken, 'el login debe dejar cookie HttpOnly de access token').toBeTruthy();
-  return accessToken as string;
-}
-
-async function fetchMyProfile(request: APIRequestContext, accessToken: string): Promise<Profile> {
-  const response = await request.post(BACKEND_GRAPHQL_URL, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    data: {
-      query: /* GraphQL */ `
-        query GetMyProfile {
-          myProfile {
-            id
-            displayName
-            avatarUrl
-            role
-            preferredPosition
-            division
-            matchesPlayed
-            matchesWon
-            winrate
-          }
+async function fetchMyProfile(
+  request: APIRequestContext,
+  accessToken: string,
+): Promise<Profile> {
+  const data = await gqlPostOrThrow<{ myProfile: Profile }>(
+    request,
+    /* GraphQL */ `
+      query GetMyProfile {
+        myProfile {
+          id displayName avatarUrl role preferredPosition division
+          matchesPlayed matchesWon winrate
         }
-      `,
-    },
-  });
-
-  expect(response.ok(), 'myProfile debe responder 2xx para el usuario autenticado').toBe(true);
-
-  const payload = (await response.json()) as {
-    data?: { myProfile?: Profile };
-    errors?: Array<{ message: string }>;
-  };
-
-  expect(payload.errors ?? []).toHaveLength(0);
-  expect(payload.data?.myProfile, 'myProfile debe devolver el perfil autenticado').toBeTruthy();
-  return payload.data?.myProfile as Profile;
-}
-
-async function gotoProfile(page: Page): Promise<void> {
-  await page.goto(PROFILE_URL);
-  await expect(page.getByRole('heading', { name: /mi perfil/i })).toBeVisible();
-  await expect(page.locator('.profile-card')).toBeVisible();
-}
-
-function statCell(page: Page, label: string) {
-  return page.locator('.profile-card .stat-cell').filter({ hasText: label });
-}
-
-async function expectStatValue(page: Page, label: string, value: string | number): Promise<void> {
-  await expect(statCell(page, label).locator('.stat-value')).toHaveText(String(value));
-}
-
-async function expectWinrate(page: Page, profile: Profile): Promise<void> {
-  const winrate = statCell(page, 'Efectividad').locator('.stat-value');
-
-  if (profile.winrate === null || profile.winrate === undefined) {
-    await expect(winrate).not.toContainText('%');
-    await expect(winrate).not.toHaveText('0%');
-    return;
-  }
-
-  await expect(winrate).toHaveText(`${profile.winrate.toFixed(1)}%`);
+      }
+    `,
+    undefined,
+    accessToken,
+  );
+  return data.myProfile;
 }
 
 test.describe('Ver perfil de usuario (/perfil)', () => {
   test.describe.configure({ mode: 'serial' });
 
   test('redirige a login cuando el jugador no esta autenticado', async ({ page }) => {
-    await page.goto(PROFILE_URL);
+    await page.goto(`${FRONTEND_URL}/perfil`);
 
     await expect(page).toHaveURL(/\/login$/);
     await expect(page.getByRole('textbox', { name: 'Email' })).toBeVisible();
@@ -149,50 +87,63 @@ test.describe('Ver perfil de usuario (/perfil)', () => {
       },
     ]);
 
-    await page.goto(PROFILE_URL);
+    await page.goto(`${FRONTEND_URL}/perfil`);
 
     await expect(page).toHaveURL(/\/login$/);
     const cookies = await context.cookies(FRONTEND_URL);
-    expect(cookies.some((cookie) => cookie.name === ACCESS_TOKEN_COOKIE)).toBe(false);
-    expect(cookies.some((cookie) => cookie.name === REFRESH_TOKEN_COOKIE)).toBe(false);
+    expect(cookies.some((c) => c.name === ACCESS_TOKEN_COOKIE)).toBe(false);
+    expect(cookies.some((c) => c.name === REFRESH_TOKEN_COOKIE)).toBe(false);
   });
 
   test('muestra nombre, division, posicion, avatar, stats y winrate del perfil autenticado', async ({
+    profilePage,
     page,
     request,
   }) => {
-    await login(page);
-    const profile = await fetchMyProfile(request, await readAccessToken(page));
+    const token = await loginAndReadToken(page, 'playerMateo');
+    const profile = await fetchMyProfile(request, token);
 
-    await gotoProfile(page);
+    await profilePage.goto();
 
-    const card = page.locator('.profile-card');
-    await expect(card.getByRole('heading', { name: profile.displayName })).toBeVisible();
-    await expect(card.getByText(`DIV ${profile.division}`)).toBeVisible();
-    await expectStatValue(page, 'Partidos', profile.matchesPlayed);
-    await expectStatValue(page, 'Victorias', profile.matchesWon);
-    await expectWinrate(page, profile);
+    await expect(profilePage.card.getByRole('heading', { name: profile.displayName })).toBeVisible();
+    await expect(profilePage.card.getByText(`DIV ${profile.division}`)).toBeVisible();
+    await profilePage.expectStatValue('Partidos', profile.matchesPlayed);
+    await profilePage.expectStatValue('Victorias', profile.matchesWon);
 
     if (profile.preferredPosition) {
-      await expect(card.getByText(POSITION_LABEL[profile.preferredPosition])).toBeVisible();
+      await expect(
+        profilePage.card.getByText(POSITION_LABEL[profile.preferredPosition]),
+      ).toBeVisible();
     } else {
-      await expect(card.locator('.position-tag')).toHaveCount(0);
+      await expect(profilePage.card.locator('.position-tag')).toHaveCount(0);
     }
 
     if (profile.avatarUrl) {
-      const avatar = card.getByAltText(`Foto de ${profile.displayName}`);
+      const avatar = profilePage.card.getByAltText(`Foto de ${profile.displayName}`);
       await expect(avatar).toBeVisible();
       await expect(avatar).toHaveAttribute('src', profile.avatarUrl);
     } else {
-      await expect(card.getByLabel(/sin foto de perfil/i)).toBeVisible();
+      await expect(profilePage.card.getByLabel(/sin foto de perfil/i)).toBeVisible();
+    }
+
+    const winrate = profilePage.statCell('Efectividad').locator('.stat-value');
+    if (profile.winrate === null || profile.winrate === undefined) {
+      await expect(winrate).not.toContainText('%');
+      await expect(winrate).not.toHaveText('0%');
+    } else {
+      await expect(winrate).toHaveText(`${profile.winrate.toFixed(1)}%`);
     }
   });
 
-  test('el winrate visible respeta los bordes de myProfile', async ({ page, request }) => {
-    await login(page);
-    const profile = await fetchMyProfile(request, await readAccessToken(page));
+  test('el winrate visible respeta los bordes de myProfile', async ({
+    profilePage,
+    page,
+    request,
+  }) => {
+    const token = await loginAndReadToken(page, 'playerMateo');
+    const profile = await fetchMyProfile(request, token);
 
-    await gotoProfile(page);
+    await profilePage.goto();
 
     const expectedWinrate =
       profile.matchesPlayed > 0
@@ -200,6 +151,12 @@ test.describe('Ver perfil de usuario (/perfil)', () => {
         : null;
 
     expect(profile.winrate).toBe(expectedWinrate);
-    await expectWinrate(page, profile);
+
+    const winrate = profilePage.statCell('Efectividad').locator('.stat-value');
+    if (profile.winrate === null) {
+      await expect(winrate).not.toContainText('%');
+    } else {
+      await expect(winrate).toHaveText(`${profile.winrate.toFixed(1)}%`);
+    }
   });
 });

--- a/apps/testing/tests/registro-club.spec.ts
+++ b/apps/testing/tests/registro-club.spec.ts
@@ -1,48 +1,42 @@
-import { test, expect, type Page } from '@playwright/test';
-
-
-const FRONTEND_URL = 'http://localhost:4321';
-const REGISTRO_URL = `${FRONTEND_URL}/registro-club`;
+import { expect, RegisterClubPage, test } from './support';
 
 /**
- * Genera un email único por corrida para evitar colisiones cuando el test de POST
- * efectivamente llega al backend (aunque esperamos un 400 por contraseñas que no
- * coinciden, igual queremos minimizar side-effects si la validación cambia).
+ * Tests E2E del registro de club (/registro-club).
+ *
+ * Decision Context:
+ * - Los tests "render y estructura" no requieren backend; los tests de "submit
+ *   inválido" sí, y `playwright.config` arranca `npm run dev` antes de la suite.
+ * - El form expone secciones (admin / club) con labels accesibles; usamos
+ *   getByLabel via la PO `RegisterClubPage` para evitar selectores frágiles.
+ * - Previously fixed bugs: none relevant.
  */
-function uniqueEmail(): string {
-  return `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.test`;
-}
-
-async function gotoRegistro(page: Page): Promise<void> {
-  await page.goto(REGISTRO_URL);
-  // Esperar a que el form esté presente — confirma que la SSR no nos redirigió.
-  await expect(page.locator('form.reg-form')).toBeVisible();
-}
 
 test.describe('Registro de club (/registro-club) — render y estructura', () => {
-  test('renderiza el header con el branding y subtítulo', async ({ page }) => {
-    await gotoRegistro(page);
+  test('renderiza el header con el branding y subtítulo', async ({ registerClubPage, page }) => {
+    await registerClubPage.goto();
 
     await expect(page).toHaveTitle(/Registrar Club — Sumate Ya/);
     await expect(page.getByRole('heading', { name: /SUMATE YA/i })).toBeVisible();
     await expect(page.getByText(/Registrá tu club y publicá tus canchas/i)).toBeVisible();
   });
 
-  test('muestra las dos secciones del formulario', async ({ page }) => {
-    await gotoRegistro(page);
+  test('muestra las dos secciones del formulario', async ({ registerClubPage, page }) => {
+    await registerClubPage.goto();
 
     await expect(page.getByText('DATOS DEL ADMINISTRADOR')).toBeVisible();
     await expect(page.getByText('DATOS DEL CLUB')).toBeVisible();
   });
 
-  test('renderiza todos los campos del administrador con sus labels', async ({ page }) => {
-    await gotoRegistro(page);
+  test('renderiza todos los campos del administrador con sus labels', async ({
+    registerClubPage,
+    page,
+  }) => {
+    await registerClubPage.goto();
 
-    // Labels asociados por `for=` → `getByLabel` matchea por el atributo accesible.
-    await expect(page.getByLabel('Nombre completo')).toBeVisible();
-    await expect(page.getByLabel('Email')).toBeVisible();
-    await expect(page.getByLabel('Contraseña', { exact: true })).toBeVisible();
-    await expect(page.getByLabel('Confirmar contraseña')).toBeVisible();
+    await expect(registerClubPage.fullName).toBeVisible();
+    await expect(registerClubPage.email).toBeVisible();
+    await expect(registerClubPage.password).toBeVisible();
+    await expect(registerClubPage.confirmPassword).toBeVisible();
 
     // Tipos correctos: password debe ser type=password (no leak en DOM como text).
     await expect(page.locator('input#password')).toHaveAttribute('type', 'password');
@@ -50,71 +44,73 @@ test.describe('Registro de club (/registro-club) — render y estructura', () =>
     await expect(page.locator('input#email')).toHaveAttribute('type', 'email');
   });
 
-  test('renderiza todos los campos del club con sus labels', async ({ page }) => {
-    await gotoRegistro(page);
+  test('renderiza todos los campos del club con sus labels', async ({ registerClubPage }) => {
+    await registerClubPage.goto();
 
-    await expect(page.getByLabel('Nombre del club')).toBeVisible();
-    await expect(page.getByLabel('Dirección')).toBeVisible();
-    await expect(page.getByLabel('Teléfono')).toBeVisible();
+    await expect(registerClubPage.clubName).toBeVisible();
+    await expect(registerClubPage.address).toBeVisible();
+    await expect(registerClubPage.phone).toBeVisible();
   });
 
-  test('los campos de zona, latitud y longitud ya no existen en el form', async ({ page }) => {
-    await gotoRegistro(page);
-
+  test('los campos de zona, latitud y longitud ya no existen en el form', async ({
+    registerClubPage,
+    page,
+  }) => {
     // Decisión de producto (2026-05-03): zona / lat / lng se sacaron del registro.
     // Las columnas siguen existiendo en DB pero nullable; el form no las pide.
+    await registerClubPage.goto();
+
     await expect(page.locator('input#lat')).toHaveCount(0);
     await expect(page.locator('input#lng')).toHaveCount(0);
     await expect(page.locator('input#zone')).toHaveCount(0);
     await expect(page.getByRole('button', { name: /Usar mi ubicación/i })).toHaveCount(0);
   });
 
-  test('el form usa method POST y tiene el botón de submit con el copy correcto', async ({ page }) => {
-    await gotoRegistro(page);
+  test('el form usa method POST y tiene el botón con copy correcto', async ({
+    registerClubPage,
+  }) => {
+    await registerClubPage.goto();
 
-    await expect(page.locator('form.reg-form')).toHaveAttribute('method', /post/i);
-    await expect(page.getByRole('button', { name: 'REGISTRAR CLUB' })).toBeVisible();
+    await expect(registerClubPage.form).toHaveAttribute('method', /post/i);
+    await expect(registerClubPage.submitButton).toBeVisible();
   });
 
-  test('muestra los links a login y a registro de jugador', async ({ page }) => {
-    await gotoRegistro(page);
+  test('muestra los links a login y a registro de jugador', async ({ registerClubPage, page }) => {
+    await registerClubPage.goto();
 
     const loginLink = page.getByRole('link', { name: /Iniciá sesión/i });
     const playerLink = page.getByRole('link', { name: /Registrate acá/i });
 
-    await expect(loginLink).toBeVisible();
     await expect(loginLink).toHaveAttribute('href', '/login');
-
-    await expect(playerLink).toBeVisible();
     await expect(playerLink).toHaveAttribute('href', '/registro-jugador');
   });
 
-  test('el link a login navega correctamente', async ({ page }) => {
-    await gotoRegistro(page);
+  test('el link a login navega correctamente', async ({ registerClubPage, page }) => {
+    await registerClubPage.goto();
 
     await page.getByRole('link', { name: /Iniciá sesión/i }).click();
     await expect(page).toHaveURL(/\/login$/);
   });
 
-  test('el link a registro de jugador navega correctamente', async ({ page }) => {
-    await gotoRegistro(page);
+  test('el link a registro de jugador navega correctamente', async ({ registerClubPage, page }) => {
+    await registerClubPage.goto();
 
     await page.getByRole('link', { name: /Registrate acá/i }).click();
     await expect(page).toHaveURL(/\/registro-jugador$/);
   });
 
-  test('los inputs aceptan valores y los retienen en el DOM', async ({ page }) => {
-    await gotoRegistro(page);
+  test('los inputs aceptan valores y los retienen en el DOM', async ({ registerClubPage }) => {
+    await registerClubPage.goto();
 
-    await page.getByLabel('Nombre completo').fill('Juan Pérez');
-    await page.getByLabel('Email').fill('juan@miclub.com.uy');
-    await page.getByLabel('Nombre del club').fill('Club Atletico Sur');
-    await page.getByLabel('Dirección').fill('Av. 18 de Julio 1234, Montevideo');
+    await registerClubPage.fullName.fill('Juan Pérez');
+    await registerClubPage.email.fill('juan@miclub.com.uy');
+    await registerClubPage.clubName.fill('Club Atletico Sur');
+    await registerClubPage.address.fill('Av. 18 de Julio 1234, Montevideo');
 
-    await expect(page.getByLabel('Nombre completo')).toHaveValue('Juan Pérez');
-    await expect(page.getByLabel('Email')).toHaveValue('juan@miclub.com.uy');
-    await expect(page.getByLabel('Nombre del club')).toHaveValue('Club Atletico Sur');
-    await expect(page.getByLabel('Dirección')).toHaveValue('Av. 18 de Julio 1234, Montevideo');
+    await expect(registerClubPage.fullName).toHaveValue('Juan Pérez');
+    await expect(registerClubPage.email).toHaveValue('juan@miclub.com.uy');
+    await expect(registerClubPage.clubName).toHaveValue('Club Atletico Sur');
+    await expect(registerClubPage.address).toHaveValue('Av. 18 de Julio 1234, Montevideo');
   });
 });
 
@@ -124,18 +120,21 @@ test.describe('Registro de club (/registro-club) — render y estructura', () =>
  * así que el backend siempre está disponible cuando se ejecutan estos tests.
  */
 test.describe('Registro de club — submit con datos inválidos (requiere backend)', () => {
-  test('contraseñas que no coinciden → muestra error inline en confirmPassword', async ({ page }) => {
-    await gotoRegistro(page);
+  test('contraseñas que no coinciden → muestra error inline', async ({
+    registerClubPage,
+    page,
+  }) => {
+    await registerClubPage.goto();
 
-    await page.getByLabel('Nombre completo').fill('Tester QA');
-    await page.getByLabel('Email').fill(uniqueEmail());
-    await page.getByLabel('Contraseña', { exact: true }).fill('Password123');
-    await page.getByLabel('Confirmar contraseña').fill('Otracosa999');
-    await page.getByLabel('Nombre del club').fill('Club Test QA');
-    await page.getByLabel('Dirección').fill('Av. 18 de Julio 1234, Montevideo');
-    await page.getByLabel('Teléfono').fill('+598 2 400 1234');
+    await registerClubPage.fullName.fill('Tester QA');
+    await registerClubPage.email.fill(RegisterClubPage.uniqueEmail());
+    await registerClubPage.password.fill('Password123');
+    await registerClubPage.confirmPassword.fill('Otracosa999');
+    await registerClubPage.clubName.fill('Club Test QA');
+    await registerClubPage.address.fill('Av. 18 de Julio 1234, Montevideo');
+    await registerClubPage.phone.fill('+598 2 400 1234');
 
-    await page.getByRole('button', { name: 'REGISTRAR CLUB' }).click();
+    await registerClubPage.submitButton.click();
 
     // El backend (Zod) devuelve 400 con `errors.confirmPassword`. La página se
     // re-renderiza con el span.field-error correspondiente. No debe redirigir a /login.
@@ -143,11 +142,12 @@ test.describe('Registro de club — submit con datos inválidos (requiere backen
     await expect(page.getByText(/no coinciden/i)).toBeVisible();
   });
 
-  test('campos vacíos → backend devuelve errores múltiples y se renderizan inline', async ({ page }) => {
-    await gotoRegistro(page);
-
-    // Submit sin completar nada.
-    await page.getByRole('button', { name: 'REGISTRAR CLUB' }).click();
+  test('campos vacíos → backend devuelve errores múltiples y se renderizan inline', async ({
+    registerClubPage,
+    page,
+  }) => {
+    await registerClubPage.goto();
+    await registerClubPage.submitButton.click();
 
     await expect(page).toHaveURL(/\/registro-club/);
     // Al menos un error inline debe estar visible (Zod requiere todos los campos).

--- a/apps/testing/tests/registro-jugador.spec.ts
+++ b/apps/testing/tests/registro-jugador.spec.ts
@@ -1,52 +1,31 @@
-import { expect, test, type Page, type Route } from '@playwright/test';
+import type { Page, Route } from '@playwright/test';
+import {
+  expect,
+  FRONTEND_URL,
+  test,
+  VALID_PLAYER_REGISTER,
+  type PlayerRegisterValues,
+} from './support';
 
 /**
  * Tests E2E del registro de jugador (/registro-jugador).
  *
  * Decision Context:
- * - La pagina usa SSR: el submit del form va a Astro y Astro llama al backend.
- *   Por eso `page.route()` no puede mockear el fetch interno al backend; solo puede
- *   interceptar la navegacion POST del navegador hacia /registro-jugador.
- * - Validaciones Zod de forma/campos se prueban contra el flujo SSR real porque no
- *   llegan a Supabase: el backend responde 400 antes de llamar authService.
- * - Casos que crearian o consultarian usuarios reales (exito, email duplicado,
- *   password debil de proveedor, rate limit) se prueban interceptando el POST del
- *   navegador. Asi verificamos el contrato visible de la pantalla sin ensuciar
- *   auth.users/profiles ni depender del estado de Supabase.
- * - Complementa los tests unitarios del backend que verifican createUser(),
- *   insert en profiles con role='player' y rollback ante fallas.
+ * - La página usa SSR: el submit del form va a Astro, que llama al backend.
+ *   Por eso `page.route()` no puede mockear el fetch interno al backend; sólo
+ *   intercepta la navegación POST del navegador hacia /registro-jugador.
+ * - Validaciones Zod de forma/campos se prueban contra el flujo SSR real porque
+ *   el backend responde 400 antes de llamar a authService.
+ * - Casos que crearían usuarios reales (éxito, email duplicado, password débil,
+ *   rate limit) interceptan el POST del navegador. Validamos el contrato visible
+ *   sin ensuciar auth.users/profiles ni depender del estado de Supabase.
+ * - Previously fixed bugs: none relevant.
  */
 
-const FRONTEND_URL = 'http://localhost:4321';
 const REGISTER_URL = `${FRONTEND_URL}/registro-jugador`;
 
-type RegisterValues = {
-  displayName: string;
-  email: string;
-  password: string;
-  confirmPassword: string;
-};
-
-const VALID_PLAYER: RegisterValues = {
-  displayName: 'Mateo Duran',
-  email: 'mateo.e2e@example.com',
-  password: 'Hola12345',
-  confirmPassword: 'Hola12345',
-};
-
-async function fillRegisterForm(page: Page, values: Partial<RegisterValues> = {}): Promise<void> {
-  const input = { ...VALID_PLAYER, ...values };
-
-  await page.locator('#displayName').fill(input.displayName);
-  await page.locator('#email').fill(input.email);
-  await page.locator('#password').fill(input.password);
-  await page.locator('#confirmPassword').fill(input.confirmPassword);
-}
-
-function parseFormBody(route: Route): RegisterValues {
-  const body = route.request().postData() ?? '';
-  const params = new URLSearchParams(body);
-
+function parseFormBody(route: Route): PlayerRegisterValues {
+  const params = new URLSearchParams(route.request().postData() ?? '');
   return {
     displayName: params.get('displayName') ?? '',
     email: params.get('email') ?? '',
@@ -55,21 +34,14 @@ function parseFormBody(route: Route): RegisterValues {
   };
 }
 
-async function submitAndWait(page: Page): Promise<void> {
-  await Promise.all([
-    page.waitForLoadState('domcontentloaded'),
-    page.getByRole('button', { name: /crear cuenta/i }).click(),
-  ]);
-}
-
 function errorPageHtml({
   values,
   globalError = '',
   fieldErrors = {},
 }: {
-  values: Pick<RegisterValues, 'displayName' | 'email'>;
+  values: Pick<PlayerRegisterValues, 'displayName' | 'email'>;
   globalError?: string;
-  fieldErrors?: Partial<Record<keyof RegisterValues, string>>;
+  fieldErrors?: Partial<Record<keyof PlayerRegisterValues, string>>;
 }): string {
   return `<!doctype html>
 <html lang="es">
@@ -107,28 +79,26 @@ function errorPageHtml({
 
 async function mockRegisterPost(
   page: Page,
-  handler: (route: Route, submitted: RegisterValues) => Promise<void>,
+  handler: (route: Route, submitted: PlayerRegisterValues) => Promise<void>,
 ): Promise<void> {
   await page.route('**/registro-jugador', async (route) => {
     if (route.request().method() !== 'POST') {
       await route.continue();
       return;
     }
-
     await handler(route, parseFormBody(route));
   });
 }
 
 test.describe('Registro de jugador (/registro-jugador)', () => {
-  test('renderiza el formulario y los links esperados', async ({ page }) => {
-    await page.goto(REGISTER_URL);
+  test('renderiza el formulario y los links esperados', async ({ registerPlayerPage, page }) => {
+    await registerPlayerPage.goto();
 
-    await expect(page.getByRole('heading', { name: /sumate ya/i })).toBeVisible();
-    await expect(page.locator('#displayName')).toBeVisible();
-    await expect(page.locator('#email')).toBeVisible();
-    await expect(page.locator('#password')).toBeVisible();
-    await expect(page.locator('#confirmPassword')).toBeVisible();
-    await expect(page.getByRole('button', { name: /crear cuenta/i })).toBeVisible();
+    await expect(registerPlayerPage.displayName).toBeVisible();
+    await expect(registerPlayerPage.email).toBeVisible();
+    await expect(registerPlayerPage.password).toBeVisible();
+    await expect(registerPlayerPage.confirmPassword).toBeVisible();
+    await expect(registerPlayerPage.submitButton).toBeVisible();
     await expect(page.getByRole('link', { name: /inici/i })).toHaveAttribute('href', '/login');
     await expect(page.getByRole('link', { name: /club/i })).toHaveAttribute(
       'href',
@@ -137,45 +107,44 @@ test.describe('Registro de jugador (/registro-jugador)', () => {
   });
 
   test('muestra errores Zod para email invalido, password corta y nombre incompleto', async ({
+    registerPlayerPage,
     page,
   }) => {
-    await page.goto(REGISTER_URL);
-
-    await fillRegisterForm(page, {
+    await registerPlayerPage.goto();
+    await registerPlayerPage.fillForm({
       displayName: 'M',
       email: 'no-es-email',
       password: '1234567',
       confirmPassword: '',
     });
-    await submitAndWait(page);
+    await registerPlayerPage.submitAndWait();
 
     await expect(page).toHaveURL(/\/registro-jugador$/);
     await expect(page.getByText(/nombre completo requerido/i)).toBeVisible();
     await expect(page.getByText(/email inv/i)).toBeVisible();
     await expect(page.getByText(/al menos 8 caracteres/i)).toBeVisible();
     await expect(page.getByText(/confirm[aá] tu contrase/i)).toBeVisible();
-    await expect(page.locator('#displayName')).toHaveValue('M');
-    await expect(page.locator('#email')).toHaveValue('no-es-email');
+    await expect(registerPlayerPage.displayName).toHaveValue('M');
+    await expect(registerPlayerPage.email).toHaveValue('no-es-email');
   });
 
-  test('muestra error cuando las contrasenas no coinciden', async ({ page }) => {
-    await page.goto(REGISTER_URL);
-
-    await fillRegisterForm(page, {
-      password: 'Hola12345',
-      confirmPassword: 'Otra12345',
-    });
-    await submitAndWait(page);
+  test('muestra error cuando las contrasenas no coinciden', async ({
+    registerPlayerPage,
+    page,
+  }) => {
+    await registerPlayerPage.goto();
+    await registerPlayerPage.fillForm({ password: 'Hola12345', confirmPassword: 'Otra12345' });
+    await registerPlayerPage.submitAndWait();
 
     await expect(page).toHaveURL(/\/registro-jugador$/);
     await expect(page.getByText(/contras.*no coinciden/i)).toBeVisible();
   });
 
   test('envia el payload correcto y redirige a login cuando el registro es exitoso', async ({
+    registerPlayerPage,
     page,
   }) => {
-    let submitted: RegisterValues | undefined;
-
+    let submitted: PlayerRegisterValues | undefined;
     await mockRegisterPost(page, async (route, formValues) => {
       submitted = formValues;
       await route.fulfill({
@@ -184,16 +153,17 @@ test.describe('Registro de jugador (/registro-jugador)', () => {
       });
     });
 
-    await page.goto(REGISTER_URL);
-    await fillRegisterForm(page);
-    await page.getByRole('button', { name: /crear cuenta/i }).click();
+    await registerPlayerPage.goto();
+    await registerPlayerPage.fillForm();
+    await registerPlayerPage.submitButton.click();
 
     await page.waitForURL('**/login?registered=1');
     await expect(page.getByText(/registro exitoso/i)).toBeVisible();
-    expect(submitted).toEqual(VALID_PLAYER);
+    expect(submitted).toEqual(VALID_PLAYER_REGISTER);
   });
 
   test('muestra error inline para email duplicado y conserva los datos no sensibles', async ({
+    registerPlayerPage,
     page,
   }) => {
     await mockRegisterPost(page, async (route, formValues) => {
@@ -207,18 +177,21 @@ test.describe('Registro de jugador (/registro-jugador)', () => {
       });
     });
 
-    await page.goto(REGISTER_URL);
-    await fillRegisterForm(page);
-    await submitAndWait(page);
+    await registerPlayerPage.goto();
+    await registerPlayerPage.fillForm();
+    await registerPlayerPage.submitAndWait();
 
     await expect(page.getByText(/email ya esta registrado/i)).toBeVisible();
-    await expect(page.locator('#displayName')).toHaveValue(VALID_PLAYER.displayName);
-    await expect(page.locator('#email')).toHaveValue(VALID_PLAYER.email);
-    await expect(page.locator('#password')).toHaveValue('');
-    await expect(page.locator('#confirmPassword')).toHaveValue('');
+    await expect(registerPlayerPage.displayName).toHaveValue(VALID_PLAYER_REGISTER.displayName);
+    await expect(registerPlayerPage.email).toHaveValue(VALID_PLAYER_REGISTER.email);
+    await expect(registerPlayerPage.password).toHaveValue('');
+    await expect(registerPlayerPage.confirmPassword).toHaveValue('');
   });
 
-  test('muestra error inline cuando Supabase rechaza una contrasena debil', async ({ page }) => {
+  test('muestra error inline cuando Supabase rechaza una contrasena debil', async ({
+    registerPlayerPage,
+    page,
+  }) => {
     await mockRegisterPost(page, async (route, formValues) => {
       await route.fulfill({
         status: 200,
@@ -230,17 +203,17 @@ test.describe('Registro de jugador (/registro-jugador)', () => {
       });
     });
 
-    await page.goto(REGISTER_URL);
-    await fillRegisterForm(page, {
-      password: 'password',
-      confirmPassword: 'password',
-    });
-    await submitAndWait(page);
+    await registerPlayerPage.goto();
+    await registerPlayerPage.fillForm({ password: 'password', confirmPassword: 'password' });
+    await registerPlayerPage.submitAndWait();
 
     await expect(page.getByText(/contrasena no cumple/i)).toBeVisible();
   });
 
-  test('muestra error global ante rate limit del proveedor de auth', async ({ page }) => {
+  test('muestra error global ante rate limit del proveedor de auth', async ({
+    registerPlayerPage,
+    page,
+  }) => {
     await mockRegisterPost(page, async (route, formValues) => {
       await route.fulfill({
         status: 200,
@@ -252,10 +225,11 @@ test.describe('Registro de jugador (/registro-jugador)', () => {
       });
     });
 
-    await page.goto(REGISTER_URL);
-    await fillRegisterForm(page);
-    await submitAndWait(page);
+    await registerPlayerPage.goto();
+    await registerPlayerPage.fillForm();
+    await registerPlayerPage.submitAndWait();
 
     await expect(page.getByRole('alert')).toContainText(/demasiados intentos/i);
   });
 });
+

--- a/apps/testing/tests/support/auth.ts
+++ b/apps/testing/tests/support/auth.ts
@@ -1,0 +1,50 @@
+import { expect, type APIRequestContext, type Page } from '@playwright/test';
+import { ACCESS_TOKEN_COOKIE, FRONTEND_URL } from './constants';
+import { TEST_USERS, type TestUser, type TestUserKey } from './users';
+
+/**
+ * Auth helpers used both by `auth.setup.ts` (storage-state warm-up) and by
+ * specs that need a logged-in user but exercise the login flow itself.
+ *
+ * Decision Context:
+ * - `loginViaForm` is the canonical UI login. It's used by auth.setup.ts to
+ *   produce per-user storage-state files, and by login.spec.ts which validates
+ *   the form behaviour directly. Specs that just need a logged-in browser do
+ *   NOT call this — they declare `test.use({ storageState: ... })` at the top
+ *   of the file and skip the login round-trip entirely.
+ * - `readAccessToken` extracts the HttpOnly cookie set by the SSR login. Tests
+ *   that hit the backend GraphQL directly (matchSnapshot, ensureJoinedMatch,
+ *   myProfile) need this token because the backend doesn't read browser
+ *   cookies — it only honors `Authorization: Bearer ...`.
+ * - Previously fixed bugs: none relevant.
+ */
+
+export async function loginViaForm(page: Page, user: TestUser): Promise<void> {
+  await page.goto(`${FRONTEND_URL}/login`);
+  await page.getByRole('textbox', { name: 'Email' }).fill(user.email);
+  await page.getByRole('textbox', { name: /contrase/i }).fill(user.password);
+  await page.getByRole('button', { name: /ingresar/i }).click();
+  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
+}
+
+export async function readAccessToken(page: Page): Promise<string> {
+  const cookies = await page.context().cookies(FRONTEND_URL);
+  const token = cookies.find((c) => c.name === ACCESS_TOKEN_COOKIE)?.value;
+  expect(token, 'login should have left an access-token cookie').toBeTruthy();
+  return token as string;
+}
+
+/**
+ * Performs a real UI login via APIRequestContext (no browser) so we can grab
+ * an access token without running tests through a full page navigation. Used
+ * for tests that prepare backend state via direct GraphQL calls.
+ */
+export async function loginAndReadToken(page: Page, userKey: TestUserKey): Promise<string> {
+  await loginViaForm(page, TEST_USERS[userKey]);
+  return readAccessToken(page);
+}
+
+export type AuthenticatedRequestOptions = {
+  request: APIRequestContext;
+  accessToken: string;
+};

--- a/apps/testing/tests/support/builders.ts
+++ b/apps/testing/tests/support/builders.ts
@@ -1,0 +1,100 @@
+/**
+ * Mock data builders for GraphQL responses.
+ *
+ * Decision Context:
+ * - Three different specs (matches-list, match-filters, matches-map) each had
+ *   their own `MockMatch` type and `buildMatch()` factory with slightly drifted
+ *   field shapes. Centralizing keeps the mock contract aligned with the real
+ *   GraphQL schema and prevents one spec from masking a regression that would
+ *   surface in another.
+ * - `buildMatch` returns a sensible OPEN match in Centro by default; tests
+ *   spread overrides for the fields that matter to them. We intentionally use
+ *   a future date so date-range filter tests aren't affected by `Date.now()`.
+ * - `buildMockSlot` mirrors clubSlots() responses for the create-match wizard.
+ * - Previously fixed bugs: none relevant.
+ */
+
+export type MatchFormat = 'FIVE_VS_FIVE' | 'SEVEN_VS_SEVEN' | 'TEN_VS_TEN' | 'ELEVEN_VS_ELEVEN';
+export type MatchStatus = 'OPEN' | 'FULL' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+export type MatchTeam = 'A' | 'B';
+
+export type MockClub = {
+  __typename?: 'Club';
+  name: string;
+  zone: string | null;
+  address?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+};
+
+export type MockMatch = {
+  __typename?: 'Match';
+  id: string;
+  title: string;
+  startTime: string;
+  format: MatchFormat;
+  totalSlots: number;
+  availableSlots: number;
+  status: MatchStatus;
+  club: MockClub | null;
+};
+
+export function buildMatch(overrides: Partial<MockMatch> = {}): MockMatch {
+  return {
+    __typename: 'Match',
+    id: 'match-default',
+    title: 'Partido de prueba',
+    startTime: '2026-05-01T20:00:00Z',
+    format: 'FIVE_VS_FIVE',
+    totalSlots: 10,
+    availableSlots: 5,
+    status: 'OPEN',
+    club: { __typename: 'Club', name: 'Club Test', zone: 'Centro', address: 'Test 123' },
+    ...overrides,
+  };
+}
+
+export type CourtSurface = 'GRASS' | 'SYNTHETIC' | 'CONCRETE' | 'INDOOR';
+
+export type MockSlot = {
+  id: string;
+  clubId: string;
+  dayOfWeek: string;
+  startTime: string;
+  endTime: string;
+  priceArs: number | null;
+  court: {
+    id: string;
+    name: string;
+    maxFormat: MatchFormat;
+    surface: CourtSurface;
+    isIndoor: boolean;
+  };
+};
+
+export const DEFAULT_MOCK_SLOT: MockSlot = {
+  id: 'slot-e2e-1900',
+  clubId: 'club-from-ui',
+  dayOfWeek: 'monday',
+  startTime: '19:00:00',
+  endTime: '20:00:00',
+  priceArs: 4200,
+  court: {
+    id: 'court-e2e-1',
+    name: 'Cancha E2E',
+    maxFormat: 'SEVEN_VS_SEVEN',
+    surface: 'SYNTHETIC',
+    isIndoor: false,
+  },
+};
+
+type MockSlotOverrides = Partial<Omit<MockSlot, 'court'>> & { court?: Partial<MockSlot['court']> };
+
+export function buildMockSlot(overrides: MockSlotOverrides = {}): MockSlot {
+  const { court, ...rest } = overrides;
+  return {
+    ...DEFAULT_MOCK_SLOT,
+    ...rest,
+    court: { ...DEFAULT_MOCK_SLOT.court, ...(court ?? {}) },
+  };
+}

--- a/apps/testing/tests/support/constants.ts
+++ b/apps/testing/tests/support/constants.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared constants for the e2e suite.
+ *
+ * Decision Context:
+ * - Centralizing URLs/cookies/route patterns avoids drift between specs (e.g.
+ *   `**\/graphql` vs `**\/api/graphql**` vs the regex variant). Each spec used
+ *   to declare these inline and small differences caused mocks to silently miss
+ *   requests.
+ * - GRAPHQL_PROXY_ROUTE: glob path-only — catches the frontend Astro proxy at
+ *   /api/graphql with or without urql querystring params.
+ * - BACKEND_GRAPHQL_ROUTE: glob — catches the backend GraphQL endpoint when the
+ *   browser island talks directly to :4000 (joinMatch, leaveMatch, myMatches).
+ * - GRAPHQL_ANY_ROUTE: regex — covers BOTH proxy and backend forms; use when a
+ *   spec doesn't care which pathway the client takes (matches-map / filters).
+ * - Previously fixed bugs: see matches-list.spec.ts comment about
+ *   host/port-literal URLs being fragile (now obsolete because everyone uses
+ *   these constants).
+ */
+
+export const FRONTEND_URL = 'http://localhost:4321';
+export const BACKEND_GRAPHQL_URL = 'http://localhost:4000/graphql';
+
+export const GRAPHQL_PROXY_ROUTE = '**/api/graphql**';
+export const BACKEND_GRAPHQL_ROUTE = '**/graphql';
+export const GRAPHQL_ANY_ROUTE = /https?:\/\/[^/]+\/(?:api\/)?graphql(?:\?.*)?$/;
+
+export const ACCESS_TOKEN_COOKIE = 'sumateya-access-token';
+export const REFRESH_TOKEN_COOKIE = 'sumateya-refresh-token';
+
+/**
+ * Match IDs guaranteed by `apps/testing/scripts/seed.ts` (Playwright globalSetup).
+ * Importing these from a single place keeps tests in sync if the seed evolves.
+ */
+export const SEED_MATCHES = {
+  /** FULL match — test player Mateo is already inscripto in team B. */
+  full: 'e1000000-0000-0000-0000-000000000001',
+  /** OPEN match with 0 participants. */
+  open: 'e1000000-0000-0000-0000-000000000002',
+} as const;

--- a/apps/testing/tests/support/fixtures.ts
+++ b/apps/testing/tests/support/fixtures.ts
@@ -1,0 +1,73 @@
+import { test as base } from '@playwright/test';
+import { CreateMatchPage } from './page-objects/CreateMatchPage';
+import { HomePage } from './page-objects/HomePage';
+import { LoginPage } from './page-objects/LoginPage';
+import { MatchDetailPage } from './page-objects/MatchDetailPage';
+import { MatchesListPage } from './page-objects/MatchesListPage';
+import { MatchesMapPage } from './page-objects/MatchesMapPage';
+import { ProfilePage } from './page-objects/ProfilePage';
+import { RegisterClubPage } from './page-objects/RegisterClubPage';
+import { RegisterPlayerPage } from './page-objects/RegisterPlayerPage';
+
+/**
+ * Custom Playwright test fixture.
+ *
+ * Decision Context:
+ * - We attach every Page Object as an auto-injected fixture so tests can
+ *   destructure exactly the surfaces they need (`{ matchesPage }`,
+ *   `{ profilePage }`). Each PO is constructed once per test against the
+ *   shared `page`, so they don't add overhead.
+ * - Authentication is NOT a fixture: storage state is provisioned by
+ *   `auth.setup.ts` (Playwright setup project) and consumed by specs via
+ *   `test.use({ storageState: TEST_USERS.<role>.storageStatePath })`. That
+ *   keeps the auth lifecycle visible at the top of each spec instead of
+ *   hidden in a fixture, and it lets unauthenticated specs (login,
+ *   registration, anonymous-visitor cases) opt out trivially.
+ * - All specs should import `test` and `expect` from this module rather than
+ *   from `@playwright/test`. The lint rule in `.claude/rules/e2e-testing.md`
+ *   makes that explicit.
+ */
+
+type Fixtures = {
+  loginPage: LoginPage;
+  registerPlayerPage: RegisterPlayerPage;
+  registerClubPage: RegisterClubPage;
+  homePage: HomePage;
+  matchesPage: MatchesListPage;
+  matchesMapPage: MatchesMapPage;
+  matchDetailPage: MatchDetailPage;
+  createMatchPage: CreateMatchPage;
+  profilePage: ProfilePage;
+};
+
+export const test = base.extend<Fixtures>({
+  loginPage: async ({ page }, use) => {
+    await use(new LoginPage(page));
+  },
+  registerPlayerPage: async ({ page }, use) => {
+    await use(new RegisterPlayerPage(page));
+  },
+  registerClubPage: async ({ page }, use) => {
+    await use(new RegisterClubPage(page));
+  },
+  homePage: async ({ page }, use) => {
+    await use(new HomePage(page));
+  },
+  matchesPage: async ({ page }, use) => {
+    await use(new MatchesListPage(page));
+  },
+  matchesMapPage: async ({ page }, use) => {
+    await use(new MatchesMapPage(page));
+  },
+  matchDetailPage: async ({ page }, use) => {
+    await use(new MatchDetailPage(page));
+  },
+  createMatchPage: async ({ page }, use) => {
+    await use(new CreateMatchPage(page));
+  },
+  profilePage: async ({ page }, use) => {
+    await use(new ProfilePage(page));
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/apps/testing/tests/support/graphql.ts
+++ b/apps/testing/tests/support/graphql.ts
@@ -1,0 +1,151 @@
+import { expect, type APIRequestContext, type Page, type Route } from '@playwright/test';
+import { BACKEND_GRAPHQL_URL } from './constants';
+
+/**
+ * GraphQL helpers shared by every spec.
+ *
+ * Decision Context:
+ * - `gqlPost` centralizes the backend GraphQL call. Each spec used to roll its
+ *   own with subtly different error handling — some asserted ok(), some didn't,
+ *   some checked `errors`, some swallowed them. One helper avoids the drift.
+ * - `mockGraphQLOperation` lets a spec mock ONLY one operation (matched by a
+ *   substring in `query`) and let everything else go through. This is the
+ *   pattern used for joinMatch / leaveMatch / myMatches / createMatch — most
+ *   pages issue several GraphQL calls and overriding all of them masks bugs.
+ * - `mockGraphQLAll` overrides every request hitting the matched route. Use
+ *   for pages that issue a single matches() query (matches-list, match-filters,
+ *   matches-map, menu-overview).
+ * - `mockGraphQLError` is a thin wrapper for the common `{ errors: [...] }`
+ *   shape, kept as a method to make spec intent obvious at the call site.
+ * - The mocks return a `payloads` array (live-updated via push) so the test
+ *   can `expect.poll(() => payloads.length).toBe(1)` to verify the mutation
+ *   actually fired. We also expose `requests` for the all-traffic mocks so
+ *   tests can introspect things like `variables.filters.status`.
+ * - `NETWORK_ERROR` sentinel: pass instead of a body to abort the request
+ *   (matches join-match.spec.ts behavior: simulates dropped connection so the
+ *   client-side catch block runs).
+ * - Previously fixed bugs: none relevant.
+ */
+
+type GraphQLRequest = { query?: string; variables?: unknown; operationName?: string | null };
+type MockBody = Record<string, unknown> | 'NETWORK_ERROR';
+type MockOptions = { delayMs?: number };
+
+export const NETWORK_ERROR = 'NETWORK_ERROR' as const;
+
+export async function gqlPost<T>(
+  request: APIRequestContext,
+  query: string,
+  variables: Record<string, unknown> | undefined,
+  accessToken?: string,
+): Promise<{ data?: T; errors?: Array<{ message: string }> }> {
+  const response = await request.post(BACKEND_GRAPHQL_URL, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    },
+    data: { query, variables },
+  });
+  return (await response.json()) as { data?: T; errors?: Array<{ message: string }> };
+}
+
+/** Variant that asserts the response is healthy and returns `data`. */
+export async function gqlPostOrThrow<T>(
+  request: APIRequestContext,
+  query: string,
+  variables?: Record<string, unknown>,
+  accessToken?: string,
+): Promise<T> {
+  const payload = await gqlPost<T>(request, query, variables, accessToken);
+  expect(payload.errors ?? [], 'GraphQL response should have no errors').toHaveLength(0);
+  expect(payload.data, 'GraphQL response should have data').toBeTruthy();
+  return payload.data as T;
+}
+
+function readGraphQLRequest(route: Route): GraphQLRequest {
+  const request = route.request();
+  const postData = request.postData();
+
+  if (postData) {
+    try {
+      return JSON.parse(postData) as GraphQLRequest;
+    } catch {
+      return { query: postData };
+    }
+  }
+
+  const url = new URL(request.url());
+  const variablesParam = url.searchParams.get('variables');
+
+  return {
+    operationName: url.searchParams.get('operationName'),
+    query: url.searchParams.get('query') ?? undefined,
+    variables: variablesParam ? (JSON.parse(variablesParam) as Record<string, unknown>) : undefined,
+  };
+}
+
+async function fulfillBody(route: Route, body: MockBody, options: MockOptions): Promise<void> {
+  if (options.delayMs) {
+    await new Promise((resolve) => setTimeout(resolve, options.delayMs));
+  }
+  if (body === NETWORK_ERROR) {
+    await route.abort('failed');
+    return;
+  }
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Mock ALL traffic hitting `route`. Captures every request body so tests can
+ * inspect `variables.filters` / etc.
+ */
+export async function mockGraphQLAll(
+  page: Page,
+  route: string | RegExp,
+  body: MockBody,
+  options: MockOptions = {},
+): Promise<{ requests: GraphQLRequest[] }> {
+  const requests: GraphQLRequest[] = [];
+
+  await page.unroute(route).catch(() => undefined);
+  await page.route(route, async (incoming: Route) => {
+    requests.push(readGraphQLRequest(incoming));
+    await fulfillBody(incoming, body, options);
+  });
+
+  return { requests };
+}
+
+/**
+ * Mock ONLY the GraphQL operation whose query body contains `operationMarker`.
+ * Other GraphQL traffic is allowed through to the real backend. Returns the
+ * captured request payloads for assertion.
+ */
+export async function mockGraphQLOperation(
+  page: Page,
+  route: string | RegExp,
+  operationMarker: string,
+  body: MockBody,
+  options: MockOptions = {},
+): Promise<{ payloads: GraphQLRequest[] }> {
+  const payloads: GraphQLRequest[] = [];
+
+  await page.route(route, async (incoming: Route) => {
+    const parsed = readGraphQLRequest(incoming);
+    if (!parsed.query?.includes(operationMarker)) {
+      await incoming.continue();
+      return;
+    }
+
+    payloads.push(parsed);
+    await fulfillBody(incoming, body, options);
+  });
+
+  return { payloads };
+}
+
+export type { GraphQLRequest, MockBody, MockOptions };

--- a/apps/testing/tests/support/index.ts
+++ b/apps/testing/tests/support/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Public surface of the e2e support package. Specs should import from
+ * `./support` (relative to tests/) instead of reaching into individual files.
+ *
+ * Decision Context:
+ * - One barrel keeps the spec import block short ("import { test, expect,
+ *   TEST_USERS, mockGraphQLAll } from './support'") and lets us refactor the
+ *   internal layout without touching every spec.
+ */
+
+export { test, expect } from './fixtures';
+export * from './constants';
+export * from './users';
+export * from './auth';
+export * from './graphql';
+export * from './network';
+export * from './builders';
+export { CreateMatchPage } from './page-objects/CreateMatchPage';
+export { HomePage } from './page-objects/HomePage';
+export { LoginPage } from './page-objects/LoginPage';
+export { MatchDetailPage } from './page-objects/MatchDetailPage';
+export { MatchesListPage } from './page-objects/MatchesListPage';
+export { MatchesMapPage } from './page-objects/MatchesMapPage';
+export { ProfilePage, ONE_PIXEL_PNG } from './page-objects/ProfilePage';
+export {
+  RegisterPlayerPage,
+  VALID_PLAYER_REGISTER,
+  type PlayerRegisterValues,
+} from './page-objects/RegisterPlayerPage';
+export { RegisterClubPage } from './page-objects/RegisterClubPage';

--- a/apps/testing/tests/support/network.ts
+++ b/apps/testing/tests/support/network.ts
@@ -1,0 +1,71 @@
+import type { Page, Route } from '@playwright/test';
+
+/**
+ * Browser-side network helpers (non-GraphQL).
+ *
+ * Decision Context:
+ * - `mockLeafletAssets` short-circuits OpenStreetMap tile + Leaflet icon CDN
+ *   requests with a 1x1 PNG. We don't validate map tiles; we validate that the
+ *   UI mounts Leaflet, creates markers, and renders popups with our contract.
+ *   Letting the real CDN respond made the matches-map suite flaky and slow.
+ * - `mockJsonRoute` is a small wrapper for endpoints that return JSON (e.g.
+ *   /api/profile/avatar, /api/matches/create). Captures payloads.
+ * - Previously fixed bugs: none relevant.
+ */
+
+export const TRANSPARENT_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+  'base64',
+);
+
+export async function mockLeafletAssets(page: Page): Promise<void> {
+  const fulfillImage = async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: TRANSPARENT_PNG,
+    });
+  };
+
+  await page.route(/https:\/\/[abc]\.tile\.openstreetmap\.org\/.*/, fulfillImage);
+  await page.route(
+    /https:\/\/cdnjs\.cloudflare\.com\/ajax\/libs\/leaflet\/1\.9\.4\/images\/.*/,
+    fulfillImage,
+  );
+}
+
+type JsonRouteOptions = {
+  status?: number;
+  body?: unknown;
+  delayMs?: number;
+};
+
+export async function mockJsonRoute(
+  page: Page,
+  route: string | RegExp,
+  options: JsonRouteOptions = {},
+): Promise<{ getPayloads: () => unknown[] }> {
+  const payloads: unknown[] = [];
+
+  await page.unroute(route).catch(() => undefined);
+  await page.route(route, async (incoming: Route) => {
+    const raw = incoming.request().postData() ?? 'null';
+    try {
+      payloads.push(JSON.parse(raw) as unknown);
+    } catch {
+      payloads.push(raw);
+    }
+
+    if (options.delayMs) {
+      await new Promise((resolve) => setTimeout(resolve, options.delayMs));
+    }
+
+    await incoming.fulfill({
+      status: options.status ?? 200,
+      contentType: 'application/json',
+      body: JSON.stringify(options.body ?? {}),
+    });
+  });
+
+  return { getPayloads: () => payloads };
+}

--- a/apps/testing/tests/support/page-objects/CreateMatchPage.ts
+++ b/apps/testing/tests/support/page-objects/CreateMatchPage.ts
@@ -1,0 +1,81 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { FRONTEND_URL } from '../constants';
+
+/**
+ * Page Object for /partidos/crear (the create-match wizard).
+ *
+ * Decision Context:
+ * - The wizard has 4 logical steps: club → slot → format → summary. Each
+ *   `goToX()` method advances the wizard and asserts the next-step element is
+ *   visible — that's our hydration/transition checkpoint.
+ * - The first wizard step waits for `aria-pressed=true` on the selected card
+ *   instead of just `click()`, because the React island hydrates after the
+ *   initial Astro paint and an early click is silently no-op'd. Don't remove
+ *   that wait.
+ * - Previously fixed bugs: clicks on `.club-card` before hydration were
+ *   no-ops; polling `aria-pressed` makes the test wait until React owns the
+ *   element.
+ */
+export class CreateMatchPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly wizard: Locator;
+  readonly continueButton: Locator;
+  readonly dateInput: Locator;
+  readonly capacityInput: Locator;
+  readonly descriptionInput: Locator;
+  readonly summaryHeading: Locator;
+  readonly viewSummaryButton: Locator;
+  readonly createButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole('heading', { name: /crear partido/i });
+    this.wizard = page.locator('.wizard');
+    this.continueButton = page.getByRole('button', { name: /continuar/i });
+    this.dateInput = page.getByLabel(/fecha del partido/i);
+    this.capacityInput = page.getByRole('spinbutton', { name: /cantidad de jugadores/i });
+    this.descriptionInput = page.getByLabel(/descripci/i);
+    this.summaryHeading = page.getByRole('heading', { name: /resumen del partido/i });
+    this.viewSummaryButton = page.getByRole('button', { name: /ver resumen/i });
+    this.createButton = page.getByRole('button', { name: /^crear partido$/i });
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto(`${FRONTEND_URL}/partidos/crear`);
+    await expect(this.heading).toBeVisible();
+    await expect(this.wizard).toBeVisible();
+  }
+
+  async selectFirstClubAndContinue(): Promise<void> {
+    const firstClub = this.page.locator('.club-card').first();
+    await expect(firstClub).toBeVisible();
+    await firstClub.click();
+    // Wait until React owns the click — see decision context above.
+    await expect(firstClub).toHaveAttribute('aria-pressed', 'true');
+    await expect(this.continueButton).toBeEnabled();
+    await this.continueButton.click();
+    await expect(this.dateInput).toBeVisible();
+  }
+
+  async selectSlotAndContinue(time = '19:00'): Promise<void> {
+    await expect(this.page.getByText(time)).toBeVisible();
+    await this.page.locator('.slot-card').filter({ hasText: time }).click();
+    await this.continueButton.click();
+    await expect(this.formatButton('5v5')).toBeVisible();
+  }
+
+  formatButton(label: '5v5' | '7v7' | '10v10' | '11v11'): Locator {
+    return this.page.getByRole('button', { name: new RegExp(`^${label}`, 'i') });
+  }
+
+  async selectFormatAndOpenSummary(label: '5v5' | '7v7' | '10v10' | '11v11' = '7v7'): Promise<void> {
+    await this.formatButton(label).click();
+    await this.viewSummaryButton.click();
+    await expect(this.summaryHeading).toBeVisible();
+  }
+
+  async readDate(): Promise<string> {
+    return this.dateInput.inputValue();
+  }
+}

--- a/apps/testing/tests/support/page-objects/HomePage.ts
+++ b/apps/testing/tests/support/page-objects/HomePage.ts
@@ -1,0 +1,42 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { FRONTEND_URL } from '../constants';
+
+/**
+ * Page Object for the marketing home (/).
+ *
+ * Decision Context:
+ * - Used by `menu-overview.spec.ts` and any flow that lands on `/`. The home
+ *   issues a `matches` GraphQL query on hydration; specs that don't care about
+ *   real data should mock that endpoint with `mockGraphQLAll`.
+ * - Stat cards have ambiguous text matches (e.g. `500+` also appears in the
+ *   hero ticker). Use `metricCard()` to scope by label.
+ */
+export class HomePage {
+  readonly page: Page;
+  readonly hero: Locator;
+  readonly loginLink: Locator;
+  readonly registerLink: Locator;
+  readonly viewAllMatchesLink: Locator;
+  readonly searchInput: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.hero = page.getByRole('heading', { name: /sumate\s+al juego/i });
+    this.loginLink = page.getByRole('link', { name: /iniciar sesi/i }).first();
+    this.registerLink = page.getByRole('link', { name: /registrarse/i }).first();
+    this.viewAllMatchesLink = page.getByRole('link', { name: /ver todos/i });
+    this.searchInput = page.getByPlaceholder(/buscar partido o club/i);
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto(FRONTEND_URL);
+    await expect(this.hero).toBeVisible();
+  }
+
+  metricCard(label: string, value: string): Locator {
+    return this.page
+      .locator('div', { has: this.page.getByText(label, { exact: true }) })
+      .filter({ hasText: value })
+      .first();
+  }
+}

--- a/apps/testing/tests/support/page-objects/LoginPage.ts
+++ b/apps/testing/tests/support/page-objects/LoginPage.ts
@@ -1,0 +1,56 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { FRONTEND_URL } from '../constants';
+import { type TestUser } from '../users';
+
+/**
+ * Page Object for /login.
+ *
+ * Decision Context:
+ * - Used both by login.spec.ts (which exercises the form behavior directly)
+ *   and by `auth.setup.ts` (which warms up storage-state). Specs that just
+ *   need a logged-in browser context should declare
+ *   `test.use({ storageState: TEST_USERS.<role>.storageStatePath })` instead
+ *   of calling `loginAs` — re-doing UI logins is the slowest way to get auth.
+ * - Locators are defined once as fields so test bodies stay declarative.
+ * - Previously fixed bugs: none relevant.
+ */
+export class LoginPage {
+  readonly page: Page;
+  readonly form: Locator;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly submitButton: Locator;
+  readonly registeredBanner: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.form = page.locator('form.login-form');
+    this.emailInput = page.getByLabel('Email');
+    this.passwordInput = page.getByLabel('Contraseña');
+    this.submitButton = page.getByRole('button', { name: /ingresar/i });
+    this.registeredBanner = page.getByText(/Registro exitoso\. Ya podés iniciar sesión/i);
+  }
+
+  async goto(query?: string): Promise<void> {
+    const url = query ? `${FRONTEND_URL}/login?${query}` : `${FRONTEND_URL}/login`;
+    await this.page.goto(url);
+    await expect(this.form).toBeVisible();
+  }
+
+  async fillCredentials(email: string, password: string): Promise<void> {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+  }
+
+  async submit(): Promise<void> {
+    await this.submitButton.click();
+  }
+
+  /** Full UI login. Waits for the SSR redirect to leave /login. */
+  async loginAs(user: Pick<TestUser, 'email' | 'password'>): Promise<void> {
+    await this.goto();
+    await this.fillCredentials(user.email, user.password);
+    await this.submit();
+    await this.page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
+  }
+}

--- a/apps/testing/tests/support/page-objects/MatchDetailPage.ts
+++ b/apps/testing/tests/support/page-objects/MatchDetailPage.ts
@@ -1,0 +1,69 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { FRONTEND_URL } from '../constants';
+
+/**
+ * Page Object for /partidos/[id].
+ *
+ * Decision Context:
+ * - The detail is SSR; the join/leave React islands use `client:load`. If a
+ *   click fires before hydration the onClick handler isn't attached and the
+ *   mutation never goes out. `waitForIslandsHydrated` polls Astro 6's
+ *   `client-render-time` attribute on every `astro-island[client="load"]` —
+ *   that attribute is set when React finishes mounting.
+ * - Why filter by `client="load"` (not all islands): islands with
+ *   `client:visible` (e.g. MatchResultsSection at the bottom) never hydrate
+ *   without scrolling; waiting for them would timeout.
+ * - Previously fixed bugs:
+ *   1. Join-team tests failing with `expected 1, received 0` because the click
+ *      ran before hydration.
+ *   2. Helper timing out at 10s after MatchResultsSection was added — fixed by
+ *      filtering on `client="load"` only.
+ */
+export class MatchDetailPage {
+  readonly page: Page;
+  readonly root: Locator;
+  readonly joinTeamA: Locator;
+  readonly joinTeamB: Locator;
+  readonly leaveButton: Locator;
+  readonly confirmDialog: Locator;
+  readonly confirmLeaveButton: Locator;
+  readonly cancelLeaveButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.root = page.locator('.match-detail');
+    this.joinTeamA = page.getByRole('button', { name: /sumarme al equipo a/i });
+    this.joinTeamB = page.getByRole('button', { name: /sumarme al equipo b/i });
+    this.leaveButton = page.getByRole('button', { name: /salirme del partido/i });
+    this.confirmDialog = page.getByRole('dialog');
+    this.confirmLeaveButton = page.getByRole('button', { name: /sí, salirme/i });
+    this.cancelLeaveButton = page.getByRole('button', { name: /cancelar/i });
+  }
+
+  async goto(matchId: string): Promise<void> {
+    await this.page.goto(`${FRONTEND_URL}/partidos/${matchId}`);
+    await expect(this.root).toBeVisible();
+    await this.waitForIslandsHydrated();
+  }
+
+  /** Astro 6 stamps `client-render-time` on each island after hydration. */
+  async waitForIslandsHydrated(): Promise<void> {
+    await this.page.waitForFunction(
+      () => {
+        const islands = Array.from(document.querySelectorAll('astro-island[client="load"]'));
+        if (islands.length === 0) return true;
+        return islands.every((island) => island.hasAttribute('client-render-time'));
+      },
+      { timeout: 10_000 },
+    );
+  }
+
+  joinButton(team: 'A' | 'B'): Locator {
+    return team === 'A' ? this.joinTeamA : this.joinTeamB;
+  }
+
+  async openLeaveDialog(): Promise<void> {
+    await this.leaveButton.click();
+    await expect(this.confirmDialog).toBeVisible();
+  }
+}

--- a/apps/testing/tests/support/page-objects/MatchesListPage.ts
+++ b/apps/testing/tests/support/page-objects/MatchesListPage.ts
@@ -1,0 +1,84 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { FRONTEND_URL } from '../constants';
+
+/**
+ * Page Object for the matches list view (/partidos).
+ *
+ * Decision Context:
+ * - The page is statically rendered; the React island (`MatchesView`) hydrates
+ *   client-side and queries via urql. Specs typically wait for the empty-state
+ *   text or a known card title before interacting with filters — that's our
+ *   proxy for "hydration finished and handlers are attached". Calling
+ *   `expectListSettled(page, knownTitle)` documents that wait at the call site.
+ * - Locators scoped to `main` keep the Astro dev-toolbar's injected `<select>`
+ *   from contaminating filter counts. Don't drop that scope.
+ * - Previously fixed bugs:
+ *   1. `page.locator('select')` counted 4 because of the dev-toolbar; scoped
+ *      to `main select` to fix.
+ *   2. Strict-mode violation between the `Ver detalle` button and a card with
+ *      aria-label `Ver detalle del partido ...`; using `name: 'Ver detalle',
+ *      exact: true` (not regex) makes the matcher unambiguous.
+ */
+export class MatchesListPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly searchInput: Locator;
+  readonly formatSelect: Locator;
+  readonly zoneSelect: Locator;
+  readonly scheduleSelect: Locator;
+  readonly dateFromInput: Locator;
+  readonly dateToInput: Locator;
+  readonly clearButton: Locator;
+  readonly emptyState: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole('heading', { name: /Partidos Disponibles/i });
+    this.searchInput = page.getByPlaceholder(/Buscar partido o club/i);
+    this.formatSelect = page.getByLabel('Formato');
+    this.zoneSelect = page.getByLabel('Zona');
+    this.scheduleSelect = page.getByLabel('Horario');
+    this.dateFromInput = page.getByLabel(/fecha desde/i);
+    this.dateToInput = page.getByLabel(/fecha hasta/i);
+    this.clearButton = page.getByRole('button', { name: /limpiar/i });
+    this.emptyState = page.getByText('No hay partidos disponibles');
+  }
+
+  async goto(path = '/partidos'): Promise<void> {
+    await this.page.goto(`${FRONTEND_URL}${path}`);
+    await this.page.locator('.matches-section').scrollIntoViewIfNeeded();
+  }
+
+  /**
+   * Wait until the list has either rendered the empty state or the given known
+   * title — guarantees the React island has hydrated and onChange handlers are
+   * attached before the test interacts with filters.
+   */
+  async expectListSettled(knownTitleOrEmpty?: string): Promise<void> {
+    if (knownTitleOrEmpty) {
+      await expect(this.page.getByText(knownTitleOrEmpty)).toBeVisible();
+      return;
+    }
+    await expect(this.emptyState).toBeVisible();
+  }
+
+  /** Open a card by its visible title. */
+  card(title: string): Locator {
+    return this.page.getByText(title);
+  }
+
+  /** Disabled-or-enabled state of the always-rendered Limpiar button. */
+  async expectClearState(state: 'enabled' | 'disabled'): Promise<void> {
+    await expect(this.clearButton).toBeVisible();
+    if (state === 'enabled') {
+      await expect(this.clearButton).toBeEnabled();
+    } else {
+      await expect(this.clearButton).toBeDisabled();
+    }
+  }
+
+  /** The detail CTA used for FULL matches. Exact match avoids the aria-label collision. */
+  detailButton(): Locator {
+    return this.page.getByRole('button', { name: 'Ver detalle', exact: true });
+  }
+}

--- a/apps/testing/tests/support/page-objects/MatchesMapPage.ts
+++ b/apps/testing/tests/support/page-objects/MatchesMapPage.ts
@@ -1,0 +1,57 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { FRONTEND_URL } from '../constants';
+
+/**
+ * Page Object for the matches map view (/partidos with the Mapa toggle).
+ *
+ * Decision Context:
+ * - The map is lazy: `GetMatchesWithCoords` fires only after the Mapa toggle
+ *   is clicked. We assert that lazy boundary in tests by checking the request
+ *   tracker on the GraphQL mock.
+ * - `name: 'Mapa', exact: true` (not regex) avoids strict-mode collisions with
+ *   match cards whose aria-label includes the word "mapa". Same trick used for
+ *   `Lista`.
+ * - Previously fixed bugs: switchToMap() failed strict-mode when the listing
+ *   contained a card with the word "mapa" in its title.
+ */
+export class MatchesMapPage {
+  readonly page: Page;
+  readonly listToggle: Locator;
+  readonly mapToggle: Locator;
+  readonly mapContainer: Locator;
+  readonly markers: Locator;
+  readonly popup: Locator;
+  readonly emptyMessage: Locator;
+  readonly searchInput: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.listToggle = page.getByRole('button', { name: 'Lista', exact: true });
+    this.mapToggle = page.getByRole('button', { name: 'Mapa', exact: true });
+    this.mapContainer = page.locator('.leaflet-container');
+    this.markers = page.locator('.leaflet-marker-icon');
+    this.popup = page.locator('.leaflet-popup');
+    this.emptyMessage = page.locator('.match-map-empty-msg');
+    this.searchInput = page.getByPlaceholder(/buscar partido o club/i);
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto(`${FRONTEND_URL}/partidos`);
+    await this.page.locator('.matches-section').scrollIntoViewIfNeeded();
+    await expect(this.listToggle).toBeVisible();
+  }
+
+  async waitForListHydration(): Promise<void> {
+    await expect
+      .poll(async () => {
+        const text = await this.page.locator('main').innerText();
+        return /No hay partidos disponibles|Error|jugadores/i.test(text);
+      })
+      .toBe(true);
+  }
+
+  async switchToMap(): Promise<void> {
+    await this.mapToggle.click();
+    await expect(this.mapToggle).toHaveAttribute('aria-pressed', 'true');
+  }
+}

--- a/apps/testing/tests/support/page-objects/ProfilePage.ts
+++ b/apps/testing/tests/support/page-objects/ProfilePage.ts
@@ -1,0 +1,76 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { FRONTEND_URL } from '../constants';
+
+/**
+ * Page Object for /perfil — both the profile card and the avatar-upload modal.
+ *
+ * Decision Context:
+ * - Splitting the profile card and the avatar modal into separate POs would
+ *   duplicate the page navigation; instead, this single PO exposes both
+ *   surfaces. Tests that only need the modal call `openAvatarModal()` and
+ *   ignore the rest.
+ * - The avatar modal opens via a hover-revealed icon button. We hover the
+ *   wrapper before clicking, otherwise the button is invisible to Playwright.
+ * - The 1×1 PNG below is the canonical valid image for upload tests — keeping
+ *   it on the PO avoids spec-level magic strings.
+ * - Previously fixed bugs: none relevant.
+ */
+
+export const ONE_PIXEL_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+  'base64',
+);
+
+export class ProfilePage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly card: Locator;
+  readonly historySection: Locator;
+  readonly avatarModal: Locator;
+  readonly fileInput: Locator;
+  readonly submitAvatarButton: Locator;
+  readonly closeAvatarButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole('heading', { name: /mi perfil/i });
+    this.card = page.locator('.profile-card');
+    this.historySection = page.locator('.history-section');
+    this.avatarModal = page.locator('#avatar-upload-modal');
+    this.fileInput = page.locator('input[type="file"]');
+    this.submitAvatarButton = page.getByRole('button', { name: /subir foto/i });
+    this.closeAvatarButton = page.locator('#close-modal-btn');
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto(`${FRONTEND_URL}/perfil`);
+    await expect(this.heading).toBeVisible();
+    await expect(this.card).toBeVisible();
+  }
+
+  async openAvatarModal(): Promise<void> {
+    await this.page.locator('.profile-card-wrapper').hover();
+    await this.page.getByTitle(/cambiar foto de perfil/i).click();
+    await expect(this.page.getByRole('dialog')).toBeVisible();
+    await expect(
+      this.page.getByRole('heading', { name: /actualizar foto de perfil/i }),
+    ).toBeVisible();
+  }
+
+  async chooseFile(file: { name: string; mimeType: string; buffer: Buffer }): Promise<void> {
+    await this.fileInput.setInputFiles(file);
+  }
+
+  async chooseValidPng(): Promise<void> {
+    await this.chooseFile({ name: 'avatar.png', mimeType: 'image/png', buffer: ONE_PIXEL_PNG });
+  }
+
+  /** Lookup helper for the stat cells (Partidos / Victorias / Efectividad). */
+  statCell(label: string): Locator {
+    return this.card.locator('.stat-cell').filter({ hasText: label });
+  }
+
+  async expectStatValue(label: string, value: string | number): Promise<void> {
+    await expect(this.statCell(label).locator('.stat-value')).toHaveText(String(value));
+  }
+}

--- a/apps/testing/tests/support/page-objects/RegisterClubPage.ts
+++ b/apps/testing/tests/support/page-objects/RegisterClubPage.ts
@@ -1,0 +1,48 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { FRONTEND_URL } from '../constants';
+
+/**
+ * Page Object for /registro-club.
+ *
+ * Decision Context:
+ * - The form has two visible sections (admin / club) with their own labels.
+ *   We expose locators by accessible name so tests stay focused on behaviour.
+ * - `uniqueEmail()` is intentionally a static helper rather than a fixture so
+ *   the same email format is used wherever a fresh-registration email is
+ *   needed (avoids accidental DB collisions across reruns).
+ * - Previously fixed bugs: none relevant.
+ */
+export class RegisterClubPage {
+  readonly page: Page;
+  readonly form: Locator;
+  readonly fullName: Locator;
+  readonly email: Locator;
+  readonly password: Locator;
+  readonly confirmPassword: Locator;
+  readonly clubName: Locator;
+  readonly address: Locator;
+  readonly phone: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.form = page.locator('form.reg-form');
+    this.fullName = page.getByLabel('Nombre completo');
+    this.email = page.getByLabel('Email');
+    this.password = page.getByLabel('Contraseña', { exact: true });
+    this.confirmPassword = page.getByLabel('Confirmar contraseña');
+    this.clubName = page.getByLabel('Nombre del club');
+    this.address = page.getByLabel('Dirección');
+    this.phone = page.getByLabel('Teléfono');
+    this.submitButton = page.getByRole('button', { name: 'REGISTRAR CLUB' });
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto(`${FRONTEND_URL}/registro-club`);
+    await expect(this.form).toBeVisible();
+  }
+
+  static uniqueEmail(): string {
+    return `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.test`;
+  }
+}

--- a/apps/testing/tests/support/page-objects/RegisterPlayerPage.ts
+++ b/apps/testing/tests/support/page-objects/RegisterPlayerPage.ts
@@ -1,0 +1,66 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { FRONTEND_URL } from '../constants';
+
+export type PlayerRegisterValues = {
+  displayName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+};
+
+export const VALID_PLAYER_REGISTER: PlayerRegisterValues = {
+  displayName: 'Mateo Duran',
+  email: 'mateo.e2e@example.com',
+  password: 'Hola12345',
+  confirmPassword: 'Hola12345',
+};
+
+/**
+ * Page Object for /registro-jugador.
+ *
+ * Decision Context:
+ * - The page is SSR — the POST is processed server-side. Some specs intercept
+ *   that POST with `page.route('**\/registro-jugador')` to validate the SSR
+ *   contract without writing real users. The page object exposes the form
+ *   fields as locators so tests can also read field values for the
+ *   "data is preserved on error" assertion.
+ * - Previously fixed bugs: none relevant.
+ */
+export class RegisterPlayerPage {
+  readonly page: Page;
+  readonly displayName: Locator;
+  readonly email: Locator;
+  readonly password: Locator;
+  readonly confirmPassword: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.displayName = page.locator('#displayName');
+    this.email = page.locator('#email');
+    this.password = page.locator('#password');
+    this.confirmPassword = page.locator('#confirmPassword');
+    this.submitButton = page.getByRole('button', { name: /crear cuenta/i });
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto(`${FRONTEND_URL}/registro-jugador`);
+    await expect(this.page.getByRole('heading', { name: /sumate ya/i })).toBeVisible();
+  }
+
+  async fillForm(overrides: Partial<PlayerRegisterValues> = {}): Promise<PlayerRegisterValues> {
+    const values = { ...VALID_PLAYER_REGISTER, ...overrides };
+    await this.displayName.fill(values.displayName);
+    await this.email.fill(values.email);
+    await this.password.fill(values.password);
+    await this.confirmPassword.fill(values.confirmPassword);
+    return values;
+  }
+
+  async submitAndWait(): Promise<void> {
+    await Promise.all([
+      this.page.waitForLoadState('domcontentloaded'),
+      this.submitButton.click(),
+    ]);
+  }
+}

--- a/apps/testing/tests/support/users.ts
+++ b/apps/testing/tests/support/users.ts
@@ -1,0 +1,57 @@
+import path from 'node:path';
+
+/**
+ * Test users and their saved auth-state files.
+ *
+ * Decision Context:
+ * - These are throwaway QA accounts that exist in the cloud development DB. The
+ *   credentials are NOT secrets — the project commits them so any dev can run
+ *   the suite without setting env vars. Env overrides exist in case someone
+ *   points the suite at a different DB.
+ * - `storageStatePath` points to a file produced by `auth.setup.ts` at the
+ *   start of every Playwright run. Specs that need a logged-in browser context
+ *   reference these paths via `test.use({ storageState })` (or via the
+ *   `authenticatedAs(...)` helper). The login form itself is exercised in
+ *   login.spec.ts, which intentionally does NOT use a saved storage state.
+ * - Why storage-state caching: doing a real UI login in every spec's
+ *   `beforeEach` was costing 1-2s per test (Astro SSR + bcrypt). With saved
+ *   state we boot a context that already has the HttpOnly cookie set and the
+ *   spec lands directly on the protected page.
+ * - Roles in the suite:
+ *   * `playerMateo` — primary player; default for most match-detail / matches
+ *     /create-match / profile tests. Inscripto in seed match E1 (team B).
+ *   * `playerRicardo` — secondary player; used by leave-match and
+ *     historial-partidos because those flows want a player whose state can
+ *     change without affecting the primary player.
+ *   * `clubAdmin` — the only club_admin in the dev DB; used by login.spec.ts
+ *     redirect-by-role tests.
+ * - Previously fixed bugs: none relevant.
+ */
+
+export type TestUser = {
+  email: string;
+  password: string;
+  storageStatePath: string;
+};
+
+const AUTH_DIR = path.resolve(__dirname, '..', '..', 'playwright', '.auth');
+
+export const TEST_USERS = {
+  playerMateo: {
+    email: process.env.TEST_PLAYER_EMAIL ?? 'mateoduran2010@gmail.com',
+    password: process.env.TEST_PLAYER_PASSWORD ?? 'Hola1234',
+    storageStatePath: path.join(AUTH_DIR, 'player-mateo.json'),
+  },
+  playerRicardo: {
+    email: process.env.TEST_PLAYER_RICARDO_EMAIL ?? 'ricardo@gmail.com',
+    password: process.env.TEST_PLAYER_RICARDO_PASSWORD ?? 'bbbb1234',
+    storageStatePath: path.join(AUTH_DIR, 'player-ricardo.json'),
+  },
+  clubAdmin: {
+    email: process.env.TEST_CLUB_EMAIL ?? 'frantestsumateya@gmail.com',
+    password: process.env.TEST_CLUB_PASSWORD ?? 'aaaa1234',
+    storageStatePath: path.join(AUTH_DIR, 'club-admin.json'),
+  },
+} as const satisfies Record<string, TestUser>;
+
+export type TestUserKey = keyof typeof TEST_USERS;

--- a/claude.md
+++ b/claude.md
@@ -60,6 +60,17 @@ When backend work touches GraphQL schema/resolvers/contracts, also read `.claude
 3. Apply `.claude/rules/graphql.md` for backend GraphQL work and run codegen after `.graphql` edits.
 4. If a backend task needs an exception, update the rule file first (or ask for confirmation) before implementing code changes.
 
+## Hard Rule: E2E Testing Rules First (Mandatory)
+
+Before adding, refactoring, or debugging any file under `apps/testing/tests/**`, always read `.claude/rules/e2e-testing.md` first.
+
+### Required behavior
+
+1. Treat `.claude/rules/e2e-testing.md` as the source of truth for the e2e architecture (page objects, fixtures, auth storage state, GraphQL mocking, builders).
+2. Specs MUST import from the `tests/support` barrel; raw selectors and per-test login flows are not allowed when an existing Page Object or fixture covers them.
+3. Authenticated specs MUST consume saved storage state via `test.use({ storageState: TEST_USERS.<role>.storageStatePath })` — `tests/auth.setup.ts` produces those files once per run.
+4. Add or update Decision Context blocks in specs and Page Objects whenever behaviour or mocking strategy changes.
+
 ### Astro SSR Strategy (CRITICAL)
 
 Use **hybrid rendering** (`output: 'hybrid'` in astro.config). Pages are **static by default** and opt into SSR only when needed.

--- a/docs/prompts/3dp9x4n7-prompt-log.md
+++ b/docs/prompts/3dp9x4n7-prompt-log.md
@@ -1,0 +1,17 @@
+# Prompt Log
+
+- Timestamp: 2026-05-04 19:03:01
+- Task ID: 3dp9x4n7
+
+## User Prompt
+
+> tenés que dividir estos tests e2e en page objects, crear archivos utilitarios para funciones, guardar el auth state y reutilizarlo etc. asegurate de agregar codigo reutilziable, page objects reutilziables etc y al final agrega reglas para seguir con este formato.
+> apps/testing/tests
+>
+> asegurate de que los tests finales sean legibles.
+
+## Agent Main Actions
+
+- Built a `tests/support/` package (constants, users, auth, GraphQL mocks, network helpers, builders, page objects, fixture barrel) plus an `auth.setup.ts` setup project that warms `playwright/.auth/<role>.json` storage state for the three test users; updated `playwright.config.ts` to chain the `setup` project before the `chrome` project so authenticated specs consume saved cookies via `test.use({ storageState })` instead of re-doing UI logins.
+- Refactored every spec under `apps/testing/tests/` (login, registro-jugador, registro-club, menu-overview, matches-list, match-filters, matches-map, match-detail, join-match, leave-match, create-match, profile-view, profile-avatar-upload, historial-partidos) to import only from `./support`, drive flows through the page objects and shared GraphQL/network mocks, and reuse seed match IDs / test user records — verified via `turbo typecheck --force` (3/3 succeed) and `playwright test --list` (setup project + 119 chrome tests discovered).
+- Added `.claude/rules/e2e-testing.md` documenting the new e2e architecture and registered it in `CLAUDE.md` as a Hard Rule (read before touching any file under `apps/testing/tests/**`, import from the support barrel, use storage-state auth, keep Decision Context blocks current).

--- a/docs/prompts/g3k7n2pq-prompt-log.md
+++ b/docs/prompts/g3k7n2pq-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-05-04 12:00:00
+- Task ID: g3k7n2pq
+
+## User Prompt
+
+> what can i use like apollo dev server or something to interacting with my grapql db etc and expriment. please set that up and give me the commands
+
+## Agent Main Actions
+
+- Inspected `apps/backend/src/graphql/server.ts` and `app.ts` to confirm Apollo Server 5 is already configured with introspection enabled in non-production, so the embedded Apollo Sandbox is served at `/graphql` with no extra setup.
+- Provided startup commands (`pnpm --filter @sumate-ya/backend dev`) and the URL `http://localhost:4000/graphql` for the embedded Sandbox playground.
+- Documented how to authenticate Sandbox requests with a `Authorization: Bearer <token>` header (token obtainable via `POST /api/auth/login`) and noted the cloud Apollo Studio alternative plus the CORS allow-list change required to use it.

--- a/docs/prompts/h2j8r5w4-prompt-log.md
+++ b/docs/prompts/h2j8r5w4-prompt-log.md
@@ -1,0 +1,16 @@
+# Prompt Log
+
+- Timestamp: 2026-05-04 18:49:31
+- Task ID: h2j8r5w4
+
+## User Prompt
+
+> ahora mismo en listar partidos, no hay opcion para ver los partidos historicos de un jugador o ver aprtidos antiguos, asegurate de agregar esa funcionalidad.
+>
+> Aclaración del usuario: si todos los partidos pasados poder mostrarlos, y tambien filtrar por los que yo me inscribí. Sería en esa pantalla (/partidos), decide el resto de la lógica vos.
+
+## Agent Main Actions
+
+- Backend: agregué `onlyMine: Boolean` al input `MatchFilters`, extendí el repo para hacer un lookup previo de los `matchIds` participados por el usuario y constreñir la query principal con `.in('id', ids)` (preservando `matchParticipants(count)` para slot counts correctos), y resolví `onlyMine` contra `ctx.user?.id` en el resolver e incorporé el user al cache key. Corrí codegen.
+- Frontend: agregué la dimensión `timeframe` ('upcoming' | 'past') a `ClientMatchFilters`, mapeada a `status` server-side (OPEN/COMPLETED). Agregué un toggle "Próximos / Pasados" en `MatchesView` y un checkbox "Solo los míos" visible solo en Pasados + autenticado. Persistí ambos en URL. Arreglé `MatchList` y `MatchMap` para refetch cuando cambia el server-filter (timeframe/onlyMine), y actualicé el empty state para distinguir Pasados / Pasados+míos / Próximos.
+- Validación: `pnpm exec turbo typecheck --force` pasó sin errores. E2e narrow (`matches-list.spec.ts` + `match-filters.spec.ts`) corrió en background con 18/18 tests verdes.

--- a/docs/prompts/k7m3p2qx-prompt-log.md
+++ b/docs/prompts/k7m3p2qx-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-05-04 19:25:00
+- Task ID: k7m3p2qx
+
+## User Prompt
+
+> Recienteennte eliminé las cordenadas, solo estoy guardando la dirección del club en la db, implementa que calcules la ubicación en base a la dirección para mostrar los pines etc.
+
+## Agent Main Actions
+
+- Added `geocodingService.ts` (Nominatim + Redis cache + per-process rate-limited queue) and a `clubRepository.updateClubCoords` write helper, plus new `CACHE_PREFIX.GEOCODE` and `CACHE_TTL.GEOCODING` slots in `config/redis.ts`.
+- Wired `enrichWithCoords` into the `listMatches`, `getMatchById`, and `getMatchDetail` cache fetchers in `matchService.ts` so any club fetched without `lat/lng` is geocoded once, persisted back to the `clubs` table, and rendered with a pin on the map.
+- Ran `turbo typecheck --force` (clean) and `playwright test matches-list.spec.ts matches-map.spec.ts` — list specs pass; the 2 map failures are pre-existing fixture issues unrelated to backend changes (mocked tests with no lat/lng + Chrome geolocation API).

--- a/docs/prompts/k7m4q9p2-prompt-log.md
+++ b/docs/prompts/k7m4q9p2-prompt-log.md
@@ -1,0 +1,17 @@
+# Prompt Log
+
+- Timestamp: 2026-05-04 18:42:00
+- Task ID: k7m4q9p2
+
+## User Prompt
+
+> agrega test e2e para esta funcionalidad, asegurate de testear casos borde etc.
+> Como jugador, quiero sumarme a un partido disponible seleccionando mi equipo para confirmar mi participación.
+>
+> prueba esta funcoinalidad completa con test e2e
+
+## Agent Main Actions
+
+- Created `apps/testing/tests/join-match.spec.ts` cubriendo el flujo completo de "Sumarme al partido" desde JoinTeamButton: visitante anonimo, click team A/B con verificacion de payload, loading (aria-busy), errores de backend (errors[]), errores de negocio (success:false con/sin message), error de red (route.abort), partido completo, usuario ya inscripto, y guard de id no-UUID — usando los partidos seed E1/E2 y mocks de `page.route('**/graphql')` para no mutar la DB.
+- Reusé el patron de hidratacion de islands `client:load` (espera por atributo `client-render-time`) ya documentado en `match-detail.spec.ts` para evitar el bug conocido de clicks pre-hidratacion.
+- Verifique con `pnpm turbo typecheck --force` (3/3 ok, 0 errors) y corri `npx playwright test join-match.spec.ts` (12/12 ok en ~22s).

--- a/docs/prompts/k7m4q9zb-prompt-log.md
+++ b/docs/prompts/k7m4q9zb-prompt-log.md
@@ -1,0 +1,22 @@
+# Prompt Log
+
+- Timestamp: 2026-05-04 22:25:00
+- Task ID: k7m4q9zb
+
+## User Prompt
+
+> soluciona este error.
+>  2) [chrome] › tests/historial-partidos.spec.ts:38:7 › Historial de partidos (/perfil → sección Historial) › sin login redirige a /login antes de mostrar el perfil
+>
+>     Error: expect(page).toHaveURL(expected) failed
+>     Expected pattern: /\/login/
+>     Received string:  "http://localhost:4321/perfil"
+>     Timeout: 30000ms
+>     34 × unexpected value "http://localhost:4321/perfil"
+>     at apps/testing/tests/historial-partidos.spec.ts:43:30
+
+## Agent Main Actions
+
+- Diagnostiqué que en Playwright 1.59 el `test.use({ storageState })` a nivel de archivo se propaga a `browser.newContext()` sin argumentos, asi que el contexto "anónimo" arrancaba con la cookie de Ricardo y el middleware lo dejaba pasar a /perfil (verificado con un spec de debug que imprimió cookies y comparó con/sin `test.use`).
+- Apliqué el fix en `apps/testing/tests/historial-partidos.spec.ts:44` pasando `storageState: { cookies: [], origins: [] }` explícitamente al `browser.newContext()` y actualicé el bloque Decision Context con el bug fijado.
+- Validé corriendo el test puntual (pasa), todo el spec (7 passed / 3 skipped esperados) y `turbo typecheck --force` desde la raíz (0 errors).

--- a/docs/prompts/k7p3q9w2-prompt-log.md
+++ b/docs/prompts/k7p3q9w2-prompt-log.md
@@ -1,0 +1,18 @@
+# Prompt Log
+
+- Timestamp: 2026-05-04 18:54:38
+- Task ID: k7p3q9w2
+
+## User Prompt
+
+> agrega test para esta funcionalidad que ya está implementada, asegurate de agregar casos borde
+> User Story:
+> Como jugador que participó en un partido, soy el primero en cargar el resultado, debo tener un modal que me permite cargar resultados, y como otro jugador que participó del partido, debo ver el resultado que agregó otro jugador, poner de acuerdo y agregar mi votación.
+> Como jugador que participó en un partido, quiero votar si el resultado cargado es correcto o proponer uno alternativo.
+> [Image attached: partidos disponibles screen showing a finalized match]
+
+## Agent Main Actions
+
+- Added `apps/backend/src/services/matchResultVoteService.test.ts` with 34 unit tests covering propose/vote/list flows, mocking the repository and Redis cache helpers.
+- Covered edge cases: auth/client guards, Zod boundaries (negative scores, >99 cap, invalid UUID, invalid vote), cancelled-match guard, non-participant rejection, non-pending submission rejection, winner derivation (A/B/draw), explicit-winner mismatch, strict-majority boundary (== threshold does not confirm), confirmation cascade and cache invalidation, REJECT vote not triggering confirmation, post-vote reload integrity, and per-caller hasUserVoted/userVote DTO mapping.
+- Verified all 34 tests pass via `pnpm vitest run` and ran `turbo typecheck --force` from the repo root with 0 errors across all 3 tasks.


### PR DESCRIPTION
- Added CreateMatchPage, HomePage, LoginPage, MatchDetailPage, MatchesListPage, MatchesMapPage, ProfilePage, RegisterClubPage, RegisterPlayerPage page objects to streamline e2e tests.
- Introduced user management utilities in users.ts for handling test user authentication states.
- Established e2e testing rules in CLAUDE.md to enforce best practices for test structure and usage of page objects.
- Enhanced existing tests to utilize new page objects, ensuring better maintainability and readability.
- Documented decision contexts for each page object to clarify design choices and testing strategies.