### PR TITLE
Creación de torneos con fixture automático

### DIFF
--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -273,6 +273,24 @@ export type CreateMatchResult = {
   success: Scalars['Boolean']['output'];
 };
 
+export type CreateTournamentInput = {
+  clubId: Scalars['ID']['input'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  format: MatchFormat;
+  name: Scalars['String']['input'];
+  playersPerTeam: Scalars['Int']['input'];
+  schedule: Array<TournamentScheduleSlotInput>;
+  teamCount: Scalars['Int']['input'];
+};
+
+export type CreateTournamentResult = {
+  __typename?: 'CreateTournamentResult';
+  message?: Maybe<Scalars['String']['output']>;
+  success: Scalars['Boolean']['output'];
+  tournament?: Maybe<Tournament>;
+  tournamentId?: Maybe<Scalars['ID']['output']>;
+};
+
 export type DashboardMatch = {
   __typename?: 'DashboardMatch';
   capacity: Scalars['Int']['output'];
@@ -291,6 +309,13 @@ export type DashboardMatch = {
   timeStatus: TimeStatus;
   timeStatusLabel: Scalars['String']['output'];
 };
+
+export enum FixtureMatchStatus {
+  Cancelled = 'CANCELLED',
+  Completed = 'COMPLETED',
+  InProgress = 'IN_PROGRESS',
+  Scheduled = 'SCHEDULED'
+}
 
 export type JoinMatchInput = {
   matchId: Scalars['ID']['input'];
@@ -457,10 +482,12 @@ export type Mutation = {
   createClubMatch: CreateClubMatchResult;
   createClubSlot: ClubSlotMutationResult;
   createMatch: CreateMatchResult;
+  createTournament: CreateTournamentResult;
   deleteClubSlot: ClubSlotMutationResult;
   joinMatch: JoinMatchResult;
   leaveMatch: LeaveMatchResult;
   proposeMatchResult: MatchResultSubmission;
+  registerTournamentTeam: TournamentTeamRegistrationResult;
   toggleSlotBlock: ClubSlotMutationResult;
   updateClubSlot: ClubSlotMutationResult;
   updateCourtPricing: CourtPricingMutationResult;
@@ -493,6 +520,11 @@ export type MutationCreateMatchArgs = {
 };
 
 
+export type MutationCreateTournamentArgs = {
+  input: CreateTournamentInput;
+};
+
+
 export type MutationDeleteClubSlotArgs = {
   slotId: Scalars['ID']['input'];
 };
@@ -510,6 +542,11 @@ export type MutationLeaveMatchArgs = {
 
 export type MutationProposeMatchResultArgs = {
   input: ProposeMatchResultInput;
+};
+
+
+export type MutationRegisterTournamentTeamArgs = {
+  input: RegisterTournamentTeamInput;
 };
 
 
@@ -651,6 +688,11 @@ export type QuerySlotImpactPreviewArgs = {
   slotIds: Array<Scalars['ID']['input']>;
 };
 
+export type RegisterTournamentTeamInput = {
+  name: Scalars['String']['input'];
+  tournamentId: Scalars['ID']['input'];
+};
+
 export type ScheduleSlot = {
   __typename?: 'ScheduleSlot';
   allowOnlineBooking: Scalars['Boolean']['output'];
@@ -731,6 +773,64 @@ export enum TimeStatus {
   Upcoming = 'UPCOMING',
   UpcomingSoon = 'UPCOMING_SOON'
 }
+
+export type Tournament = {
+  __typename?: 'Tournament';
+  club?: Maybe<TournamentClub>;
+  createdAt: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  endDate?: Maybe<Scalars['String']['output']>;
+  fixtureMatches: Array<TournamentFixtureMatch>;
+  format: MatchFormat;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  organizerId: Scalars['ID']['output'];
+  playersPerTeam: Scalars['Int']['output'];
+  startDate?: Maybe<Scalars['String']['output']>;
+  status: TournamentStatus;
+  teamCount: Scalars['Int']['output'];
+};
+
+export type TournamentClub = {
+  __typename?: 'TournamentClub';
+  address?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  imageUrl?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  zone?: Maybe<Scalars['String']['output']>;
+};
+
+export type TournamentFixtureMatch = {
+  __typename?: 'TournamentFixtureMatch';
+  awayTeamId?: Maybe<Scalars['ID']['output']>;
+  courtId?: Maybe<Scalars['ID']['output']>;
+  homeTeamId?: Maybe<Scalars['ID']['output']>;
+  id: Scalars['ID']['output'];
+  round: Scalars['Int']['output'];
+  scheduledAt?: Maybe<Scalars['String']['output']>;
+  status: FixtureMatchStatus;
+  tournamentId: Scalars['ID']['output'];
+};
+
+export type TournamentScheduleSlotInput = {
+  date: Scalars['String']['input'];
+  slotId: Scalars['ID']['input'];
+};
+
+export enum TournamentStatus {
+  Cancelled = 'CANCELLED',
+  Completed = 'COMPLETED',
+  InProgress = 'IN_PROGRESS',
+  Registration = 'REGISTRATION'
+}
+
+export type TournamentTeamRegistrationResult = {
+  __typename?: 'TournamentTeamRegistrationResult';
+  message?: Maybe<Scalars['String']['output']>;
+  success: Scalars['Boolean']['output'];
+  teamId?: Maybe<Scalars['ID']['output']>;
+  tournament?: Maybe<Tournament>;
+};
 
 export type UpdateClubSlotInput = {
   allowOnlineBooking?: InputMaybe<Scalars['Boolean']['input']>;
@@ -881,7 +981,10 @@ export type ResolversTypes = ResolversObject<{
   CreateClubSlotInput: CreateClubSlotInput;
   CreateMatchInput: CreateMatchInput;
   CreateMatchResult: ResolverTypeWrapper<CreateMatchResult>;
+  CreateTournamentInput: CreateTournamentInput;
+  CreateTournamentResult: ResolverTypeWrapper<CreateTournamentResult>;
   DashboardMatch: ResolverTypeWrapper<DashboardMatch>;
+  FixtureMatchStatus: FixtureMatchStatus;
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
@@ -907,6 +1010,7 @@ export type ResolversTypes = ResolversObject<{
   ProfileSummary: ResolverTypeWrapper<ProfileSummary>;
   ProposeMatchResultInput: ProposeMatchResultInput;
   Query: ResolverTypeWrapper<Record<PropertyKey, never>>;
+  RegisterTournamentTeamInput: RegisterTournamentTeamInput;
   ScheduleSlot: ResolverTypeWrapper<ScheduleSlot>;
   ScheduleSlotStatus: ScheduleSlotStatus;
   SlotAction: SlotAction;
@@ -916,6 +1020,12 @@ export type ResolversTypes = ResolversObject<{
   SubmissionStatus: SubmissionStatus;
   TeamMember: ResolverTypeWrapper<TeamMember>;
   TimeStatus: TimeStatus;
+  Tournament: ResolverTypeWrapper<Tournament>;
+  TournamentClub: ResolverTypeWrapper<TournamentClub>;
+  TournamentFixtureMatch: ResolverTypeWrapper<TournamentFixtureMatch>;
+  TournamentScheduleSlotInput: TournamentScheduleSlotInput;
+  TournamentStatus: TournamentStatus;
+  TournamentTeamRegistrationResult: ResolverTypeWrapper<TournamentTeamRegistrationResult>;
   UpdateClubSlotInput: UpdateClubSlotInput;
   UpdateCourtPricingInput: UpdateCourtPricingInput;
   UserRole: UserRole;
@@ -954,6 +1064,8 @@ export type ResolversParentTypes = ResolversObject<{
   CreateClubSlotInput: CreateClubSlotInput;
   CreateMatchInput: CreateMatchInput;
   CreateMatchResult: CreateMatchResult;
+  CreateTournamentInput: CreateTournamentInput;
+  CreateTournamentResult: CreateTournamentResult;
   DashboardMatch: DashboardMatch;
   Float: Scalars['Float']['output'];
   ID: Scalars['ID']['output'];
@@ -975,11 +1087,17 @@ export type ResolversParentTypes = ResolversObject<{
   ProfileSummary: ProfileSummary;
   ProposeMatchResultInput: ProposeMatchResultInput;
   Query: Record<PropertyKey, never>;
+  RegisterTournamentTeamInput: RegisterTournamentTeamInput;
   ScheduleSlot: ScheduleSlot;
   SlotAuditLog: SlotAuditLog;
   SlotImpactPreview: SlotImpactPreview;
   String: Scalars['String']['output'];
   TeamMember: TeamMember;
+  Tournament: Tournament;
+  TournamentClub: TournamentClub;
+  TournamentFixtureMatch: TournamentFixtureMatch;
+  TournamentScheduleSlotInput: TournamentScheduleSlotInput;
+  TournamentTeamRegistrationResult: TournamentTeamRegistrationResult;
   UpdateClubSlotInput: UpdateClubSlotInput;
   UpdateCourtPricingInput: UpdateCourtPricingInput;
   VoteMatchResultInput: VoteMatchResultInput;
@@ -1143,6 +1261,13 @@ export type CreateMatchResultResolvers<ContextType = GraphQLContext, ParentType 
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
 }>;
 
+export type CreateTournamentResultResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['CreateTournamentResult'] = ResolversParentTypes['CreateTournamentResult']> = ResolversObject<{
+  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  tournament?: Resolver<Maybe<ResolversTypes['Tournament']>, ParentType, ContextType>;
+  tournamentId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+}>;
+
 export type DashboardMatchResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['DashboardMatch'] = ResolversParentTypes['DashboardMatch']> = ResolversObject<{
   capacity?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   clubSlotId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
@@ -1270,10 +1395,12 @@ export type MutationResolvers<ContextType = GraphQLContext, ParentType extends R
   createClubMatch?: Resolver<ResolversTypes['CreateClubMatchResult'], ParentType, ContextType, RequireFields<MutationCreateClubMatchArgs, 'input'>>;
   createClubSlot?: Resolver<ResolversTypes['ClubSlotMutationResult'], ParentType, ContextType, RequireFields<MutationCreateClubSlotArgs, 'input'>>;
   createMatch?: Resolver<ResolversTypes['CreateMatchResult'], ParentType, ContextType, RequireFields<MutationCreateMatchArgs, 'input'>>;
+  createTournament?: Resolver<ResolversTypes['CreateTournamentResult'], ParentType, ContextType, RequireFields<MutationCreateTournamentArgs, 'input'>>;
   deleteClubSlot?: Resolver<ResolversTypes['ClubSlotMutationResult'], ParentType, ContextType, RequireFields<MutationDeleteClubSlotArgs, 'slotId'>>;
   joinMatch?: Resolver<ResolversTypes['JoinMatchResult'], ParentType, ContextType, RequireFields<MutationJoinMatchArgs, 'input'>>;
   leaveMatch?: Resolver<ResolversTypes['LeaveMatchResult'], ParentType, ContextType, RequireFields<MutationLeaveMatchArgs, 'input'>>;
   proposeMatchResult?: Resolver<ResolversTypes['MatchResultSubmission'], ParentType, ContextType, RequireFields<MutationProposeMatchResultArgs, 'input'>>;
+  registerTournamentTeam?: Resolver<ResolversTypes['TournamentTeamRegistrationResult'], ParentType, ContextType, RequireFields<MutationRegisterTournamentTeamArgs, 'input'>>;
   toggleSlotBlock?: Resolver<ResolversTypes['ClubSlotMutationResult'], ParentType, ContextType, RequireFields<MutationToggleSlotBlockArgs, 'input'>>;
   updateClubSlot?: Resolver<ResolversTypes['ClubSlotMutationResult'], ParentType, ContextType, RequireFields<MutationUpdateClubSlotArgs, 'input'>>;
   updateCourtPricing?: Resolver<ResolversTypes['CourtPricingMutationResult'], ParentType, ContextType, RequireFields<MutationUpdateCourtPricingArgs, 'input'>>;
@@ -1359,6 +1486,48 @@ export type TeamMemberResolvers<ContextType = GraphQLContext, ParentType extends
   preferredPosition?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
+export type TournamentResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Tournament'] = ResolversParentTypes['Tournament']> = ResolversObject<{
+  club?: Resolver<Maybe<ResolversTypes['TournamentClub']>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  endDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  fixtureMatches?: Resolver<Array<ResolversTypes['TournamentFixtureMatch']>, ParentType, ContextType>;
+  format?: Resolver<ResolversTypes['MatchFormat'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  organizerId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  playersPerTeam?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  startDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['TournamentStatus'], ParentType, ContextType>;
+  teamCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type TournamentClubResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TournamentClub'] = ResolversParentTypes['TournamentClub']> = ResolversObject<{
+  address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  imageUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  zone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type TournamentFixtureMatchResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TournamentFixtureMatch'] = ResolversParentTypes['TournamentFixtureMatch']> = ResolversObject<{
+  awayTeamId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  courtId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  homeTeamId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  round?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  scheduledAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['FixtureMatchStatus'], ParentType, ContextType>;
+  tournamentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+}>;
+
+export type TournamentTeamRegistrationResultResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TournamentTeamRegistrationResult'] = ResolversParentTypes['TournamentTeamRegistrationResult']> = ResolversObject<{
+  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  teamId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  tournament?: Resolver<Maybe<ResolversTypes['Tournament']>, ParentType, ContextType>;
+}>;
+
 export type VoteSubmissionResultResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['VoteSubmissionResult'] = ResolversParentTypes['VoteSubmissionResult']> = ResolversObject<{
   statusChanged?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   submission?: Resolver<ResolversTypes['MatchResultSubmission'], ParentType, ContextType>;
@@ -1383,6 +1552,7 @@ export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   CourtPricingMutationResult?: CourtPricingMutationResultResolvers<ContextType>;
   CreateClubMatchResult?: CreateClubMatchResultResolvers<ContextType>;
   CreateMatchResult?: CreateMatchResultResolvers<ContextType>;
+  CreateTournamentResult?: CreateTournamentResultResolvers<ContextType>;
   DashboardMatch?: DashboardMatchResolvers<ContextType>;
   JoinMatchResult?: JoinMatchResultResolvers<ContextType>;
   LeaveMatchResult?: LeaveMatchResultResolvers<ContextType>;
@@ -1401,6 +1571,10 @@ export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   SlotAuditLog?: SlotAuditLogResolvers<ContextType>;
   SlotImpactPreview?: SlotImpactPreviewResolvers<ContextType>;
   TeamMember?: TeamMemberResolvers<ContextType>;
+  Tournament?: TournamentResolvers<ContextType>;
+  TournamentClub?: TournamentClubResolvers<ContextType>;
+  TournamentFixtureMatch?: TournamentFixtureMatchResolvers<ContextType>;
+  TournamentTeamRegistrationResult?: TournamentTeamRegistrationResultResolvers<ContextType>;
   VoteSubmissionResult?: VoteSubmissionResultResolvers<ContextType>;
 }>;
 

--- a/apps/backend/src/graphql/resolvers/domains/tournament.ts
+++ b/apps/backend/src/graphql/resolvers/domains/tournament.ts
@@ -1,0 +1,95 @@
+/**
+ * Tournament Resolver - GraphQL mutation for tournament creation.
+ *
+ * Decision Context:
+ * - Both players and club_admins can create tournaments, so the resolver only requires
+ *   authentication and delegates business authorization to the service.
+ * - User-scoped client is passed into writes so RLS can enforce organizerId = auth.uid().
+ * - Errors are returned in the CreateTournamentResult shape for consistent form UX.
+ */
+
+import { z } from 'zod';
+import { createUserClient } from '../../../config/supabase.js';
+import { tournamentService } from '../../../services/tournamentService.js';
+import { requireAuth } from '../../../types/context.js';
+import { MatchFormat } from '../../generated/graphql.js';
+import type { MutationResolvers } from '../../generated/graphql.js';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+const CreateTournamentSchema = z.object({
+  clubId: z.string().regex(UUID_REGEX, 'clubId inválido'),
+  name: z.string().trim().min(3, 'El nombre debe tener al menos 3 caracteres').max(120),
+  format: z.enum([
+    MatchFormat.FiveVsFive,
+    MatchFormat.SevenVsSeven,
+    MatchFormat.TenVsTen,
+    MatchFormat.ElevenVsEleven,
+  ]),
+  teamCount: z.number().int().min(2, 'Mínimo 2 equipos').max(32, 'Máximo 32 equipos'),
+  playersPerTeam: z.number().int().min(1, 'Mínimo 1 jugador por equipo').max(30),
+  description: z.string().max(700, 'La descripción no puede superar 700 caracteres').optional().nullable(),
+  schedule: z
+    .array(
+      z.object({
+        slotId: z.string().regex(UUID_REGEX, 'slotId inválido'),
+        date: z.string().regex(DATE_REGEX, 'date debe ser YYYY-MM-DD'),
+      }),
+    )
+    .min(1, 'Seleccioná al menos un horario')
+    .max(256, 'Demasiados horarios seleccionados'),
+});
+
+const RegisterTournamentTeamSchema = z.object({
+  tournamentId: z.string().regex(UUID_REGEX, 'tournamentId inválido'),
+  name: z.string().trim().min(2, 'El nombre del equipo debe tener al menos 2 caracteres').max(80),
+});
+
+const Mutation: MutationResolvers = {
+  createTournament: async (_parent, args, ctx) => {
+    const user = requireAuth(ctx);
+    const userClient = ctx.accessToken ? createUserClient(ctx.accessToken) : undefined;
+
+    const parsed = CreateTournamentSchema.safeParse(args.input);
+    if (!parsed.success) {
+      const message = parsed.error.issues.map((issue) => issue.message).join('; ');
+      return { success: false, tournamentId: null, message: `Datos inválidos: ${message}`, tournament: null };
+    }
+
+    try {
+      return await tournamentService.createTournament(parsed.data, {
+        userId: user.id,
+        supabase: userClient,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error al crear el torneo';
+      console.error(`[tournamentResolver.createTournament] Failed for userId=${user.id}:`, error);
+      return { success: false, tournamentId: null, message, tournament: null };
+    }
+  },
+
+  registerTournamentTeam: async (_parent, args, ctx) => {
+    const user = requireAuth(ctx);
+    const userClient = ctx.accessToken ? createUserClient(ctx.accessToken) : undefined;
+
+    const parsed = RegisterTournamentTeamSchema.safeParse(args.input);
+    if (!parsed.success) {
+      const message = parsed.error.issues.map((issue) => issue.message).join('; ');
+      return { success: false, teamId: null, message: `Datos inválidos: ${message}`, tournament: null };
+    }
+
+    try {
+      return await tournamentService.registerTournamentTeam(parsed.data, {
+        userId: user.id,
+        supabase: userClient,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error al inscribir el equipo';
+      console.error(`[tournamentResolver.registerTournamentTeam] Failed for userId=${user.id}:`, error);
+      return { success: false, teamId: null, message, tournament: null };
+    }
+  },
+};
+
+export const tournamentResolvers = { Mutation };

--- a/apps/backend/src/graphql/resolvers/index.ts
+++ b/apps/backend/src/graphql/resolvers/index.ts
@@ -17,6 +17,7 @@ import { clubMatchResolvers } from './domains/club-match.js';
 import { matchResolvers } from './domains/match.js';
 import { matchResultResolvers } from './domains/match-result.js';
 import { profileResolvers } from './domains/profile.js';
+import { tournamentResolvers } from './domains/tournament.js';
 
 export const resolvers = {
   Query: {
@@ -33,5 +34,6 @@ export const resolvers = {
     ...matchResultResolvers.Mutation,
     ...clubSlotResolvers.Mutation,
     ...clubMatchResolvers.Mutation,
+    ...tournamentResolvers.Mutation,
   },
 };

--- a/apps/backend/src/graphql/schema/tournament.graphql
+++ b/apps/backend/src/graphql/schema/tournament.graphql
@@ -1,0 +1,99 @@
+# Tournament creation and fixture planning
+#
+# Decision Context:
+# - Tournaments already exist in the DB schema, but this is the first GraphQL contract
+#   that lets authenticated users create them.
+# - createTournament accepts concrete slot/date pairs. The service validates each selected
+#   occurrence and writes planned fixtureMatches rows with round numbers. Team ids stay
+#   null until registration is complete, at which point the service can fill them using
+#   round-robin pairing.
+# - MatchFormat is reused from match.graphql so tournament formats stay aligned with
+#   player and club match creation.
+
+enum TournamentStatus {
+  REGISTRATION
+  IN_PROGRESS
+  COMPLETED
+  CANCELLED
+}
+
+enum FixtureMatchStatus {
+  SCHEDULED
+  IN_PROGRESS
+  COMPLETED
+  CANCELLED
+}
+
+type TournamentClub {
+  id: ID!
+  name: String!
+  zone: String
+  address: String
+  imageUrl: String
+}
+
+type TournamentFixtureMatch {
+  id: ID!
+  tournamentId: ID!
+  round: Int!
+  homeTeamId: ID
+  awayTeamId: ID
+  courtId: ID
+  scheduledAt: String
+  status: FixtureMatchStatus!
+}
+
+type Tournament {
+  id: ID!
+  organizerId: ID!
+  name: String!
+  format: MatchFormat!
+  teamCount: Int!
+  playersPerTeam: Int!
+  status: TournamentStatus!
+  description: String
+  startDate: String
+  endDate: String
+  createdAt: String!
+  club: TournamentClub
+  fixtureMatches: [TournamentFixtureMatch!]!
+}
+
+input TournamentScheduleSlotInput {
+  slotId: ID!
+  date: String!
+}
+
+input CreateTournamentInput {
+  clubId: ID!
+  name: String!
+  format: MatchFormat!
+  teamCount: Int!
+  playersPerTeam: Int!
+  description: String
+  schedule: [TournamentScheduleSlotInput!]!
+}
+
+type CreateTournamentResult {
+  success: Boolean!
+  tournamentId: ID
+  message: String
+  tournament: Tournament
+}
+
+type TournamentTeamRegistrationResult {
+  success: Boolean!
+  teamId: ID
+  message: String
+  tournament: Tournament
+}
+
+input RegisterTournamentTeamInput {
+  tournamentId: ID!
+  name: String!
+}
+
+extend type Mutation {
+  createTournament(input: CreateTournamentInput!): CreateTournamentResult!
+  registerTournamentTeam(input: RegisterTournamentTeamInput!): TournamentTeamRegistrationResult!
+}

--- a/apps/backend/src/repositories/tournamentRepository.ts
+++ b/apps/backend/src/repositories/tournamentRepository.ts
@@ -1,0 +1,493 @@
+/**
+ * Tournament Repository - DB access for tournaments and fixtureMatches.
+ *
+ * Decision Context:
+ * - Explicit column lists keep tournament reads small and predictable.
+ * - Writes accept an optional user-scoped client so RLS can enforce organizer ownership.
+ * - Availability checks read from both matches and fixtureMatches because tournament
+ *   creation reserves club/court time before the participating teams are known.
+ */
+
+import { supabase, type SupabaseClient } from '../config/supabase.js';
+
+// =====================================================
+// Column Definitions
+// =====================================================
+
+const TOURNAMENT_COLUMNS = `
+  id,
+  "organizerId",
+  "clubId",
+  name,
+  format,
+  "teamCount",
+  "playersPerTeam",
+  status,
+  description,
+  "startDate",
+  "endDate",
+  "createdAt"
+`;
+
+const TOURNAMENT_CLUB_COLUMNS = `
+  id,
+  name,
+  zone,
+  address,
+  "imageUrl"
+`;
+
+const FIXTURE_COLUMNS = `
+  id,
+  "tournamentId",
+  round,
+  "homeTeamId",
+  "awayTeamId",
+  "courtId",
+  "scheduledAt",
+  status,
+  "createdAt"
+`;
+
+const SLOT_COLUMNS = `
+  id,
+  "clubId",
+  "courtId",
+  "dayOfWeek",
+  "startTime",
+  "endTime",
+  "isBlocked",
+  "isActive",
+  "allowOnlineBooking",
+  courts(id, name, "maxFormat")
+`;
+
+// =====================================================
+// Types
+// =====================================================
+
+export interface TournamentClubRow {
+  id: string;
+  name: string;
+  zone: string | null;
+  address: string | null;
+  imageUrl: string | null;
+}
+
+export interface FixtureMatchRow {
+  id: string;
+  tournamentId: string;
+  round: number;
+  homeTeamId: string | null;
+  awayTeamId: string | null;
+  courtId: string | null;
+  scheduledAt: string | null;
+  status: string;
+  createdAt: string;
+}
+
+export interface TournamentRow {
+  id: string;
+  organizerId: string;
+  clubId: string;
+  name: string;
+  format: string;
+  teamCount: number;
+  playersPerTeam: number;
+  status: string;
+  description: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  createdAt: string;
+  clubs?: TournamentClubRow | null;
+  fixtureMatches?: FixtureMatchRow[];
+}
+
+export interface TournamentSlotCourtRow {
+  id: string;
+  name: string;
+  maxFormat: string;
+}
+
+export interface TournamentSlotRow {
+  id: string;
+  clubId: string;
+  courtId: string;
+  dayOfWeek: string;
+  startTime: string;
+  endTime: string;
+  isBlocked: boolean;
+  isActive: boolean;
+  allowOnlineBooking: boolean;
+  courts: TournamentSlotCourtRow | null;
+}
+
+export interface CreateTournamentRowInput {
+  organizerId: string;
+  clubId: string;
+  name: string;
+  format: string;
+  teamCount: number;
+  playersPerTeam: number;
+  description?: string | null;
+  startDate: string;
+  endDate: string;
+}
+
+export interface CreateFixtureMatchInput {
+  tournamentId: string;
+  round: number;
+  courtId: string;
+  scheduledAt: string;
+}
+
+export interface CreateTournamentWithFixtureRpcInput {
+  clubId: string;
+  name: string;
+  format: string;
+  teamCount: number;
+  playersPerTeam: number;
+  description?: string | null;
+  schedule: Array<{
+    slotId: string;
+    date: string;
+  }>;
+}
+
+export interface RegisterTournamentTeamRpcInput {
+  tournamentId: string;
+  name: string;
+}
+
+export interface MatchSlotReservationRow {
+  id: string;
+  clubSlotId: string | null;
+  scheduledAt: string;
+}
+
+export interface FixtureReservationRow {
+  id: string;
+  courtId: string | null;
+  scheduledAt: string | null;
+}
+
+export interface TournamentTeamRow {
+  id: string;
+  tournamentId?: string;
+  name: string;
+  captainId?: string;
+  createdAt?: string;
+}
+
+function isMissingTournamentRpcError(message: string): boolean {
+  return (
+    message.includes('Could not find the function public.create_tournament_with_fixture') ||
+    message.includes('Could not find the function public.register_tournament_team') ||
+    message.includes('function public.create_tournament_with_fixture') ||
+    message.includes('function public.register_tournament_team')
+  );
+}
+
+// =====================================================
+// Repository Functions
+// =====================================================
+
+export async function getSlotsByIds(
+  slotIds: string[],
+  client: SupabaseClient = supabase,
+): Promise<TournamentSlotRow[]> {
+  if (slotIds.length === 0) return [];
+
+  const { data, error } = await client
+    .from('clubSlots')
+    .select(SLOT_COLUMNS)
+    .in('id', slotIds);
+
+  if (error) {
+    console.error('[tournamentRepository.getSlotsByIds] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return (data as unknown as TournamentSlotRow[]) ?? [];
+}
+
+export async function getMatchesForSlotDates(
+  slotIds: string[],
+  startDate: string,
+  endDate: string,
+  client: SupabaseClient = supabase,
+): Promise<MatchSlotReservationRow[]> {
+  if (slotIds.length === 0) return [];
+
+  const { data, error } = await client
+    .from('matches')
+    .select('id, "clubSlotId", "scheduledAt"')
+    .in('clubSlotId', slotIds)
+    .neq('status', 'cancelled')
+    .gte('scheduledAt', `${startDate}T00:00:00`)
+    .lte('scheduledAt', `${endDate}T23:59:59`);
+
+  if (error) {
+    console.error('[tournamentRepository.getMatchesForSlotDates] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return (data as unknown as MatchSlotReservationRow[]) ?? [];
+}
+
+export async function getFixtureReservationsForCourts(
+  courtIds: string[],
+  startDate: string,
+  endDate: string,
+  client: SupabaseClient = supabase,
+): Promise<FixtureReservationRow[]> {
+  if (courtIds.length === 0) return [];
+
+  const { data, error } = await client
+    .from('fixtureMatches')
+    .select('id, "courtId", "scheduledAt"')
+    .in('courtId', courtIds)
+    .neq('status', 'cancelled')
+    .gte('scheduledAt', `${startDate}T00:00:00`)
+    .lte('scheduledAt', `${endDate}T23:59:59`);
+
+  if (error) {
+    console.error(
+      '[tournamentRepository.getFixtureReservationsForCourts] Supabase error:',
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return (data as unknown as FixtureReservationRow[]) ?? [];
+}
+
+export async function createTournament(
+  input: CreateTournamentRowInput,
+  client: SupabaseClient = supabase,
+): Promise<TournamentRow> {
+  const { data, error } = await client
+    .from('tournaments')
+    .insert({
+      organizerId: input.organizerId,
+      clubId: input.clubId,
+      name: input.name,
+      format: input.format,
+      teamCount: input.teamCount,
+      playersPerTeam: input.playersPerTeam,
+      description: input.description ?? null,
+      startDate: input.startDate,
+      endDate: input.endDate,
+    })
+    .select(TOURNAMENT_COLUMNS)
+    .single();
+
+  if (error) {
+    console.error('[tournamentRepository.createTournament] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return data as unknown as TournamentRow;
+}
+
+export async function createTournamentWithFixtureRpc(
+  input: CreateTournamentWithFixtureRpcInput,
+  client: SupabaseClient,
+): Promise<string> {
+  const { data, error } = await client.rpc('create_tournament_with_fixture', {
+    p_club_id: input.clubId,
+    p_name: input.name,
+    p_format: input.format,
+    p_team_count: input.teamCount,
+    p_players_per_team: input.playersPerTeam,
+    p_description: input.description ?? null,
+    p_schedule: input.schedule,
+  });
+
+  if (error) {
+    console.error('[tournamentRepository.createTournamentWithFixtureRpc] Supabase error:', error.message);
+    if (isMissingTournamentRpcError(error.message)) {
+      throw new Error('Falta aplicar la migracion SQL de torneos en Supabase');
+    }
+    throw new Error(error.message);
+  }
+
+  if (!data || typeof data !== 'string') {
+    throw new Error('No se pudo crear el torneo en Supabase');
+  }
+
+  return data;
+}
+
+export async function registerTournamentTeamRpc(
+  input: RegisterTournamentTeamRpcInput,
+  client: SupabaseClient,
+): Promise<string> {
+  const { data, error } = await client.rpc('register_tournament_team', {
+    p_tournament_id: input.tournamentId,
+    p_name: input.name,
+  });
+
+  if (error) {
+    console.error('[tournamentRepository.registerTournamentTeamRpc] Supabase error:', error.message);
+    if (isMissingTournamentRpcError(error.message)) {
+      throw new Error('Falta aplicar la migracion SQL de torneos en Supabase');
+    }
+    throw new Error(error.message);
+  }
+
+  if (!data || typeof data !== 'string') {
+    throw new Error('No se pudo inscribir el equipo en Supabase');
+  }
+
+  return data;
+}
+
+export async function insertFixtureMatches(
+  rows: CreateFixtureMatchInput[],
+  client: SupabaseClient = supabase,
+): Promise<FixtureMatchRow[]> {
+  if (rows.length === 0) return [];
+
+  const { data, error } = await client
+    .from('fixtureMatches')
+    .insert(rows.map((row) => ({
+      tournamentId: row.tournamentId,
+      round: row.round,
+      courtId: row.courtId,
+      scheduledAt: row.scheduledAt,
+    })))
+    .select(FIXTURE_COLUMNS);
+
+  if (error) {
+    console.error('[tournamentRepository.insertFixtureMatches] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return (data as unknown as FixtureMatchRow[]) ?? [];
+}
+
+export async function getTournamentById(
+  tournamentId: string,
+  client: SupabaseClient = supabase,
+): Promise<TournamentRow | null> {
+  const { data, error } = await client
+    .from('tournaments')
+    .select(`${TOURNAMENT_COLUMNS}, clubs(${TOURNAMENT_CLUB_COLUMNS}), fixtureMatches(${FIXTURE_COLUMNS})`)
+    .eq('id', tournamentId)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return null;
+    console.error('[tournamentRepository.getTournamentById] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return data as unknown as TournamentRow;
+}
+
+export async function getTournamentTeams(
+  tournamentId: string,
+  client: SupabaseClient = supabase,
+): Promise<TournamentTeamRow[]> {
+  const { data, error } = await client
+    .from('tournamentTeams')
+    .select('id, name')
+    .eq('tournamentId', tournamentId)
+    .order('createdAt', { ascending: true });
+
+  if (error) {
+    console.error('[tournamentRepository.getTournamentTeams] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return (data as unknown as TournamentTeamRow[]) ?? [];
+}
+
+export async function createTournamentTeam(
+  tournamentId: string,
+  name: string,
+  captainId: string,
+  client: SupabaseClient = supabase,
+): Promise<TournamentTeamRow> {
+  const { data, error } = await client
+    .from('tournamentTeams')
+    .insert({
+      tournamentId,
+      name,
+      captainId,
+    })
+    .select('id, "tournamentId", name, "captainId", "createdAt"')
+    .single();
+
+  if (error) {
+    console.error('[tournamentRepository.createTournamentTeam] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return data as unknown as TournamentTeamRow;
+}
+
+export async function createTournamentTeamMember(
+  teamId: string,
+  playerId: string,
+  client: SupabaseClient = supabase,
+): Promise<void> {
+  const { error } = await client
+    .from('tournamentTeamMembers')
+    .insert({ teamId, playerId });
+
+  if (error) {
+    console.error('[tournamentRepository.createTournamentTeamMember] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+}
+
+export async function updateFixtureTeams(
+  fixtureId: string,
+  homeTeamId: string,
+  awayTeamId: string,
+  client: SupabaseClient = supabase,
+): Promise<void> {
+  const { error } = await client
+    .from('fixtureMatches')
+    .update({ homeTeamId, awayTeamId })
+    .eq('id', fixtureId);
+
+  if (error) {
+    console.error('[tournamentRepository.updateFixtureTeams] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+}
+
+export async function updateTournamentStatus(
+  tournamentId: string,
+  status: 'registration' | 'in_progress' | 'completed' | 'cancelled',
+  client: SupabaseClient = supabase,
+): Promise<void> {
+  const { error } = await client
+    .from('tournaments')
+    .update({ status })
+    .eq('id', tournamentId);
+
+  if (error) {
+    console.error('[tournamentRepository.updateTournamentStatus] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+}
+
+export const tournamentRepository = {
+  getSlotsByIds,
+  getMatchesForSlotDates,
+  getFixtureReservationsForCourts,
+  createTournament,
+  createTournamentWithFixtureRpc,
+  registerTournamentTeamRpc,
+  insertFixtureMatches,
+  getTournamentById,
+  getTournamentTeams,
+  createTournamentTeam,
+  createTournamentTeamMember,
+  updateFixtureTeams,
+  updateTournamentStatus,
+};

--- a/apps/backend/src/services/tournamentService.ts
+++ b/apps/backend/src/services/tournamentService.ts
@@ -1,0 +1,431 @@
+/**
+ * Tournament Service - creation, availability validation, and round-robin fixture planning.
+ *
+ * Decision Context:
+ * - Creation delegates the tournament + fixture reservation write to Supabase RPC so the
+ *   full insert happens transactionally under auth.uid() without direct table RLS friction.
+ * - Once tournamentTeams reaches teamCount, generateFixtureIfRegistrationComplete() fills
+ *   those fixture rows with round-robin pairings and marks the tournament in_progress.
+ * - Services return data only; resolvers decide how to shape success/error responses.
+ */
+
+import { supabase } from '../config/supabase.js';
+import {
+  FixtureMatchStatus,
+  MatchFormat,
+  TournamentStatus,
+  type CreateTournamentInput,
+  type CreateTournamentResult,
+  type RegisterTournamentTeamInput,
+  type Tournament,
+  type TournamentFixtureMatch,
+  type TournamentTeamRegistrationResult,
+} from '../graphql/generated/graphql.js';
+import {
+  tournamentRepository,
+  type FixtureMatchRow,
+  type TournamentRow,
+  type TournamentSlotRow,
+} from '../repositories/tournamentRepository.js';
+import { clubRepository } from '../repositories/clubRepository.js';
+import { dateToDayOfWeek } from './clubService.js';
+import type { ServiceContext } from '../types/context.js';
+
+// =====================================================
+// Enum Mapping
+// =====================================================
+
+const FORMAT_TO_DB: Record<MatchFormat, string> = {
+  [MatchFormat.FiveVsFive]: '5v5',
+  [MatchFormat.SevenVsSeven]: '7v7',
+  [MatchFormat.TenVsTen]: '10v10',
+  [MatchFormat.ElevenVsEleven]: '11v11',
+};
+
+const DB_TO_FORMAT: Record<string, MatchFormat> = {
+  '5v5': MatchFormat.FiveVsFive,
+  '7v7': MatchFormat.SevenVsSeven,
+  '10v10': MatchFormat.TenVsTen,
+  '11v11': MatchFormat.ElevenVsEleven,
+};
+
+const DB_TO_STATUS: Record<string, TournamentStatus> = {
+  registration: TournamentStatus.Registration,
+  in_progress: TournamentStatus.InProgress,
+  completed: TournamentStatus.Completed,
+  cancelled: TournamentStatus.Cancelled,
+};
+
+const DB_TO_FIXTURE_STATUS: Record<string, FixtureMatchStatus> = {
+  scheduled: FixtureMatchStatus.Scheduled,
+  in_progress: FixtureMatchStatus.InProgress,
+  completed: FixtureMatchStatus.Completed,
+  cancelled: FixtureMatchStatus.Cancelled,
+};
+
+const FORMAT_ORDER: Record<string, number> = {
+  '5v5': 1,
+  '7v7': 2,
+  '10v10': 3,
+  '11v11': 4,
+};
+
+// =====================================================
+// Helpers
+// =====================================================
+
+interface NormalizedScheduleSlot {
+  slotId: string;
+  date: string;
+  slot: TournamentSlotRow;
+  scheduledAt: string;
+}
+
+function roundRobinShape(teamCount: number): {
+  rounds: number;
+  matchesPerRound: number;
+  requiredMatches: number;
+} {
+  const matchesPerRound = Math.floor(teamCount / 2);
+  const rounds = teamCount % 2 === 0 ? teamCount - 1 : teamCount;
+  return { rounds, matchesPerRound, requiredMatches: rounds * matchesPerRound };
+}
+
+function dateFromTimestamp(value: string | null | undefined): string {
+  return value?.slice(0, 10) ?? '';
+}
+
+function timeFromTimestamp(value: string | null | undefined): string {
+  if (!value) return '';
+  const timePart = value.includes('T') ? value.split('T')[1] : value.split(' ')[1];
+  return (timePart ?? '').slice(0, 5);
+}
+
+function slotTimeKey(courtId: string | null | undefined, scheduledAt: string | null | undefined): string {
+  return `${courtId ?? ''}|${dateFromTimestamp(scheduledAt)}|${timeFromTimestamp(scheduledAt)}`;
+}
+
+function toFixtureMatch(row: FixtureMatchRow): TournamentFixtureMatch {
+  return {
+    id: row.id,
+    tournamentId: row.tournamentId,
+    round: row.round,
+    homeTeamId: row.homeTeamId,
+    awayTeamId: row.awayTeamId,
+    courtId: row.courtId,
+    scheduledAt: row.scheduledAt,
+    status: DB_TO_FIXTURE_STATUS[row.status] ?? FixtureMatchStatus.Scheduled,
+  };
+}
+
+function toTournament(row: TournamentRow): Tournament {
+  const fixtureMatches = [...(row.fixtureMatches ?? [])].sort((a, b) => {
+    if (a.round !== b.round) return a.round - b.round;
+    return (a.scheduledAt ?? '').localeCompare(b.scheduledAt ?? '');
+  });
+
+  return {
+    id: row.id,
+    organizerId: row.organizerId,
+    name: row.name,
+    format: DB_TO_FORMAT[row.format] ?? MatchFormat.FiveVsFive,
+    teamCount: row.teamCount,
+    playersPerTeam: row.playersPerTeam,
+    status: DB_TO_STATUS[row.status] ?? TournamentStatus.Registration,
+    description: row.description,
+    startDate: row.startDate,
+    endDate: row.endDate,
+    createdAt: row.createdAt,
+    club: row.clubs
+      ? {
+          id: row.clubs.id,
+          name: row.clubs.name,
+          zone: row.clubs.zone,
+          address: row.clubs.address,
+          imageUrl: row.clubs.imageUrl,
+        }
+      : null,
+    fixtureMatches: fixtureMatches.map(toFixtureMatch),
+  };
+}
+
+async function normalizeAndValidateSchedule(
+  input: CreateTournamentInput,
+  dbFormat: string,
+): Promise<NormalizedScheduleSlot[]> {
+  const shape = roundRobinShape(input.teamCount);
+
+  if (input.schedule.length < shape.requiredMatches) {
+    throw new Error(
+      `Necesitás seleccionar ${shape.requiredMatches} horarios para un round-robin de ${input.teamCount} equipos.`,
+    );
+  }
+
+  const occurrenceKeys = new Set<string>();
+  for (const occurrence of input.schedule) {
+    const key = `${occurrence.slotId}|${occurrence.date}`;
+    if (occurrenceKeys.has(key)) {
+      throw new Error('Hay horarios repetidos en el fixture del torneo');
+    }
+    occurrenceKeys.add(key);
+  }
+
+  const uniqueSlotIds = [...new Set(input.schedule.map((s) => s.slotId))];
+  const slots = await tournamentRepository.getSlotsByIds(uniqueSlotIds);
+  const slotsById = new Map(slots.map((slot) => [slot.id, slot]));
+
+  const normalized = input.schedule.map((occurrence) => {
+    const slot = slotsById.get(occurrence.slotId);
+    if (!slot) throw new Error('Uno de los horarios seleccionados ya no existe');
+    if (slot.clubId !== input.clubId) {
+      throw new Error('Uno de los horarios no pertenece al club seleccionado');
+    }
+    if (!slot.isActive) throw new Error('Uno de los horarios seleccionados fue eliminado');
+    if (slot.isBlocked) throw new Error('Uno de los horarios seleccionados está bloqueado');
+    if (!slot.allowOnlineBooking) {
+      throw new Error('Uno de los horarios no permite reservas online');
+    }
+    if (!slot.courts) throw new Error('No se pudo validar la cancha del horario seleccionado');
+
+    const expectedDay = dateToDayOfWeek(occurrence.date);
+    if (slot.dayOfWeek !== expectedDay) {
+      throw new Error(
+        `El horario ${slot.startTime.slice(0, 5)} corresponde a ${slot.dayOfWeek}, pero la fecha elegida es ${expectedDay}`,
+      );
+    }
+
+    if ((FORMAT_ORDER[dbFormat] ?? 0) > (FORMAT_ORDER[slot.courts.maxFormat] ?? 0)) {
+      throw new Error(
+        `La cancha ${slot.courts.name} soporta hasta ${slot.courts.maxFormat}. El formato ${dbFormat} no es compatible.`,
+      );
+    }
+
+    const scheduledAt = `${occurrence.date}T${slot.startTime}`;
+    if (new Date(scheduledAt).getTime() <= Date.now()) {
+      throw new Error('Todos los horarios del torneo deben ser futuros');
+    }
+
+    return {
+      slotId: occurrence.slotId,
+      date: occurrence.date,
+      slot,
+      scheduledAt,
+    };
+  });
+
+  normalized.sort((a, b) => a.scheduledAt.localeCompare(b.scheduledAt));
+
+  const selected = normalized.slice(0, shape.requiredMatches);
+  const selectedSlotIds = [...new Set(selected.map((s) => s.slotId))];
+  const selectedCourtIds = [...new Set(selected.map((s) => s.slot.courtId))];
+  const startDate = selected[0]?.date;
+  const endDate = selected[selected.length - 1]?.date;
+  if (!startDate || !endDate) throw new Error('Seleccioná al menos un horario');
+
+  const [matches, fixtureReservations] = await Promise.all([
+    tournamentRepository.getMatchesForSlotDates(selectedSlotIds, startDate, endDate),
+    tournamentRepository.getFixtureReservationsForCourts(selectedCourtIds, startDate, endDate),
+  ]);
+
+  const matchKeys = new Set(
+    matches
+      .filter((match) => match.clubSlotId)
+      .map((match) => `${match.clubSlotId}|${dateFromTimestamp(match.scheduledAt)}`),
+  );
+  const fixtureKeys = new Set(
+    fixtureReservations.map((fixture) => slotTimeKey(fixture.courtId, fixture.scheduledAt)),
+  );
+
+  for (const occurrence of selected) {
+    if (matchKeys.has(`${occurrence.slotId}|${occurrence.date}`)) {
+      throw new Error('Ya existe un partido en uno de los horarios seleccionados');
+    }
+    if (fixtureKeys.has(slotTimeKey(occurrence.slot.courtId, occurrence.scheduledAt))) {
+      throw new Error('Ya existe un fixture de torneo en uno de los horarios seleccionados');
+    }
+  }
+
+  return selected;
+}
+
+function buildRoundRobinPairings(teamIds: string[]): Array<{
+  round: number;
+  homeTeamId: string;
+  awayTeamId: string;
+}> {
+  const participants: Array<string | null> =
+    teamIds.length % 2 === 0 ? [...teamIds] : [...teamIds, null];
+  const rounds = participants.length - 1;
+  const half = participants.length / 2;
+  const pairings: Array<{ round: number; homeTeamId: string; awayTeamId: string }> = [];
+
+  for (let round = 1; round <= rounds; round++) {
+    for (let i = 0; i < half; i++) {
+      const home = participants[i];
+      const away = participants[participants.length - 1 - i];
+      if (!home || !away) continue;
+
+      pairings.push(
+        round % 2 === 0
+          ? { round, homeTeamId: away, awayTeamId: home }
+          : { round, homeTeamId: home, awayTeamId: away },
+      );
+    }
+
+    const fixed = participants[0];
+    const rotated = [fixed, participants[participants.length - 1], ...participants.slice(1, -1)];
+    participants.splice(0, participants.length, ...rotated);
+  }
+
+  return pairings;
+}
+
+// =====================================================
+// Service Functions
+// =====================================================
+
+export async function createTournament(
+  input: CreateTournamentInput,
+  ctx: ServiceContext,
+): Promise<CreateTournamentResult> {
+  if (!ctx.userId) throw new Error('Authentication required');
+  const db = ctx.supabase;
+  if (!db) throw new Error('User-scoped client required for write operations');
+
+  const name = input.name.trim();
+  if (name.length < 3) throw new Error('El nombre del torneo debe tener al menos 3 caracteres');
+  if (input.teamCount < 2) throw new Error('El torneo debe tener al menos 2 equipos');
+  if (input.teamCount > 32) throw new Error('El torneo no puede superar los 32 equipos');
+  if (input.playersPerTeam < 1) throw new Error('Jugadores por equipo debe ser mayor a 0');
+  if (input.playersPerTeam > 30) throw new Error('Jugadores por equipo no puede superar 30');
+
+  const dbFormat = FORMAT_TO_DB[input.format];
+  if (!dbFormat) throw new Error('Formato de torneo inválido');
+
+  const club = await clubRepository.getClubById(input.clubId);
+  if (!club) throw new Error('Club no encontrado');
+
+  const selectedSlots = await normalizeAndValidateSchedule(input, dbFormat);
+
+  const tournamentId = await tournamentRepository.createTournamentWithFixtureRpc(
+    {
+      clubId: input.clubId,
+      name,
+      format: dbFormat,
+      teamCount: input.teamCount,
+      playersPerTeam: input.playersPerTeam,
+      description: input.description?.trim() || null,
+      schedule: selectedSlots.map((slot) => ({
+        slotId: slot.slotId,
+        date: slot.date,
+      })),
+    },
+    db,
+  );
+
+  await generateFixtureIfRegistrationComplete({ userId: ctx.userId, supabase: db }, tournamentId);
+
+  const created = await tournamentRepository.getTournamentById(tournamentId);
+  if (!created) throw new Error('No se pudo cargar el torneo creado');
+
+  return {
+    success: true,
+    tournamentId: created.id,
+    message: null,
+    tournament: toTournament(created),
+  };
+}
+
+export async function generateFixtureIfRegistrationComplete(
+  ctx: ServiceContext,
+  tournamentId: string,
+): Promise<boolean> {
+  if (!ctx.userId) throw new Error('Authentication required');
+  const tournament = await tournamentRepository.getTournamentById(tournamentId);
+  if (!tournament) throw new Error('Torneo no encontrado');
+
+  const teams = await tournamentRepository.getTournamentTeams(tournamentId);
+  if (teams.length < tournament.teamCount) return false;
+
+  const fixtures = [...(tournament.fixtureMatches ?? [])].sort((a, b) => {
+    if (a.round !== b.round) return a.round - b.round;
+    return (a.scheduledAt ?? '').localeCompare(b.scheduledAt ?? '');
+  });
+
+  if (fixtures.some((fixture) => fixture.homeTeamId && fixture.awayTeamId)) {
+    return false;
+  }
+
+  const pairings = buildRoundRobinPairings(teams.slice(0, tournament.teamCount).map((team) => team.id));
+  if (fixtures.length < pairings.length) {
+    throw new Error('El torneo no tiene suficientes horarios reservados para generar el fixture');
+  }
+
+  // System-side generation may be triggered by the captain who completes registration,
+  // not necessarily by the organizer. Use the service-role client after business checks.
+  const writeClient = supabase;
+  await Promise.all(
+    pairings.map((pairing, index) =>
+      tournamentRepository.updateFixtureTeams(
+        fixtures[index].id,
+        pairing.homeTeamId,
+        pairing.awayTeamId,
+        writeClient,
+      ),
+    ),
+  );
+
+  await tournamentRepository.updateTournamentStatus(tournamentId, 'in_progress', writeClient);
+  return true;
+}
+
+export async function registerTournamentTeam(
+  input: RegisterTournamentTeamInput,
+  ctx: ServiceContext,
+): Promise<TournamentTeamRegistrationResult> {
+  if (!ctx.userId) throw new Error('Authentication required');
+  const db = ctx.supabase;
+  if (!db) throw new Error('User-scoped client required for write operations');
+
+  const teamName = input.name.trim();
+  if (teamName.length < 2) throw new Error('El nombre del equipo debe tener al menos 2 caracteres');
+  if (teamName.length > 80) throw new Error('El nombre del equipo no puede superar 80 caracteres');
+
+  const tournament = await tournamentRepository.getTournamentById(input.tournamentId);
+  if (!tournament) throw new Error('Torneo no encontrado');
+  if (tournament.status !== 'registration') {
+    throw new Error('La inscripción de este torneo ya está cerrada');
+  }
+
+  const currentTeams = await tournamentRepository.getTournamentTeams(input.tournamentId);
+  if (currentTeams.length >= tournament.teamCount) {
+    throw new Error('El torneo ya completó todos sus cupos de equipos');
+  }
+  if (currentTeams.some((team) => team.name.toLowerCase() === teamName.toLowerCase())) {
+    throw new Error('Ya existe un equipo con ese nombre en el torneo');
+  }
+
+  const teamId = await tournamentRepository.registerTournamentTeamRpc(
+    {
+      tournamentId: input.tournamentId,
+      name: teamName,
+    },
+    db,
+  );
+
+  const updatedTournament = await tournamentRepository.getTournamentById(input.tournamentId);
+  if (!updatedTournament) throw new Error('No se pudo cargar el torneo actualizado');
+
+  return {
+    success: true,
+    teamId,
+    message: null,
+    tournament: toTournament(updatedTournament),
+  };
+}
+
+export const tournamentService = {
+  createTournament,
+  generateFixtureIfRegistrationComplete,
+  registerTournamentTeam,
+};

--- a/apps/backend/supabase/migrations/20260511000000_tournament_creation_policies.sql
+++ b/apps/backend/supabase/migrations/20260511000000_tournament_creation_policies.sql
@@ -1,0 +1,128 @@
+-- ==================== RLS Policies: tournaments + fixtureMatches ====================
+--
+-- Decision Context:
+-- - createTournament writes with the authenticated user's Supabase client so RLS
+--   enforces organizerId = auth.uid().
+-- - fixtureMatches are inserted immediately after the tournament to reserve the selected
+--   club times. The insert policy scopes those rows to tournaments owned by auth.uid().
+-- - SELECT is public because tournaments are discovery content, like public matches.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'tournaments'
+      AND policyname = 'tournaments_public_select'
+  ) THEN
+    EXECUTE 'CREATE POLICY "tournaments_public_select" ON public."tournaments" FOR SELECT TO public USING (true)';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'tournaments'
+      AND policyname = 'tournaments_insert_own'
+  ) THEN
+    EXECUTE 'CREATE POLICY "tournaments_insert_own" ON public."tournaments" FOR INSERT TO authenticated WITH CHECK ("organizerId" = auth.uid())';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'tournamentTeams'
+      AND policyname = 'tournament_teams_insert_captain'
+  ) THEN
+    EXECUTE 'CREATE POLICY "tournament_teams_insert_captain" ON public."tournamentTeams" FOR INSERT TO authenticated WITH CHECK ("captainId" = auth.uid())';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'tournaments'
+      AND policyname = 'tournaments_update_own'
+  ) THEN
+    EXECUTE 'CREATE POLICY "tournaments_update_own" ON public."tournaments" FOR UPDATE TO authenticated USING ("organizerId" = auth.uid()) WITH CHECK ("organizerId" = auth.uid())';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'tournamentTeamMembers'
+      AND policyname = 'tournament_team_members_insert_self_captain'
+  ) THEN
+    EXECUTE 'CREATE POLICY "tournament_team_members_insert_self_captain" ON public."tournamentTeamMembers" FOR INSERT TO authenticated WITH CHECK ("playerId" = auth.uid() AND EXISTS (SELECT 1 FROM public."tournamentTeams" tt WHERE tt.id = "teamId" AND tt."captainId" = auth.uid()))';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'fixtureMatches'
+      AND policyname = 'fixture_matches_public_select'
+  ) THEN
+    EXECUTE 'CREATE POLICY "fixture_matches_public_select" ON public."fixtureMatches" FOR SELECT TO public USING (true)';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'fixtureMatches'
+      AND policyname = 'fixture_matches_insert_own_tournament'
+  ) THEN
+    EXECUTE 'CREATE POLICY "fixture_matches_insert_own_tournament" ON public."fixtureMatches" FOR INSERT TO authenticated WITH CHECK (EXISTS (SELECT 1 FROM public."tournaments" t WHERE t.id = "tournamentId" AND t."organizerId" = auth.uid()))';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'fixtureMatches'
+      AND policyname = 'fixture_matches_update_own_tournament'
+  ) THEN
+    EXECUTE 'CREATE POLICY "fixture_matches_update_own_tournament" ON public."fixtureMatches" FOR UPDATE TO authenticated USING (EXISTS (SELECT 1 FROM public."tournaments" t WHERE t.id = "tournamentId" AND t."organizerId" = auth.uid())) WITH CHECK (EXISTS (SELECT 1 FROM public."tournaments" t WHERE t.id = "tournamentId" AND t."organizerId" = auth.uid()))';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'tournamentTeams'
+      AND policyname = 'tournament_teams_public_select'
+  ) THEN
+    EXECUTE 'CREATE POLICY "tournament_teams_public_select" ON public."tournamentTeams" FOR SELECT TO public USING (true)';
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'tournamentTeamMembers'
+      AND policyname = 'tournament_team_members_public_select'
+  ) THEN
+    EXECUTE 'CREATE POLICY "tournament_team_members_public_select" ON public."tournamentTeamMembers" FOR SELECT TO public USING (true)';
+  END IF;
+END;
+$$;

--- a/apps/backend/supabase/migrations/20260511010000_tournament_rpc_functions.sql
+++ b/apps/backend/supabase/migrations/20260511010000_tournament_rpc_functions.sql
@@ -1,0 +1,459 @@
+-- ==================== Tournament RPC functions ====================
+--
+-- Supabase usage:
+--   select public.create_tournament_with_fixture(
+--     '<club_id>'::uuid,
+--     'Copa Nocturna',
+--     '7v7'::"matchFormat",
+--     4,
+--     8,
+--     'Torneo abierto',
+--     '[{"slotId":"<slot_uuid>","date":"2026-05-20"}]'::jsonb
+--   );
+--
+--   select public.register_tournament_team('<tournament_id>'::uuid, 'Los Pibes');
+--
+-- Decision Context:
+-- - The app uses Supabase Auth. These functions read auth.uid(), so they are intended
+--   to be called as authenticated RPCs through Supabase/PostgREST or from the backend
+--   with the user's JWT.
+-- - SECURITY DEFINER is used so the complete operation can be atomic even when fixture
+--   generation is triggered by the captain that fills the last team slot. Every function
+--   performs explicit auth and business-rule checks before writing.
+-- - Existing tournament tables already come from the initial schema. This file adds
+--   RPC-level behavior and a small compatibility guard for clubSlots fields used by
+--   current booking flows.
+
+-- Compatibility for projects whose remote DB predates the slot-management columns.
+ALTER TABLE public."clubSlots"
+  ADD COLUMN IF NOT EXISTS "isActive" boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS "allowOnlineBooking" boolean NOT NULL DEFAULT true;
+
+CREATE OR REPLACE FUNCTION public.tournament_required_matches(team_count integer)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT (team_count * (team_count - 1)) / 2;
+$$;
+
+CREATE OR REPLACE FUNCTION public.tournament_day_of_week(slot_date date)
+RETURNS "dayOfWeek"
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE EXTRACT(DOW FROM slot_date)::int
+    WHEN 0 THEN 'sunday'::"dayOfWeek"
+    WHEN 1 THEN 'monday'::"dayOfWeek"
+    WHEN 2 THEN 'tuesday'::"dayOfWeek"
+    WHEN 3 THEN 'wednesday'::"dayOfWeek"
+    WHEN 4 THEN 'thursday'::"dayOfWeek"
+    WHEN 5 THEN 'friday'::"dayOfWeek"
+    WHEN 6 THEN 'saturday'::"dayOfWeek"
+  END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.generate_round_robin_fixture(p_tournament_id uuid)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_auth_uid uuid := auth.uid();
+  v_tournament record;
+  v_team_ids uuid[];
+  v_team_count integer;
+  v_participants uuid[];
+  v_participant_count integer;
+  v_rounds integer;
+  v_half integer;
+  v_round integer;
+  v_idx integer;
+  v_home uuid;
+  v_away uuid;
+  v_fixture_ids uuid[];
+  v_pair_index integer := 1;
+  v_updated integer := 0;
+BEGIN
+  IF v_auth_uid IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  SELECT *
+  INTO v_tournament
+  FROM public."tournaments"
+  WHERE id = p_tournament_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Torneo no encontrado';
+  END IF;
+
+  IF v_tournament.status <> 'registration'::"tournamentStatus" THEN
+    RETURN 0;
+  END IF;
+
+  IF v_tournament."organizerId" <> v_auth_uid
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public."tournamentTeams" tt
+      WHERE tt."tournamentId" = p_tournament_id
+        AND tt."captainId" = v_auth_uid
+    )
+  THEN
+    RAISE EXCEPTION 'No tenés permisos para generar el fixture de este torneo';
+  END IF;
+
+  SELECT array_agg(tt.id ORDER BY tt."createdAt", tt.id), count(*)
+  INTO v_team_ids, v_team_count
+  FROM public."tournamentTeams" tt
+  WHERE tt."tournamentId" = p_tournament_id;
+
+  IF COALESCE(v_team_count, 0) < v_tournament."teamCount" THEN
+    RETURN 0;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public."fixtureMatches" fm
+    WHERE fm."tournamentId" = p_tournament_id
+      AND (fm."homeTeamId" IS NOT NULL OR fm."awayTeamId" IS NOT NULL)
+  ) THEN
+    RETURN 0;
+  END IF;
+
+  SELECT array_agg(fm.id ORDER BY fm.round, fm."scheduledAt" NULLS LAST, fm."createdAt", fm.id)
+  INTO v_fixture_ids
+  FROM public."fixtureMatches" fm
+  WHERE fm."tournamentId" = p_tournament_id;
+
+  IF COALESCE(array_length(v_fixture_ids, 1), 0) < public.tournament_required_matches(v_tournament."teamCount") THEN
+    RAISE EXCEPTION 'El torneo no tiene suficientes horarios reservados para generar el fixture';
+  END IF;
+
+  v_participants := v_team_ids[1:v_tournament."teamCount"];
+  IF v_tournament."teamCount" % 2 = 1 THEN
+    v_participants := array_append(v_participants, NULL::uuid);
+  END IF;
+
+  v_participant_count := array_length(v_participants, 1);
+  v_rounds := v_participant_count - 1;
+  v_half := v_participant_count / 2;
+
+  FOR v_round IN 1..v_rounds LOOP
+    FOR v_idx IN 1..v_half LOOP
+      v_home := v_participants[v_idx];
+      v_away := v_participants[v_participant_count - v_idx + 1];
+
+      IF v_home IS NOT NULL AND v_away IS NOT NULL THEN
+        IF v_round % 2 = 0 THEN
+          UPDATE public."fixtureMatches"
+          SET "homeTeamId" = v_away,
+              "awayTeamId" = v_home
+          WHERE id = v_fixture_ids[v_pair_index];
+        ELSE
+          UPDATE public."fixtureMatches"
+          SET "homeTeamId" = v_home,
+              "awayTeamId" = v_away
+          WHERE id = v_fixture_ids[v_pair_index];
+        END IF;
+
+        v_pair_index := v_pair_index + 1;
+        v_updated := v_updated + 1;
+      END IF;
+    END LOOP;
+
+    IF v_participant_count > 2 THEN
+      v_participants :=
+        ARRAY[v_participants[1], v_participants[v_participant_count]]
+        || v_participants[2:v_participant_count - 1];
+    END IF;
+  END LOOP;
+
+  UPDATE public."tournaments"
+  SET status = 'in_progress'::"tournamentStatus"
+  WHERE id = p_tournament_id;
+
+  RETURN v_updated;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_tournament_with_fixture(
+  p_club_id uuid,
+  p_name text,
+  p_format "matchFormat",
+  p_team_count integer,
+  p_players_per_team integer,
+  p_description text,
+  p_schedule jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_auth_uid uuid := auth.uid();
+  v_required_matches integer;
+  v_matches_per_round integer;
+  v_tournament_id uuid;
+  v_start_date date;
+  v_end_date date;
+BEGIN
+  IF v_auth_uid IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF trim(COALESCE(p_name, '')) = '' OR char_length(trim(p_name)) < 3 THEN
+    RAISE EXCEPTION 'El nombre del torneo debe tener al menos 3 caracteres';
+  END IF;
+
+  IF p_team_count < 2 THEN
+    RAISE EXCEPTION 'El torneo debe tener al menos 2 equipos';
+  END IF;
+
+  IF p_players_per_team < 1 THEN
+    RAISE EXCEPTION 'Jugadores por equipo debe ser mayor a 0';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM public."clubs" c WHERE c.id = p_club_id) THEN
+    RAISE EXCEPTION 'Club no encontrado';
+  END IF;
+
+  v_required_matches := public.tournament_required_matches(p_team_count);
+  v_matches_per_round := floor(p_team_count / 2.0)::integer;
+
+  CREATE TEMP TABLE IF NOT EXISTS _tournament_schedule_input (
+    slot_id uuid NOT NULL,
+    slot_date date NOT NULL
+  ) ON COMMIT DROP;
+  TRUNCATE TABLE _tournament_schedule_input;
+
+  INSERT INTO _tournament_schedule_input (slot_id, slot_date)
+  SELECT raw."slotId"::uuid, raw."date"::date
+  FROM jsonb_to_recordset(p_schedule) AS raw("slotId" text, "date" text);
+
+  IF (SELECT count(*) FROM _tournament_schedule_input) < v_required_matches THEN
+    RAISE EXCEPTION 'Necesitás seleccionar % horarios para este round-robin', v_required_matches;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM _tournament_schedule_input tsi
+    GROUP BY tsi.slot_id, tsi.slot_date
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Hay horarios repetidos en el fixture del torneo';
+  END IF;
+
+  CREATE TEMP TABLE IF NOT EXISTS _tournament_schedule_validated (
+    row_no bigint NOT NULL,
+    slot_id uuid NOT NULL,
+    slot_date date NOT NULL,
+    court_id uuid NOT NULL,
+    scheduled_at timestamptz NOT NULL
+  ) ON COMMIT DROP;
+  TRUNCATE TABLE _tournament_schedule_validated;
+
+  INSERT INTO _tournament_schedule_validated (row_no, slot_id, slot_date, court_id, scheduled_at)
+  SELECT
+    row_number() OVER (ORDER BY tsi.slot_date, cs."startTime", cs.id) AS row_no,
+    cs.id,
+    tsi.slot_date,
+    cs."courtId",
+    (tsi.slot_date::text || 'T' || cs."startTime"::text)::timestamptz AS scheduled_at
+  FROM _tournament_schedule_input tsi
+  JOIN public."clubSlots" cs ON cs.id = tsi.slot_id
+  JOIN public."courts" c ON c.id = cs."courtId"
+  WHERE cs."clubId" = p_club_id
+    AND cs."isActive" = true
+    AND cs."isBlocked" = false
+    AND cs."allowOnlineBooking" = true
+    AND cs."dayOfWeek" = public.tournament_day_of_week(tsi.slot_date)
+    AND (CASE p_format
+      WHEN '5v5'::"matchFormat" THEN 1
+      WHEN '7v7'::"matchFormat" THEN 2
+      WHEN '10v10'::"matchFormat" THEN 3
+      WHEN '11v11'::"matchFormat" THEN 4
+    END) <= (CASE c."maxFormat"
+      WHEN '5v5'::"matchFormat" THEN 1
+      WHEN '7v7'::"matchFormat" THEN 2
+      WHEN '10v10'::"matchFormat" THEN 3
+      WHEN '11v11'::"matchFormat" THEN 4
+    END)
+    AND (tsi.slot_date::text || 'T' || cs."startTime"::text)::timestamptz > now();
+
+  IF (SELECT count(*) FROM _tournament_schedule_validated) < v_required_matches THEN
+    RAISE EXCEPTION 'Algunos horarios no existen, no pertenecen al club, están bloqueados o no son compatibles';
+  END IF;
+
+  DELETE FROM _tournament_schedule_validated
+  WHERE row_no > v_required_matches;
+
+  IF EXISTS (
+    SELECT 1
+    FROM _tournament_schedule_validated v
+    JOIN public."matches" m
+      ON m."clubSlotId" = v.slot_id
+     AND m.status <> 'cancelled'::"matchStatus"
+     AND m."scheduledAt"::date = v.slot_date
+  ) THEN
+    RAISE EXCEPTION 'Ya existe un partido en uno de los horarios seleccionados';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM _tournament_schedule_validated v
+    JOIN public."fixtureMatches" fm
+      ON fm."courtId" = v.court_id
+     AND fm.status <> 'cancelled'::"fixtureMatchStatus"
+     AND fm."scheduledAt"::date = v.slot_date
+     AND fm."scheduledAt"::time = v.scheduled_at::time
+  ) THEN
+    RAISE EXCEPTION 'Ya existe un fixture de torneo en uno de los horarios seleccionados';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_club_id::text, 0));
+
+  SELECT min(slot_date), max(slot_date)
+  INTO v_start_date, v_end_date
+  FROM _tournament_schedule_validated;
+
+  INSERT INTO public."tournaments" (
+    "organizerId",
+    "clubId",
+    name,
+    format,
+    "teamCount",
+    "playersPerTeam",
+    description,
+    "startDate",
+    "endDate"
+  )
+  VALUES (
+    v_auth_uid,
+    p_club_id,
+    trim(p_name),
+    p_format,
+    p_team_count,
+    p_players_per_team,
+    NULLIF(trim(COALESCE(p_description, '')), ''),
+    v_start_date,
+    v_end_date
+  )
+  RETURNING id INTO v_tournament_id;
+
+  INSERT INTO public."fixtureMatches" (
+    "tournamentId",
+    round,
+    "courtId",
+    "scheduledAt"
+  )
+  SELECT
+    v_tournament_id,
+    (((row_no - 1) / v_matches_per_round) + 1)::smallint,
+    court_id,
+    scheduled_at
+  FROM _tournament_schedule_validated
+  ORDER BY row_no;
+
+  RETURN v_tournament_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.register_tournament_team(
+  p_tournament_id uuid,
+  p_name text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_auth_uid uuid := auth.uid();
+  v_tournament record;
+  v_team_id uuid;
+  v_team_count integer;
+BEGIN
+  IF v_auth_uid IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF trim(COALESCE(p_name, '')) = '' OR char_length(trim(p_name)) < 2 THEN
+    RAISE EXCEPTION 'El nombre del equipo debe tener al menos 2 caracteres';
+  END IF;
+
+  SELECT *
+  INTO v_tournament
+  FROM public."tournaments"
+  WHERE id = p_tournament_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Torneo no encontrado';
+  END IF;
+
+  IF v_tournament.status <> 'registration'::"tournamentStatus" THEN
+    RAISE EXCEPTION 'La inscripción de este torneo ya está cerrada';
+  END IF;
+
+  SELECT count(*)
+  INTO v_team_count
+  FROM public."tournamentTeams"
+  WHERE "tournamentId" = p_tournament_id;
+
+  IF v_team_count >= v_tournament."teamCount" THEN
+    RAISE EXCEPTION 'El torneo ya completó todos sus cupos de equipos';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public."tournamentTeams"
+    WHERE "tournamentId" = p_tournament_id
+      AND lower(name) = lower(trim(p_name))
+  ) THEN
+    RAISE EXCEPTION 'Ya existe un equipo con ese nombre en el torneo';
+  END IF;
+
+  INSERT INTO public."tournamentTeams" ("tournamentId", name, "captainId")
+  VALUES (p_tournament_id, trim(p_name), v_auth_uid)
+  RETURNING id INTO v_team_id;
+
+  INSERT INTO public."tournamentTeamMembers" ("teamId", "playerId")
+  VALUES (v_team_id, v_auth_uid);
+
+  PERFORM public.generate_round_robin_fixture(p_tournament_id);
+
+  RETURN v_team_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.tournament_required_matches(integer) FROM public;
+REVOKE ALL ON FUNCTION public.tournament_day_of_week(date) FROM public;
+REVOKE ALL ON FUNCTION public.generate_round_robin_fixture(uuid) FROM public;
+REVOKE ALL ON FUNCTION public.create_tournament_with_fixture(
+  uuid,
+  text,
+  "matchFormat",
+  integer,
+  integer,
+  text,
+  jsonb
+) FROM public;
+REVOKE ALL ON FUNCTION public.register_tournament_team(uuid, text) FROM public;
+
+GRANT EXECUTE ON FUNCTION public.tournament_required_matches(integer) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.tournament_day_of_week(date) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.generate_round_robin_fixture(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_tournament_with_fixture(
+  uuid,
+  text,
+  "matchFormat",
+  integer,
+  integer,
+  text,
+  jsonb
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.register_tournament_team(uuid, text) TO authenticated;

--- a/apps/frontend/src/components/panel-club/ClubMobileNav.tsx
+++ b/apps/frontend/src/components/panel-club/ClubMobileNav.tsx
@@ -17,7 +17,7 @@
 import { useState } from 'react';
 import {
   Menu, X, LayoutDashboard, Calendar, Plus,
-  Volleyball, Users, Settings, BarChart3, LogOut,
+  Volleyball, Users, Settings, BarChart3, LogOut, Trophy,
 } from 'lucide-react';
 
 interface Props {
@@ -29,6 +29,7 @@ const NAV_LINKS = [
   { href: '/panel-club/dashboard', icon: LayoutDashboard, label: 'Dashboard', highlight: false },
   { href: '/panel-club/crear-partido', icon: Plus, label: 'Crear partido', highlight: true },
   { href: '/panel-club/horarios', icon: Calendar, label: 'Horarios', highlight: false },
+  { href: '/torneos/crear', icon: Trophy, label: 'Crear torneo', highlight: false },
 ];
 
 const PLACEHOLDER_LINKS = [

--- a/apps/frontend/src/components/panel-club/ClubSidebar.astro
+++ b/apps/frontend/src/components/panel-club/ClubSidebar.astro
@@ -17,7 +17,7 @@
  *     creation feature unreachable from navigation. Fixed by adding it here.
  */
 
-import { LayoutDashboard, Calendar, Plus, Volleyball, Users, Settings, BarChart3 } from 'lucide-react';
+import { LayoutDashboard, Calendar, Plus, Volleyball, Users, Settings, BarChart3, Trophy } from 'lucide-react';
 
 const { currentPath } = Astro.props;
 
@@ -52,6 +52,14 @@ function isActive(href: string): boolean {
       >
         <span class="sidebar-icon"><Calendar size={16} strokeWidth={2} aria-hidden="true" /></span>
         Horarios
+      </a>
+
+      <a
+        href="/torneos/crear"
+        class={`sidebar-link${isActive('/torneos/crear') ? ' sidebar-link--active' : ''}`}
+      >
+        <span class="sidebar-icon"><Trophy size={16} strokeWidth={2} aria-hidden="true" /></span>
+        Crear torneo
       </a>
 
       <a href="#" class="sidebar-link sidebar-link--placeholder">

--- a/apps/frontend/src/components/tournaments/create/CreateTournamentFlow.tsx
+++ b/apps/frontend/src/components/tournaments/create/CreateTournamentFlow.tsx
@@ -1,0 +1,887 @@
+/**
+ * CreateTournamentFlow - single-page tournament creation form.
+ *
+ * Decision Context:
+ * - Tournament creation is denser than match creation because the organizer must reserve
+ *   every fixture slot needed by the round-robin. A single screen keeps the arithmetic
+ *   visible while still behaving like a focused operational tool.
+ * - Club and slot data reuse the existing public GraphQL operations from matches.ts.
+ * - Submit goes through /api/graphql-auth so the HttpOnly auth cookie is forwarded.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  AlertCircle,
+  CalendarPlus,
+  Check,
+  Clock,
+  Loader2,
+  MapPin,
+  Plus,
+  Trash2,
+  Trophy,
+  Users,
+} from 'lucide-react';
+import {
+  GET_CLUB_SLOTS,
+  type ClubDetail,
+  type ClubSlot,
+  type MatchFormat,
+} from '../../../graphql/operations/matches';
+import {
+  CREATE_TOURNAMENT,
+  type CreateTournamentResult,
+} from '../../../graphql/operations/tournaments';
+
+interface Props {
+  initialClubs: ClubDetail[];
+  accessToken: string;
+  userName: string;
+  userRole: 'player' | 'club_admin';
+}
+
+interface SelectedFixtureSlot {
+  slotId: string;
+  date: string;
+  courtId: string;
+  courtName: string;
+  startTime: string;
+  endTime: string;
+}
+
+const FORMAT_LABEL: Record<MatchFormat, string> = {
+  FIVE_VS_FIVE: '5v5',
+  SEVEN_VS_SEVEN: '7v7',
+  TEN_VS_TEN: '10v10',
+  ELEVEN_VS_ELEVEN: '11v11',
+};
+
+const FORMAT_PLAYERS: Record<MatchFormat, number> = {
+  FIVE_VS_FIVE: 5,
+  SEVEN_VS_SEVEN: 7,
+  TEN_VS_TEN: 10,
+  ELEVEN_VS_ELEVEN: 11,
+};
+
+const ALL_FORMATS = Object.keys(FORMAT_LABEL) as MatchFormat[];
+
+function toLocalDateString(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function roundRobinShape(teamCount: number) {
+  const matchesPerRound = Math.floor(teamCount / 2);
+  const rounds = teamCount % 2 === 0 ? teamCount - 1 : teamCount;
+  return {
+    rounds,
+    matchesPerRound,
+    requiredMatches: rounds * matchesPerRound,
+  };
+}
+
+function formatDate(date: string) {
+  const [year, month, day] = date.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('es-AR', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  });
+}
+
+function sortSlots(slots: SelectedFixtureSlot[]) {
+  return [...slots].sort((a, b) =>
+    `${a.date}T${a.startTime}`.localeCompare(`${b.date}T${b.startTime}`),
+  );
+}
+
+const today = toLocalDateString(new Date());
+
+export default function CreateTournamentFlow({
+  initialClubs,
+  accessToken,
+  userName,
+  userRole,
+}: Props) {
+  const [name, setName] = useState('');
+  const [format, setFormat] = useState<MatchFormat>('SEVEN_VS_SEVEN');
+  const [teamCount, setTeamCount] = useState(4);
+  const [playersPerTeam, setPlayersPerTeam] = useState(8);
+  const [clubId, setClubId] = useState(initialClubs[0]?.id ?? '');
+  const [description, setDescription] = useState('');
+
+  const [slotDate, setSlotDate] = useState(today);
+  const [availableSlots, setAvailableSlots] = useState<ClubSlot[]>([]);
+  const [slotLoading, setSlotLoading] = useState(false);
+  const [slotError, setSlotError] = useState<string | null>(null);
+  const [selectedSlots, setSelectedSlots] = useState<SelectedFixtureSlot[]>([]);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [created, setCreated] = useState<CreateTournamentResult | null>(null);
+
+  const selectedClub = initialClubs.find((club) => club.id === clubId) ?? null;
+  const shape = useMemo(() => roundRobinShape(teamCount), [teamCount]);
+  const sortedSelected = useMemo(() => sortSlots(selectedSlots), [selectedSlots]);
+  const remainingSlots = Math.max(0, shape.requiredMatches - selectedSlots.length);
+  const completion = Math.min(100, Math.round((selectedSlots.length / shape.requiredMatches) * 100));
+
+  useEffect(() => {
+    setSelectedSlots((prev) => sortSlots(prev).slice(0, shape.requiredMatches));
+  }, [shape.requiredMatches]);
+
+  useEffect(() => {
+    if (!clubId) {
+      setAvailableSlots([]);
+      return;
+    }
+
+    setSlotLoading(true);
+    setSlotError(null);
+
+    fetch('/api/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: GET_CLUB_SLOTS,
+        variables: { clubId, date: slotDate },
+      }),
+    })
+      .then((response) => response.json())
+      .then((payload: { data?: { clubSlots: ClubSlot[] }; errors?: Array<{ message: string }> }) => {
+        if (payload.errors?.length) {
+          setSlotError(payload.errors[0].message);
+          setAvailableSlots([]);
+          return;
+        }
+        setAvailableSlots(payload.data?.clubSlots ?? []);
+      })
+      .catch(() => {
+        setSlotError('No se pudieron cargar los horarios');
+        setAvailableSlots([]);
+      })
+      .finally(() => setSlotLoading(false));
+  }, [clubId, slotDate]);
+
+  function handleFormatChange(nextFormat: MatchFormat) {
+    setFormat(nextFormat);
+    setPlayersPerTeam((current) => Math.max(current, FORMAT_PLAYERS[nextFormat]));
+  }
+
+  function handleClubChange(nextClubId: string) {
+    setClubId(nextClubId);
+    setSelectedSlots([]);
+  }
+
+  function addSlot(slot: ClubSlot) {
+    if (selectedSlots.length >= shape.requiredMatches) return;
+
+    const alreadySelected = selectedSlots.some(
+      (selected) => selected.slotId === slot.id && selected.date === slotDate,
+    );
+    if (alreadySelected) return;
+
+    setSelectedSlots((prev) =>
+      sortSlots([
+        ...prev,
+        {
+          slotId: slot.id,
+          date: slotDate,
+          courtId: slot.court.id,
+          courtName: slot.court.name,
+          startTime: slot.startTime,
+          endTime: slot.endTime,
+        },
+      ]),
+    );
+  }
+
+  function removeSlot(slotId: string, date: string) {
+    setSelectedSlots((prev) =>
+      prev.filter((selected) => !(selected.slotId === slotId && selected.date === date)),
+    );
+  }
+
+  const rounds = useMemo(() => {
+    const groups: SelectedFixtureSlot[][] = [];
+    for (let i = 0; i < shape.rounds; i++) {
+      groups.push(
+        sortedSelected.slice(i * shape.matchesPerRound, (i + 1) * shape.matchesPerRound),
+      );
+    }
+    return groups;
+  }, [shape.matchesPerRound, shape.rounds, sortedSelected]);
+
+  const canSubmit =
+    name.trim().length >= 3 &&
+    !!clubId &&
+    teamCount >= 2 &&
+    playersPerTeam >= 1 &&
+    selectedSlots.length === shape.requiredMatches &&
+    !submitting;
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const response = await fetch('/api/graphql-auth', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+        body: JSON.stringify({
+          query: CREATE_TOURNAMENT,
+          variables: {
+            input: {
+              clubId,
+              name: name.trim(),
+              format,
+              teamCount,
+              playersPerTeam,
+              description: description.trim() || null,
+              schedule: sortedSelected.map((slot) => ({ slotId: slot.slotId, date: slot.date })),
+            },
+          },
+        }),
+      });
+
+      const payload = (await response.json()) as {
+        data?: { createTournament?: CreateTournamentResult };
+        errors?: Array<{ message: string }>;
+      };
+
+      if (payload.errors?.length) {
+        throw new Error(payload.errors[0].message);
+      }
+
+      const result = payload.data?.createTournament;
+      if (!result) throw new Error('Respuesta inesperada del servidor');
+      if (!result.success) {
+        throw new Error(result.message ?? 'No se pudo crear el torneo');
+      }
+
+      setCreated(result);
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Error al crear el torneo');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function resetForm() {
+    setName('');
+    setDescription('');
+    setSelectedSlots([]);
+    setCreated(null);
+    setSubmitError(null);
+  }
+
+  if (created?.success) {
+    return (
+      <section className="tournament-shell">
+        <div className="success-panel">
+          <div className="success-mark">
+            <Check size={30} strokeWidth={2.5} aria-hidden="true" />
+          </div>
+          <p className="eyebrow">TORNEO CREADO</p>
+          <h2>{created.tournament?.name ?? 'Torneo'}</h2>
+          <p className="success-copy">
+            Se reservaron {created.tournament?.fixtureMatches.length ?? shape.requiredMatches} partidos del fixture.
+          </p>
+          <div className="success-actions">
+            <button type="button" className="btn-primary" onClick={resetForm}>
+              Crear otro torneo
+            </button>
+            <a className="btn-secondary" href={userRole === 'club_admin' ? '/panel-club/dashboard' : '/partidos'}>
+              Volver
+            </a>
+          </div>
+        </div>
+        <style>{styles}</style>
+      </section>
+    );
+  }
+
+  return (
+    <section className="tournament-shell">
+      <div className="tournament-main">
+        <div className="form-surface">
+          <div className="surface-heading">
+            <div>
+              <p className="eyebrow">ORGANIZADOR</p>
+              <h2>Nuevo torneo</h2>
+            </div>
+            <span className="organizer-pill">{userName}</span>
+          </div>
+
+          <div className="field-grid">
+            <label className="field field-wide">
+              <span>Nombre</span>
+              <input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                maxLength={120}
+                placeholder="Copa nocturna"
+              />
+            </label>
+
+            <label className="field field-wide">
+              <span>Club</span>
+              <select value={clubId} onChange={(event) => handleClubChange(event.target.value)}>
+                {initialClubs.map((club) => (
+                  <option key={club.id} value={club.id}>
+                    {club.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className="field field-wide">
+              <span>Formato</span>
+              <div className="format-row">
+                {ALL_FORMATS.map((value) => (
+                  <button
+                    type="button"
+                    key={value}
+                    className={`format-chip${format === value ? ' format-chip--active' : ''}`}
+                    onClick={() => handleFormatChange(value)}
+                  >
+                    {FORMAT_LABEL[value]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <label className="field">
+              <span>Equipos</span>
+              <input
+                type="number"
+                min={2}
+                max={8}
+                value={teamCount}
+                onChange={(event) => setTeamCount(Math.max(2, Math.min(8, Number(event.target.value))))}
+              />
+            </label>
+
+            <label className="field">
+              <span>Jugadores por equipo</span>
+              <input
+                type="number"
+                min={1}
+                max={30}
+                value={playersPerTeam}
+                onChange={(event) => setPlayersPerTeam(Math.max(1, Math.min(30, Number(event.target.value))))}
+              />
+            </label>
+
+            <label className="field field-wide">
+              <span>Descripción</span>
+              <textarea
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                maxLength={700}
+                rows={3}
+                placeholder="Premios, categoría, detalles de inscripción..."
+              />
+            </label>
+          </div>
+
+          <div className="metrics-row">
+            <div className="metric">
+              <Trophy size={17} strokeWidth={2} aria-hidden="true" />
+              <strong>{shape.rounds}</strong>
+              <span>jornadas</span>
+            </div>
+            <div className="metric">
+              <Users size={17} strokeWidth={2} aria-hidden="true" />
+              <strong>{shape.requiredMatches}</strong>
+              <span>partidos</span>
+            </div>
+            <div className="metric">
+              <Clock size={17} strokeWidth={2} aria-hidden="true" />
+              <strong>{remainingSlots}</strong>
+              <span>horarios faltan</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="form-surface">
+          <div className="surface-heading">
+            <div>
+              <p className="eyebrow">FIXTURE</p>
+              <h2>Horarios</h2>
+            </div>
+            <span className="count-pill">{selectedSlots.length}/{shape.requiredMatches}</span>
+          </div>
+
+          <div className="slot-toolbar">
+            <label className="field compact-date">
+              <span>Fecha</span>
+              <input
+                type="date"
+                value={slotDate}
+                min={today}
+                onChange={(event) => setSlotDate(event.target.value)}
+              />
+            </label>
+            {selectedClub && (
+              <div className="club-chip">
+                <MapPin size={14} strokeWidth={2} aria-hidden="true" />
+                {selectedClub.name}
+              </div>
+            )}
+          </div>
+
+          {slotLoading && (
+            <div className="inline-state">
+              <Loader2 className="spin" size={18} strokeWidth={2} aria-hidden="true" />
+              Cargando horarios...
+            </div>
+          )}
+          {slotError && (
+            <div className="inline-state error" role="alert">
+              <AlertCircle size={18} strokeWidth={2} aria-hidden="true" />
+              {slotError}
+            </div>
+          )}
+          {!slotLoading && !slotError && availableSlots.length === 0 && (
+            <div className="inline-state">No hay horarios disponibles para esta fecha.</div>
+          )}
+
+          <div className="slot-grid">
+            {availableSlots.map((slot) => {
+              const selected = selectedSlots.some((item) => item.slotId === slot.id && item.date === slotDate);
+              const full = selectedSlots.length >= shape.requiredMatches && !selected;
+              return (
+                <button
+                  type="button"
+                  key={slot.id}
+                  className={`slot-option${selected ? ' slot-option--selected' : ''}`}
+                  disabled={full}
+                  onClick={() => addSlot(slot)}
+                >
+                  <span className="slot-time">{slot.startTime.slice(0, 5)}-{slot.endTime.slice(0, 5)}</span>
+                  <span className="slot-court">{slot.court.name}</span>
+                  <span className="slot-format">hasta {FORMAT_LABEL[slot.court.maxFormat]}</span>
+                  {selected && <Check size={16} strokeWidth={2.5} aria-hidden="true" />}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="progress-wrap" aria-hidden="true">
+            <div style={{ width: `${completion}%` }} />
+          </div>
+
+          <div className="rounds-list">
+            {rounds.map((roundSlots, index) => (
+              <div className="round-row" key={index}>
+                <div className="round-title">Jornada {index + 1}</div>
+                <div className="round-slots">
+                  {roundSlots.length === 0 && <span className="empty-slot">Sin horarios</span>}
+                  {roundSlots.map((slot) => (
+                    <span className="selected-slot" key={`${slot.slotId}-${slot.date}`}>
+                      <CalendarPlus size={13} strokeWidth={2} aria-hidden="true" />
+                      {formatDate(slot.date)} {slot.startTime.slice(0, 5)}
+                      <button
+                        type="button"
+                        onClick={() => removeSlot(slot.slotId, slot.date)}
+                        aria-label="Quitar horario"
+                      >
+                        <Trash2 size={12} strokeWidth={2} aria-hidden="true" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {submitError && (
+            <div className="submit-error" role="alert">
+              <AlertCircle size={17} strokeWidth={2} aria-hidden="true" />
+              {submitError}
+            </div>
+          )}
+
+          <div className="submit-row">
+            <button type="button" className="btn-primary" onClick={handleSubmit} disabled={!canSubmit}>
+              {submitting ? (
+                <>
+                  <Loader2 className="spin" size={16} strokeWidth={2} aria-hidden="true" />
+                  Creando...
+                </>
+              ) : (
+                <>
+                  <Plus size={16} strokeWidth={2.5} aria-hidden="true" />
+                  Crear torneo
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <style>{styles}</style>
+    </section>
+  );
+}
+
+const styles = `
+  .tournament-shell { width: 100%; }
+  .tournament-main {
+    display: grid;
+    grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1.1fr);
+    gap: 1.25rem;
+    align-items: start;
+  }
+  .form-surface, .success-panel {
+    background: hsl(220 55% 10%);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 12px;
+    padding: 1.25rem;
+    box-shadow: 0 8px 26px rgba(0,0,0,0.22);
+  }
+  .surface-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+  .eyebrow {
+    margin: 0 0 0.2rem;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    color: hsl(42 100% 60%);
+  }
+  h2 {
+    margin: 0;
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.55rem;
+    font-weight: 400;
+    letter-spacing: 0.04em;
+    color: #fff;
+    line-height: 1;
+  }
+  .organizer-pill, .count-pill, .club-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border-radius: 999px;
+    border: 1px solid rgba(246,164,0,0.24);
+    background: rgba(246,164,0,0.1);
+    color: hsl(42 100% 65%);
+    padding: 0.25rem 0.7rem;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+  }
+  .field-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.85rem;
+  }
+  .field { display: flex; flex-direction: column; gap: 0.32rem; }
+  .field-wide { grid-column: 1 / -1; }
+  .field span {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: hsl(215 20% 52%);
+  }
+  .field input, .field select, .field textarea {
+    width: 100%;
+    background: hsl(220 35% 14%);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 8px;
+    color: hsl(210 20% 92%);
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.9rem;
+    padding: 0.58rem 0.72rem;
+    outline: none;
+    transition: border-color 0.12s, background 0.12s;
+  }
+  .field textarea { resize: vertical; min-height: 84px; }
+  .field input:focus, .field select:focus, .field textarea:focus {
+    border-color: rgba(246,164,0,0.48);
+    background: hsl(220 35% 16%);
+  }
+  .field select option { background: hsl(220 55% 10%); }
+  .format-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.45rem; }
+  .format-chip {
+    min-height: 40px;
+    border-radius: 8px;
+    border: 1px solid rgba(255,255,255,0.1);
+    background: rgba(255,255,255,0.04);
+    color: hsl(215 20% 64%);
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+  }
+  .format-chip--active {
+    background: rgba(246,164,0,0.14);
+    border-color: rgba(246,164,0,0.38);
+    color: hsl(42 100% 66%);
+  }
+  .metrics-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.6rem;
+    margin-top: 1rem;
+  }
+  .metric {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.05rem 0.45rem;
+    align-items: center;
+    background: rgba(255,255,255,0.035);
+    border: 1px solid rgba(255,255,255,0.07);
+    border-radius: 10px;
+    padding: 0.7rem;
+    color: hsl(42 100% 62%);
+  }
+  .metric strong {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.35rem;
+    color: #fff;
+    line-height: 1;
+  }
+  .metric span {
+    grid-column: 1 / -1;
+    color: hsl(215 20% 50%);
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.76rem;
+  }
+  .slot-toolbar {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.8rem;
+  }
+  .compact-date { max-width: 180px; }
+  .inline-state {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 48px;
+    color: hsl(215 20% 55%);
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.88rem;
+  }
+  .inline-state.error { color: hsl(0 72% 66%); }
+  .slot-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(156px, 1fr));
+    gap: 0.55rem;
+  }
+  .slot-option {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.1rem 0.4rem;
+    text-align: left;
+    min-height: 74px;
+    border-radius: 9px;
+    border: 1px solid rgba(255,255,255,0.08);
+    background: rgba(255,255,255,0.035);
+    padding: 0.65rem 0.72rem;
+    color: hsl(210 20% 86%);
+    cursor: pointer;
+    transition: border-color 0.12s, background 0.12s;
+  }
+  .slot-option:hover:not(:disabled) {
+    border-color: rgba(255,255,255,0.18);
+    background: rgba(255,255,255,0.06);
+  }
+  .slot-option:disabled { opacity: 0.42; cursor: not-allowed; }
+  .slot-option--selected {
+    border-color: rgba(246,164,0,0.5);
+    background: rgba(246,164,0,0.11);
+  }
+  .slot-time {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.22rem;
+    letter-spacing: 0.04em;
+    color: #fff;
+  }
+  .slot-court {
+    grid-column: 1 / -1;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.82rem;
+    color: hsl(215 20% 66%);
+  }
+  .slot-format {
+    grid-column: 1 / -1;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: hsl(216 85% 66%);
+    text-transform: uppercase;
+  }
+  .progress-wrap {
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.06);
+    overflow: hidden;
+    margin: 1rem 0;
+  }
+  .progress-wrap div {
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, hsl(35 100% 48%), hsl(142 70% 45%));
+    transition: width 0.18s ease;
+  }
+  .rounds-list { display: flex; flex-direction: column; gap: 0.45rem; }
+  .round-row {
+    display: grid;
+    grid-template-columns: 88px 1fr;
+    gap: 0.65rem;
+    align-items: start;
+    padding: 0.55rem 0;
+    border-top: 1px solid rgba(255,255,255,0.06);
+  }
+  .round-title {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: hsl(42 100% 62%);
+    text-transform: uppercase;
+  }
+  .round-slots { display: flex; flex-wrap: wrap; gap: 0.38rem; }
+  .empty-slot {
+    color: hsl(215 20% 38%);
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.8rem;
+  }
+  .selected-slot {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.32rem;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.055);
+    border: 1px solid rgba(255,255,255,0.08);
+    color: hsl(210 20% 78%);
+    padding: 0.24rem 0.34rem 0.24rem 0.55rem;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.78rem;
+  }
+  .selected-slot button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: hsl(215 20% 50%);
+    cursor: pointer;
+  }
+  .selected-slot button:hover {
+    background: rgba(239,68,68,0.12);
+    color: hsl(0 72% 65%);
+  }
+  .submit-error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.9rem;
+    border: 1px solid rgba(239,68,68,0.24);
+    background: rgba(239,68,68,0.1);
+    color: hsl(0 72% 68%);
+    border-radius: 9px;
+    padding: 0.7rem 0.85rem;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.86rem;
+  }
+  .submit-row {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1rem;
+  }
+  .btn-primary, .btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.42rem;
+    min-height: 42px;
+    border-radius: 8px;
+    padding: 0.62rem 1.15rem;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-decoration: none;
+    cursor: pointer;
+  }
+  .btn-primary {
+    border: 0;
+    background: hsl(35 100% 48%);
+    color: hsl(220 72% 7%);
+  }
+  .btn-primary:hover:not(:disabled) { background: hsl(35 100% 55%); }
+  .btn-primary:disabled { opacity: 0.45; cursor: not-allowed; }
+  .btn-secondary {
+    border: 1px solid rgba(255,255,255,0.12);
+    background: rgba(255,255,255,0.05);
+    color: hsl(210 20% 82%);
+  }
+  .spin { animation: spin 0.8s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .success-panel {
+    max-width: 560px;
+    margin: 0 auto;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.85rem;
+  }
+  .success-mark {
+    display: inline-flex;
+    width: 64px;
+    height: 64px;
+    border-radius: 999px;
+    align-items: center;
+    justify-content: center;
+    color: hsl(142 70% 52%);
+    background: rgba(34,197,94,0.14);
+    border: 1px solid rgba(34,197,94,0.28);
+  }
+  .success-panel h2 { font-size: 2rem; }
+  .success-copy {
+    margin: 0;
+    color: hsl(215 20% 58%);
+    font-family: 'Barlow', sans-serif;
+  }
+  .success-actions { display: flex; gap: 0.65rem; flex-wrap: wrap; justify-content: center; }
+  @media (max-width: 920px) {
+    .tournament-main { grid-template-columns: 1fr; }
+  }
+  @media (max-width: 560px) {
+    .form-surface { padding: 1rem; border-radius: 10px; }
+    .field-grid, .metrics-row { grid-template-columns: 1fr; }
+    .format-row { grid-template-columns: repeat(2, 1fr); }
+    .slot-toolbar { align-items: stretch; flex-direction: column; }
+    .compact-date { max-width: 100%; }
+    .round-row { grid-template-columns: 1fr; gap: 0.35rem; }
+    .submit-row, .btn-primary, .btn-secondary { width: 100%; }
+    .success-actions { width: 100%; flex-direction: column; }
+  }
+`;

--- a/apps/frontend/src/graphql/operations/tournaments.graphql
+++ b/apps/frontend/src/graphql/operations/tournaments.graphql
@@ -1,0 +1,59 @@
+# Tournament creation
+
+mutation CreateTournament($input: CreateTournamentInput!) {
+  createTournament(input: $input) {
+    success
+    tournamentId
+    message
+    tournament {
+      id
+      organizerId
+      name
+      format
+      teamCount
+      playersPerTeam
+      status
+      description
+      startDate
+      endDate
+      createdAt
+      club {
+        id
+        name
+        zone
+        address
+        imageUrl
+      }
+      fixtureMatches {
+        id
+        tournamentId
+        round
+        homeTeamId
+        awayTeamId
+        courtId
+        scheduledAt
+        status
+      }
+    }
+  }
+}
+
+mutation RegisterTournamentTeam($input: RegisterTournamentTeamInput!) {
+  registerTournamentTeam(input: $input) {
+    success
+    teamId
+    message
+    tournament {
+      id
+      status
+      fixtureMatches {
+        id
+        round
+        homeTeamId
+        awayTeamId
+        scheduledAt
+        status
+      }
+    }
+  }
+}

--- a/apps/frontend/src/graphql/operations/tournaments.ts
+++ b/apps/frontend/src/graphql/operations/tournaments.ts
@@ -1,0 +1,143 @@
+/**
+ * Tournament GraphQL operations.
+ *
+ * Decision Context:
+ * - Kept as a TS companion to the .graphql file because this app currently imports
+ *   operation strings directly from React islands.
+ * - MatchFormat is shared with matches.ts so tournament creation uses the same enum
+ *   contract as match creation.
+ */
+
+import type { MatchFormat } from './matches';
+
+export type TournamentStatus = 'REGISTRATION' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+export type FixtureMatchStatus = 'SCHEDULED' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+
+export interface TournamentScheduleSlotInput {
+  slotId: string;
+  date: string;
+}
+
+export interface CreateTournamentInput {
+  clubId: string;
+  name: string;
+  format: MatchFormat;
+  teamCount: number;
+  playersPerTeam: number;
+  description?: string | null;
+  schedule: TournamentScheduleSlotInput[];
+}
+
+export interface TournamentFixtureMatch {
+  id: string;
+  tournamentId: string;
+  round: number;
+  homeTeamId: string | null;
+  awayTeamId: string | null;
+  courtId: string | null;
+  scheduledAt: string | null;
+  status: FixtureMatchStatus;
+}
+
+export interface TournamentData {
+  id: string;
+  organizerId: string;
+  name: string;
+  format: MatchFormat;
+  teamCount: number;
+  playersPerTeam: number;
+  status: TournamentStatus;
+  description: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  createdAt: string;
+  club: {
+    id: string;
+    name: string;
+    zone: string | null;
+    address: string | null;
+    imageUrl: string | null;
+  } | null;
+  fixtureMatches: TournamentFixtureMatch[];
+}
+
+export interface CreateTournamentResult {
+  success: boolean;
+  tournamentId: string | null;
+  message: string | null;
+  tournament: TournamentData | null;
+}
+
+export interface RegisterTournamentTeamInput {
+  tournamentId: string;
+  name: string;
+}
+
+export interface TournamentTeamRegistrationResult {
+  success: boolean;
+  teamId: string | null;
+  message: string | null;
+  tournament: TournamentData | null;
+}
+
+export const CREATE_TOURNAMENT = /* GraphQL */ `
+  mutation CreateTournament($input: CreateTournamentInput!) {
+    createTournament(input: $input) {
+      success
+      tournamentId
+      message
+      tournament {
+        id
+        organizerId
+        name
+        format
+        teamCount
+        playersPerTeam
+        status
+        description
+        startDate
+        endDate
+        createdAt
+        club {
+          id
+          name
+          zone
+          address
+          imageUrl
+        }
+        fixtureMatches {
+          id
+          tournamentId
+          round
+          homeTeamId
+          awayTeamId
+          courtId
+          scheduledAt
+          status
+        }
+      }
+    }
+  }
+`;
+
+export const REGISTER_TOURNAMENT_TEAM = /* GraphQL */ `
+  mutation RegisterTournamentTeam($input: RegisterTournamentTeamInput!) {
+    registerTournamentTeam(input: $input) {
+      success
+      teamId
+      message
+      tournament {
+        id
+        status
+        fixtureMatches {
+          id
+          round
+          homeTeamId
+          awayTeamId
+          scheduledAt
+          status
+        }
+      }
+    }
+  }
+`;

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -42,7 +42,7 @@ import {
 } from './lib/auth';
 
 /** Rutas que requieren autenticación */
-const PROTECTED_ROUTES: string[] = ['/panel-club', '/perfil', '/partidos/crear'];
+const PROTECTED_ROUTES: string[] = ['/panel-club', '/perfil', '/partidos/crear', '/torneos/crear'];
 
 /** Rutas restringidas por rol: sólo accesibles para el rol indicado */
 const ROLE_RESTRICTED: Record<string, UserRole> = {

--- a/apps/frontend/src/pages/partidos/crear.astro
+++ b/apps/frontend/src/pages/partidos/crear.astro
@@ -61,6 +61,7 @@ try {
         </div>
         <div class="topbar-actions">
           <a href="/partidos" class="nav-link">Partidos</a>
+          <a href="/torneos/crear" class="nav-link">Crear torneo</a>
           <a href="/perfil" class="nav-link">Mi Perfil</a>
           <span class="user-badge">
             <span class="user-dot"></span>

--- a/apps/frontend/src/pages/partidos/index.astro
+++ b/apps/frontend/src/pages/partidos/index.astro
@@ -35,6 +35,7 @@ const nombre = user?.displayName || user?.email;
               {user?.role === 'player' && (
                 <a href="/partidos/crear" class="btn-crear">+ Crear partido</a>
               )}
+              <a href="/torneos/crear" class="btn-torneo">Crear torneo</a>
               {user?.role === 'club_admin' && (
                 <a href="/panel-club" class="btn-panel-club">Panel de Club</a>
               )}
@@ -184,6 +185,25 @@ const nombre = user?.displayName || user?.email;
     background: hsl(35 100% 55%);
   }
 
+  .btn-torneo {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    text-decoration: none;
+    padding: 0.35rem 0.875rem;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: hsl(210 20% 84%);
+    transition: background 0.15s, color 0.15s;
+  }
+  .btn-torneo:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+  }
+
   /* ---- User badge ---- */
   .user-badge {
     display: flex;
@@ -280,7 +300,7 @@ const nombre = user?.displayName || user?.email;
   @media (max-width: 767px) {
     .topbar-inner { padding: 0 1rem; }
     /* Hide secondary nav actions on mobile — keep only login/logout */
-    .btn-crear, .btn-panel-club, .nav-link { display: none; }
+    .btn-crear, .btn-torneo, .btn-panel-club, .nav-link { display: none; }
     /* Truncate user badge on mobile */
     .user-badge {
       max-width: 120px;

--- a/apps/frontend/src/pages/torneos/crear.astro
+++ b/apps/frontend/src/pages/torneos/crear.astro
@@ -1,0 +1,240 @@
+---
+/**
+ * /torneos/crear - authenticated tournament creation page.
+ *
+ * Decision Context:
+ * - Both players and club_admins may create tournaments, so the page is auth-only with
+ *   no role gate.
+ * - Clubs are prefetched SSR for a fast first paint; slot availability stays client-side
+ *   because it depends on the chosen date.
+ * - accessToken is passed to the React island so createTournament can call the authenticated
+ *   GraphQL proxy.
+ */
+export const prerender = false;
+
+import { Trophy, Volleyball } from 'lucide-react';
+import Layout from '../../layouts/Layout.astro';
+import CreateTournamentFlow from '../../components/tournaments/create/CreateTournamentFlow';
+import { ACCESS_TOKEN_COOKIE } from '../../lib/auth';
+import { GET_CLUBS, type ClubDetail } from '../../graphql/operations/matches';
+
+const user = Astro.locals.user;
+
+if (!user) {
+  return Astro.redirect('/login');
+}
+
+const accessToken = Astro.cookies.get(ACCESS_TOKEN_COOKIE)?.value ?? '';
+const backendUrl =
+  import.meta.env.PRIVATE_BACKEND_URL ||
+  (typeof process !== 'undefined' ? process.env.PRIVATE_BACKEND_URL : undefined) ||
+  'http://localhost:4000';
+
+let clubs: ClubDetail[] = [];
+try {
+  const res = await fetch(`${backendUrl}/graphql`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    },
+    body: JSON.stringify({ query: GET_CLUBS }),
+  });
+  const json = (await res.json()) as { data?: { clubs: ClubDetail[] }; errors?: unknown[] };
+  clubs = json.data?.clubs ?? [];
+} catch (error) {
+  console.error('[torneos/crear] Failed to pre-fetch clubs:', error);
+}
+
+const displayName = user.displayName || user.email;
+const backHref = user.role === 'club_admin' ? '/panel-club/dashboard' : '/partidos';
+---
+
+<Layout title="Crear Torneo - Sumate Ya">
+  <div class="app-shell">
+    <nav class="topbar">
+      <div class="topbar-inner">
+        <a class="topbar-brand" href={backHref}>
+          <span class="topbar-ball"><Volleyball size={20} strokeWidth={2} aria-hidden="true" /></span>
+          <span class="topbar-name">SUMATE YA</span>
+        </a>
+        <div class="topbar-actions">
+          <a href="/partidos" class="nav-link">Partidos</a>
+          {user.role === 'club_admin' && <a href="/panel-club/dashboard" class="nav-link">Panel</a>}
+          {user.role === 'player' && <a href="/perfil" class="nav-link">Mi Perfil</a>}
+          <span class="user-badge">
+            <span class="user-dot"></span>
+            {displayName}
+          </span>
+          <form method="POST" action="/api/auth/logout">
+            <button type="submit" class="btn-logout">Salir</button>
+          </form>
+        </div>
+      </div>
+      <div class="topbar-accent"></div>
+    </nav>
+
+    <main class="page-content">
+      <header class="section-header">
+        <div class="section-label">
+          <Trophy size={15} strokeWidth={2} aria-hidden="true" />
+          TORNEOS
+        </div>
+        <h1 class="section-title">Crear Torneo</h1>
+        <p class="section-sub">Round-robin con horarios reservados desde el inicio</p>
+      </header>
+
+      {clubs.length > 0 ? (
+        <CreateTournamentFlow
+          client:load
+          initialClubs={clubs}
+          accessToken={accessToken}
+          userName={displayName}
+          userRole={user.role}
+        />
+      ) : (
+        <section class="empty-state" role="status">
+          <h2>No hay clubes disponibles</h2>
+          <p>Cuando haya clubes cargados vas a poder reservar horarios para torneos.</p>
+        </section>
+      )}
+    </main>
+  </div>
+</Layout>
+
+<style>
+  .app-shell { min-height: 100vh; display: flex; flex-direction: column; }
+  .topbar {
+    position: sticky; top: 0; z-index: 50;
+    background: rgba(7,15,31,0.85);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+  }
+  .topbar-inner {
+    max-width: 1280px; margin: 0 auto;
+    height: 56px; padding: 0 1.25rem;
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .topbar-brand {
+    display: flex; align-items: center; gap: 0.5rem;
+    text-decoration: none;
+  }
+  .topbar-ball { display: inline-flex; color: hsl(42 100% 60%); }
+  .topbar-name {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.35rem;
+    letter-spacing: 0.1em;
+    color: #fff;
+  }
+  .topbar-actions { display: flex; align-items: center; gap: 0.75rem; }
+  .topbar-accent {
+    height: 2px;
+    background: linear-gradient(90deg, hsl(42 100% 55%), hsl(216 85% 45%), transparent);
+  }
+  .nav-link {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: hsl(215 20% 65%);
+    padding: 0.3rem 0.6rem;
+    border-radius: 6px;
+  }
+  .nav-link:hover { background: rgba(255,255,255,0.06); color: hsl(210 20% 92%); }
+  .user-badge {
+    display: flex; align-items: center; gap: 0.4rem;
+    background: rgba(246,164,0,0.1);
+    border: 1px solid rgba(246,164,0,0.24);
+    color: hsl(42 100% 65%);
+    border-radius: 20px;
+    padding: 0.25rem 0.875rem;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+  }
+  .user-dot {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: hsl(42 100% 58%);
+    box-shadow: 0 0 4px hsl(42 100% 58%);
+  }
+  .btn-logout {
+    background: transparent;
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 6px;
+    padding: 0.3rem 0.75rem;
+    color: hsl(215 20% 60%);
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.8125rem;
+    cursor: pointer;
+  }
+  .btn-logout:hover { background: rgba(255,255,255,0.07); color: hsl(210 20% 90%); }
+  .page-content {
+    flex: 1;
+    width: 100%;
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 2rem 1.25rem 3rem;
+  }
+  .section-header {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.25rem;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+  }
+  .section-label {
+    display: inline-flex; align-items: center; gap: 0.4rem;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    color: hsl(42 100% 55%);
+    margin-bottom: 0.5rem;
+  }
+  .section-title {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: clamp(1.8rem, 5vw, 2.7rem);
+    font-weight: 400;
+    letter-spacing: 0.04em;
+    color: #fff;
+    margin: 0 0 0.35rem;
+    line-height: 1;
+  }
+  .section-sub {
+    margin: 0;
+    color: hsl(215 20% 50%);
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.92rem;
+  }
+  .empty-state {
+    max-width: 520px;
+    background: hsl(220 55% 10%);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 12px;
+    padding: 1.5rem;
+  }
+  .empty-state h2 {
+    margin: 0 0 0.5rem;
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.5rem;
+    color: #fff;
+  }
+  .empty-state p {
+    margin: 0;
+    color: hsl(215 20% 55%);
+    font-family: 'Barlow', sans-serif;
+  }
+  @media (max-width: 767px) {
+    .topbar-actions .nav-link { display: none; }
+    .topbar-inner { padding: 0 1rem; }
+    .user-badge {
+      max-width: 130px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      padding: 0.25rem 0.625rem;
+    }
+    .page-content { padding: 1.25rem 1rem 2rem; }
+  }
+</style>


### PR DESCRIPTION
- agrega pantalla /torneos/crear para crear torneos desde jugador o club admin
- incorpora mutation GraphQL createTournament y registro de equipos
- valida formato, cantidad mínima de equipos, horarios y disponibilidad del club
- genera reservas en fixtureMatches y fixture round-robin al completar inscripción
- agrega migraciones SQL/RPC de Supabase para crear torneos respetando RLS
- suma accesos de navegación desde partidos y panel de club