### PR TITLE
feat: show court name in calendar cells and increase row height to ma…

### DIFF
--- a/apps/frontend/src/components/calendar/CalendarGrid.tsx
+++ b/apps/frontend/src/components/calendar/CalendarGrid.tsx
@@ -205,7 +205,7 @@ export default function CalendarGrid({
         .cal-body { max-height: 68vh; overflow-y: auto; }
         .cal-row {
           display: grid;
-          min-height: 38px;
+          min-height: 52px;
         }
         .cal-row:not(:last-child) { border-bottom: 1px solid hsl(var(--border) / 0.4); }
         .cal-time {
@@ -229,7 +229,14 @@ export default function CalendarGrid({
           display: flex;
           align-items: center;
           justify-content: center;
-          min-height: 38px;
+          min-height: 52px;
+        }
+        /* Shared court label — used by ClubScheduleView, SlotCalendarView, AvailableSlotsPicker */
+        .cal-court-label {
+          position: absolute; bottom: 4px; left: 5px; right: 5px;
+          font-family: 'Barlow Condensed', sans-serif; font-size: 0.68rem; font-weight: 700;
+          letter-spacing: 0.04em; color: inherit; white-space: nowrap;
+          overflow: hidden; text-overflow: ellipsis; line-height: 1;
         }
         .cal-cell:last-child { border-right: none; }
         .cal-cell[role="button"] { cursor: pointer; }

--- a/apps/frontend/src/components/club/AvailableSlotsPicker.tsx
+++ b/apps/frontend/src/components/club/AvailableSlotsPicker.tsx
@@ -160,7 +160,7 @@ export default function AvailableSlotsPicker({ accessToken, prefillSlotId, prefi
 
     const content = (
       <>
-        <span className="pk-court">{courtLabel}</span>
+        <span className="cal-court-label">{courtLabel}</span>
         {primary.hasMatch && <Lock size={9} strokeWidth={2.5} className="pk-icon" aria-hidden="true" />}
         {primary.priceArs != null && !primary.hasMatch && withinGrace && (
           <span className="pk-price">${Math.round(primary.priceArs)}</span>
@@ -226,7 +226,7 @@ export default function AvailableSlotsPicker({ accessToken, prefillSlotId, prefi
         </span>
       )}
       <style>{`
-        .pk-court { font-family:'Barlow Condensed',sans-serif; font-size:.68rem; font-weight:700; letter-spacing:.04em; color:inherit; position:absolute; bottom:3px; left:5px; right:5px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+        
         .pk-icon { position:absolute; top:50%; left:50%; transform:translate(-50%,-60%); color:hsl(var(--destructive-foreground)); }
         .pk-price { position:absolute; top:3px; right:4px; font-size:.62rem; font-weight:700; color:hsl(142 70% 55%); font-family:'Barlow Condensed',sans-serif; }
         .pk-extra { position:absolute; top:3px; left:4px; font-size:.62rem; font-weight:700; color:hsl(var(--muted-foreground)); font-family:'Barlow Condensed',sans-serif; }

--- a/apps/frontend/src/components/club/ClubScheduleView.tsx
+++ b/apps/frontend/src/components/club/ClubScheduleView.tsx
@@ -163,6 +163,10 @@ export default function ClubScheduleView({
       isClickable = true;
     }
 
+    const courtLabel = primary.courtName.length > 10
+      ? primary.courtName.slice(0, 9) + '…'
+      : primary.courtName;
+
     const content = (
       <>
         {isBlocked && <Lock size={10} strokeWidth={2.5} className="sched-icon" aria-hidden="true" />}
@@ -171,6 +175,7 @@ export default function ClubScheduleView({
         )}
         {hasMatch && <span className="sched-pip" aria-hidden="true" />}
         {extraCount > 0 && <span className="sched-extra">+{extraCount}</span>}
+        <span className="cal-court-label">{courtLabel}</span>
       </>
     );
 

--- a/apps/frontend/src/components/club/SlotCalendarView.tsx
+++ b/apps/frontend/src/components/club/SlotCalendarView.tsx
@@ -115,6 +115,7 @@ export function SlotCalendarView({ slots, selectedIds, onToggleSelect, onEdit }:
         )}
         {status === 'match' && <span className="slot-pip" aria-hidden="true" />}
         {extra > 0 && <span className="slot-extra">+{extra}</span>}
+        <span className="cal-court-label">{primary.court.name}</span>
       </>
     );
 

--- a/apps/frontend/src/lib/calendar-utils.ts
+++ b/apps/frontend/src/lib/calendar-utils.ts
@@ -36,7 +36,7 @@ export const DOW_ABBR: Record<DayOfWeek, string> = {
 export const DISPLAY_HOURS = Array.from({ length: 17 }, (_, i) => i + 7);
 
 /** Pixel height per calendar row — must match .cal-row min-height in CalendarGrid */
-export const ROW_HEIGHT_PX = 38;
+export const ROW_HEIGHT_PX = 52;
 
 /** The hour to auto-scroll into view on calendar mount */
 export const SCROLL_TO_HOUR = 7;


### PR DESCRIPTION
…tch Crear Partido style

- calendar-utils.ts: ROW_HEIGHT_PX 38 -> 52 so scroll offset matches new height
- CalendarGrid.tsx: .cal-row and .cal-cell min-height 38px -> 52px; add shared .cal-court-label class (absolute, bottom of cell, Barlow Condensed 0.68rem)
- ClubScheduleView: render cal-court-label with truncated court name in every cell
- SlotCalendarView: render cal-court-label with primary.court.name in every cell
- AvailableSlotsPicker: replace local .pk-court with shared .cal-court-label so all three calendars are visually identical (same cell height, same label style)