### PR TITLE
feat: Implement privacy settings for user profiles

### DIFF
--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -491,6 +491,7 @@ export type Mutation = {
   toggleSlotBlock: ClubSlotMutationResult;
   updateClubSlot: ClubSlotMutationResult;
   updateCourtPricing: CourtPricingMutationResult;
+  updatePrivacy: PrivacySettings;
   voteMatchResult: VoteSubmissionResult;
 };
 
@@ -565,6 +566,11 @@ export type MutationUpdateCourtPricingArgs = {
 };
 
 
+export type MutationUpdatePrivacyArgs = {
+  input: UpdatePrivacyInput;
+};
+
+
 export type MutationVoteMatchResultArgs = {
   input: VoteMatchResultInput;
 };
@@ -576,14 +582,24 @@ export enum PlayerPosition {
   Midfielder = 'MIDFIELDER'
 }
 
+export type PrivacySettings = {
+  __typename?: 'PrivacySettings';
+  isPublic: Scalars['Boolean']['output'];
+  showDivision: Scalars['Boolean']['output'];
+  showHistory: Scalars['Boolean']['output'];
+  showPosition: Scalars['Boolean']['output'];
+  showStats: Scalars['Boolean']['output'];
+};
+
 export type Profile = {
   __typename?: 'Profile';
   avatarUrl?: Maybe<Scalars['String']['output']>;
   displayName: Scalars['String']['output'];
-  division: Scalars['Int']['output'];
+  division?: Maybe<Scalars['Int']['output']>;
   id: Scalars['ID']['output'];
-  matchesPlayed: Scalars['Int']['output'];
-  matchesWon: Scalars['Int']['output'];
+  isPrivate?: Maybe<Scalars['Boolean']['output']>;
+  matchesPlayed?: Maybe<Scalars['Int']['output']>;
+  matchesWon?: Maybe<Scalars['Int']['output']>;
   preferredPosition?: Maybe<PlayerPosition>;
   role: UserRole;
   winrate?: Maybe<Scalars['Float']['output']>;
@@ -619,6 +635,8 @@ export type Query = {
   myClubSlots: Array<ManagedClubSlot>;
   myMatches: MatchHistoryConnection;
   myProfile: Profile;
+  mySettings: PrivacySettings;
+  profile?: Maybe<Profile>;
   slotAuditLog: Array<SlotAuditLog>;
   slotImpactPreview: SlotImpactPreview;
 };
@@ -674,6 +692,11 @@ export type QueryMatchesArgs = {
 export type QueryMyMatchesArgs = {
   page?: InputMaybe<Scalars['Int']['input']>;
   pageSize?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryProfileArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -851,6 +874,14 @@ export type UpdateCourtPricingInput = {
   peakStart?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type UpdatePrivacyInput = {
+  isPublic?: InputMaybe<Scalars['Boolean']['input']>;
+  showDivision?: InputMaybe<Scalars['Boolean']['input']>;
+  showHistory?: InputMaybe<Scalars['Boolean']['input']>;
+  showPosition?: InputMaybe<Scalars['Boolean']['input']>;
+  showStats?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
 export enum UserRole {
   ClubAdmin = 'CLUB_ADMIN',
   Player = 'PLAYER'
@@ -1006,6 +1037,7 @@ export type ResolversTypes = ResolversObject<{
   MatchUserResult: MatchUserResult;
   Mutation: ResolverTypeWrapper<Record<PropertyKey, never>>;
   PlayerPosition: PlayerPosition;
+  PrivacySettings: ResolverTypeWrapper<PrivacySettings>;
   Profile: ResolverTypeWrapper<Profile>;
   ProfileSummary: ResolverTypeWrapper<ProfileSummary>;
   ProposeMatchResultInput: ProposeMatchResultInput;
@@ -1028,6 +1060,7 @@ export type ResolversTypes = ResolversObject<{
   TournamentTeamRegistrationResult: ResolverTypeWrapper<TournamentTeamRegistrationResult>;
   UpdateClubSlotInput: UpdateClubSlotInput;
   UpdateCourtPricingInput: UpdateCourtPricingInput;
+  UpdatePrivacyInput: UpdatePrivacyInput;
   UserRole: UserRole;
   VoteMatchResultInput: VoteMatchResultInput;
   VoteSubmissionResult: ResolverTypeWrapper<VoteSubmissionResult>;
@@ -1083,6 +1116,7 @@ export type ResolversParentTypes = ResolversObject<{
   MatchResultSubmission: MatchResultSubmission;
   MatchResultVote: MatchResultVote;
   Mutation: Record<PropertyKey, never>;
+  PrivacySettings: PrivacySettings;
   Profile: Profile;
   ProfileSummary: ProfileSummary;
   ProposeMatchResultInput: ProposeMatchResultInput;
@@ -1100,6 +1134,7 @@ export type ResolversParentTypes = ResolversObject<{
   TournamentTeamRegistrationResult: TournamentTeamRegistrationResult;
   UpdateClubSlotInput: UpdateClubSlotInput;
   UpdateCourtPricingInput: UpdateCourtPricingInput;
+  UpdatePrivacyInput: UpdatePrivacyInput;
   VoteMatchResultInput: VoteMatchResultInput;
   VoteSubmissionResult: VoteSubmissionResult;
 }>;
@@ -1404,16 +1439,26 @@ export type MutationResolvers<ContextType = GraphQLContext, ParentType extends R
   toggleSlotBlock?: Resolver<ResolversTypes['ClubSlotMutationResult'], ParentType, ContextType, RequireFields<MutationToggleSlotBlockArgs, 'input'>>;
   updateClubSlot?: Resolver<ResolversTypes['ClubSlotMutationResult'], ParentType, ContextType, RequireFields<MutationUpdateClubSlotArgs, 'input'>>;
   updateCourtPricing?: Resolver<ResolversTypes['CourtPricingMutationResult'], ParentType, ContextType, RequireFields<MutationUpdateCourtPricingArgs, 'input'>>;
+  updatePrivacy?: Resolver<ResolversTypes['PrivacySettings'], ParentType, ContextType, RequireFields<MutationUpdatePrivacyArgs, 'input'>>;
   voteMatchResult?: Resolver<ResolversTypes['VoteSubmissionResult'], ParentType, ContextType, RequireFields<MutationVoteMatchResultArgs, 'input'>>;
+}>;
+
+export type PrivacySettingsResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['PrivacySettings'] = ResolversParentTypes['PrivacySettings']> = ResolversObject<{
+  isPublic?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  showDivision?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  showHistory?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  showPosition?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  showStats?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
 }>;
 
 export type ProfileResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Profile'] = ResolversParentTypes['Profile']> = ResolversObject<{
   avatarUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  division?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  division?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  matchesPlayed?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  matchesWon?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  isPrivate?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  matchesPlayed?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  matchesWon?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   preferredPosition?: Resolver<Maybe<ResolversTypes['PlayerPosition']>, ParentType, ContextType>;
   role?: Resolver<ResolversTypes['UserRole'], ParentType, ContextType>;
   winrate?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
@@ -1440,6 +1485,8 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   myClubSlots?: Resolver<Array<ResolversTypes['ManagedClubSlot']>, ParentType, ContextType>;
   myMatches?: Resolver<ResolversTypes['MatchHistoryConnection'], ParentType, ContextType, Partial<QueryMyMatchesArgs>>;
   myProfile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
+  mySettings?: Resolver<ResolversTypes['PrivacySettings'], ParentType, ContextType>;
+  profile?: Resolver<Maybe<ResolversTypes['Profile']>, ParentType, ContextType, RequireFields<QueryProfileArgs, 'id'>>;
   slotAuditLog?: Resolver<Array<ResolversTypes['SlotAuditLog']>, ParentType, ContextType, RequireFields<QuerySlotAuditLogArgs, 'slotId'>>;
   slotImpactPreview?: Resolver<ResolversTypes['SlotImpactPreview'], ParentType, ContextType, RequireFields<QuerySlotImpactPreviewArgs, 'slotIds'>>;
 }>;
@@ -1564,6 +1611,7 @@ export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   MatchResultSubmission?: MatchResultSubmissionResolvers<ContextType>;
   MatchResultVote?: MatchResultVoteResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
+  PrivacySettings?: PrivacySettingsResolvers<ContextType>;
   Profile?: ProfileResolvers<ContextType>;
   ProfileSummary?: ProfileSummaryResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;

--- a/apps/backend/src/graphql/resolvers/domains/profile.ts
+++ b/apps/backend/src/graphql/resolvers/domains/profile.ts
@@ -1,25 +1,27 @@
 /**
- * Profile Resolver — GraphQL resolvers for Profile queries
+ * Profile Resolver — GraphQL resolvers for Profile queries and privacy mutations
  *
  * Decision Context:
- * - Why: Lives under `resolvers/domains/` per backend.md MANDATORY resolver layout.
- * - Auth: `myProfile` requires auth — we call `requireAuth(context)` which throws a
- *   clean "Authentication required" error if the JWT was absent/invalid. The frontend
- *   SSR page catches this and redirects to /login.
- * - RLS: we build a user-scoped Supabase client from `context.accessToken` and pass it
- *   through `ServiceContext.supabase`. This lets the RLS policy on `profiles` verify
- *   `auth.uid()` against the requested row. Using the singleton service client here
- *   would bypass RLS and break the defense-in-depth posture required by backend.md.
- * - Thin resolver: no data shaping lives here — service/repo own the DB contract and
- *   the service owns winrate computation. Keep this file as a 1:1 mapping from GraphQL
- *   fields to service calls.
+ * - Lives under `resolvers/domains/` per backend.md MANDATORY resolver layout.
+ * - myProfile: requires auth — owner always sees all their own fields, no privacy filter.
+ * - profile(id): uses getProfile(id, requesterId) which applies field-level privacy
+ *   filtering when the requester is not the profile owner. Auth required so we always
+ *   have a requesterId; anonymous callers cannot access profile data.
+ * - mySettings: requires auth — returns the caller's own PrivacySettings (isPublic,
+ *   showStats, showHistory, showPosition, showDivision).
+ * - updatePrivacy: requires auth + user-scoped client (RLS UPDATE policy). Zod
+ *   validation lives in the service layer (messages in Spanish).
+ * - Thin resolvers: no data shaping here — service owns all business logic.
  * - Previously fixed bugs: none relevant.
  */
 
 import { createUserClient } from '../../../config/supabase.js';
 import { profileService } from '../../../services/profileService.js';
 import { requireAuth } from '../../../types/context.js';
-import type { QueryResolvers } from '../../generated/graphql.js';
+import type {
+  MutationResolvers,
+  QueryResolvers,
+} from '../../generated/graphql.js';
 
 const Query: QueryResolvers = {
   myProfile: async (_parent, _args, context) => {
@@ -33,6 +35,46 @@ const Query: QueryResolvers = {
       supabase: userClient,
     });
   },
+
+  profile: async (_parent, args, context) => {
+    const user = requireAuth(context);
+    return profileService.getProfile(args.id as string, user.id);
+  },
+
+  mySettings: async (_parent, _args, context) => {
+    const user = requireAuth(context);
+    const userClient = context.accessToken
+      ? createUserClient(context.accessToken)
+      : undefined;
+
+    return profileService.getMySettings({
+      userId: user.id,
+      supabase: userClient,
+    });
+  },
 };
 
-export const profileResolvers = { Query };
+const Mutation: MutationResolvers = {
+  updatePrivacy: async (_parent, args, context) => {
+    const user = requireAuth(context);
+    const userClient = context.accessToken
+      ? createUserClient(context.accessToken)
+      : undefined;
+
+    // Strip null values from InputMaybe<boolean> — service expects boolean | undefined
+    const input = {
+      isPublic: args.input.isPublic ?? undefined,
+      showStats: args.input.showStats ?? undefined,
+      showHistory: args.input.showHistory ?? undefined,
+      showPosition: args.input.showPosition ?? undefined,
+      showDivision: args.input.showDivision ?? undefined,
+    };
+
+    return profileService.updatePrivacy(input, {
+      userId: user.id,
+      supabase: userClient,
+    });
+  },
+};
+
+export const profileResolvers = { Query, Mutation };

--- a/apps/backend/src/graphql/resolvers/index.ts
+++ b/apps/backend/src/graphql/resolvers/index.ts
@@ -32,6 +32,7 @@ export const resolvers = {
   Mutation: {
     ...matchResolvers.Mutation,
     ...matchResultResolvers.Mutation,
+    ...profileResolvers.Mutation,
     ...clubSlotResolvers.Mutation,
     ...clubMatchResolvers.Mutation,
     ...tournamentResolvers.Mutation,

--- a/apps/backend/src/graphql/schema/profile.graphql
+++ b/apps/backend/src/graphql/schema/profile.graphql
@@ -1,12 +1,17 @@
-# GraphQL Schema: Profile type and myProfile query
+# GraphQL Schema: Profile type, privacy settings, and profile queries/mutations
 #
 # Decision Context:
-# - Why: Player-facing profile page needs a self-scoped query (`myProfile`) instead of a
-#   public `profile(id)` so the resolver can enforce auth + RLS via the caller's JWT.
-# - Why Int for `division`: DB column is smallint; keeping it as Int here avoids exposing
-#   a made-up enum that would drift from the DB default (1) without a migration.
-# - `winrate` is Float? and nullable: a player with 0 matches has no meaningful winrate,
-#   so we surface `null` instead of a misleading 0.0.
+# - Why: Player-facing profile page needs a self-scoped query (`myProfile`) and a public
+#   query (`profile(id)`) that respects privacy settings at the service layer.
+# - Privacy model: fields are nullable when the requester is NOT the profile owner AND
+#   the owner has disabled that field via their privacy settings. The backend service
+#   applies the filter — RLS allows all authenticated users to SELECT any profile row,
+#   but only the backend knows which columns to redact.
+# - profile(id) vs myProfile: `myProfile` always returns all fields (owner sees everything).
+#   `profile(id)` applies privacy filters when the requester != owner.
+# - PrivacySettings is only accessible by the owner (`mySettings` requires auth).
+# - `isPublic` is not exposed on Profile to visitors — inferring it from a null response
+#   would leak the same info, so visitors just see nulls on private fields.
 # - Previously fixed bugs: none relevant.
 
 # User role enum (mirrors DB enum "userRole": player | club_admin)
@@ -24,20 +29,60 @@ enum PlayerPosition {
 }
 
 # A player or club-admin profile linked to auth.users
+# Fields marked nullable may be null when viewed by another user and the owner
+# has disabled that field via their privacy settings.
 type Profile {
   id: ID!
   displayName: String!
   avatarUrl: String
   role: UserRole!
+  # Null if owner set showPosition = false and requester != owner
   preferredPosition: PlayerPosition
-  division: Int!
-  matchesPlayed: Int!
-  matchesWon: Int!
-  # Win percentage 0-100 with 2 decimals, or null when matchesPlayed = 0
+  # Null if owner set showDivision = false and requester != owner
+  division: Int
+  # Null if owner set showStats = false and requester != owner
+  matchesPlayed: Int
+  # Null if owner set showStats = false and requester != owner
+  matchesWon: Int
+  # Null if owner set showStats = false or matchesPlayed = 0 and requester != owner
   winrate: Float
+  # True when this profile is private and the requester is not the owner
+  isPrivate: Boolean
+}
+
+# Granular privacy settings — visible only to the profile owner via mySettings
+type PrivacySettings {
+  isPublic: Boolean!
+  showStats: Boolean!
+  showHistory: Boolean!
+  showPosition: Boolean!
+  showDivision: Boolean!
+}
+
+# Input for updatePrivacy mutation — all fields optional (partial update)
+input UpdatePrivacyInput {
+  isPublic: Boolean
+  showStats: Boolean
+  showHistory: Boolean
+  showPosition: Boolean
+  showDivision: Boolean
 }
 
 extend type Query {
-  # Returns the authenticated user's profile. Auth required.
+  # Returns the authenticated user's own profile (all fields, no privacy filter).
+  # Auth required.
   myProfile: Profile!
+
+  # Returns another player's public profile, respecting their privacy settings.
+  # Fields may be null if the owner disabled them. Auth required.
+  profile(id: ID!): Profile
+
+  # Returns the authenticated user's current privacy settings. Auth required.
+  mySettings: PrivacySettings!
+}
+
+extend type Mutation {
+  # Updates the authenticated user's privacy settings. Auth required.
+  # At least one field must be provided.
+  updatePrivacy(input: UpdatePrivacyInput!): PrivacySettings!
 }

--- a/apps/backend/src/repositories/profileRepository.ts
+++ b/apps/backend/src/repositories/profileRepository.ts
@@ -1,17 +1,24 @@
 /**
- * Profile Repository — DB access for the `profiles` table
+ * Profile Repository — DB access for the `profiles` and `privacyAuditLog` tables
  *
  * Decision Context:
- * - Why: Explicit column list (PROFILE_COLUMNS) enforces backend.md egress-prevention rule
- *   "NEVER use select('*')". Future additions to the DB schema won't silently grow the
- *   response size until a field is added here intentionally.
- * - Accepts an optional `client` argument so the myProfile resolver can pass a user-scoped
- *   Supabase client — RLS policies on `profiles` must be able to verify auth.uid().
- * - camelCase identifiers are quoted because the DB uses quoted-camelCase naming (backend.md
- *   "Database (Supabase)" rule). Unquoted identifiers would be lowercased by Postgres and
- *   fail to match columns like "displayName".
+ * - Why: Explicit column lists (PROFILE_COLUMNS, PROFILE_WITH_PRIVACY_COLUMNS) enforce
+ *   backend.md egress-prevention rule "NEVER use select('*')".
+ * - Privacy columns (showStats, showHistory, showPosition, showDivision, isPublic) are
+ *   fetched in PROFILE_WITH_PRIVACY_COLUMNS — used for both own-profile reads and for
+ *   reads of other users' profiles where the service must apply privacy filtering.
+ * - getProfileById: lightweight fetch without privacy flags — used for myProfile (owner
+ *   always sees everything, no need to fetch privacy flags for filtering).
+ * - getProfileWithPrivacy: includes all privacy flags — used when fetching another user's
+ *   profile so the service can decide which fields to redact.
+ * - updatePrivacyFields: updates privacy columns + sets privacyUpdatedAt automatically.
+ *   Uses the service-role singleton (writes go through the resolver with ownership check).
+ * - insertPrivacyAuditLog: records each privacy change. The singleton supabase client is
+ *   used here because the backend writes on behalf of the user; the owner check happens
+ *   in the service (userId must match the authenticated caller's ID).
  * - PGRST116 is Supabase's not-found code on `.single()`; we translate to `null` so the
  *   service can decide whether missing profile is a real error or an edge case.
+ * - camelCase identifiers are quoted because DB uses quoted-camelCase naming.
  * - Previously fixed bugs: none relevant.
  */
 
@@ -32,6 +39,30 @@ const PROFILE_COLUMNS = `
   "matchesWon"
 `;
 
+const PROFILE_WITH_PRIVACY_COLUMNS = `
+  id,
+  "displayName",
+  "avatarUrl",
+  role,
+  "preferredPosition",
+  division,
+  "matchesPlayed",
+  "matchesWon",
+  "isPublic",
+  "showStats",
+  "showHistory",
+  "showPosition",
+  "showDivision"
+`;
+
+const PRIVACY_SETTINGS_COLUMNS = `
+  "isPublic",
+  "showStats",
+  "showHistory",
+  "showPosition",
+  "showDivision"
+`;
+
 // =====================================================
 // Types
 // =====================================================
@@ -45,6 +76,30 @@ export interface ProfileRow {
   division: number;
   matchesPlayed: number;
   matchesWon: number;
+}
+
+export interface ProfileWithPrivacyRow extends ProfileRow {
+  isPublic: boolean;
+  showStats: boolean;
+  showHistory: boolean;
+  showPosition: boolean;
+  showDivision: boolean;
+}
+
+export interface PrivacySettingsRow {
+  isPublic: boolean;
+  showStats: boolean;
+  showHistory: boolean;
+  showPosition: boolean;
+  showDivision: boolean;
+}
+
+export interface UpdatePrivacyFields {
+  isPublic?: boolean;
+  showStats?: boolean;
+  showHistory?: boolean;
+  showPosition?: boolean;
+  showDivision?: boolean;
 }
 
 // =====================================================
@@ -73,6 +128,90 @@ export async function getProfileById(
   }
 
   return data as unknown as ProfileRow;
+}
+
+/**
+ * Fetches a profile including all privacy flags.
+ * Used when reading another user's profile to apply service-layer privacy filtering.
+ * Uses the service-role singleton to bypass RLS (ownership enforced at service layer).
+ */
+export async function getProfileWithPrivacy(
+  id: string,
+  client: SupabaseClient = supabase,
+): Promise<ProfileWithPrivacyRow | null> {
+  const { data, error } = await client
+    .from('profiles')
+    .select(PROFILE_WITH_PRIVACY_COLUMNS)
+    .eq('id', id)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    console.error(
+      `[profileRepository.getProfileWithPrivacy] Supabase error for profileId=${id}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return data as unknown as ProfileWithPrivacyRow;
+}
+
+/**
+ * Fetches only the privacy settings for a given profile.
+ * Used by mySettings resolver — owner-only.
+ */
+export async function getPrivacySettings(
+  userId: string,
+  client: SupabaseClient = supabase,
+): Promise<PrivacySettingsRow | null> {
+  const { data, error } = await client
+    .from('profiles')
+    .select(PRIVACY_SETTINGS_COLUMNS)
+    .eq('id', userId)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    console.error(
+      `[profileRepository.getPrivacySettings] Supabase error for userId=${userId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+
+  return data as unknown as PrivacySettingsRow;
+}
+
+/**
+ * Updates privacy fields for a given profile.
+ * Sets privacyUpdatedAt to now() automatically.
+ * Uses the user-scoped client so RLS UPDATE policy enforces auth.uid() = id.
+ */
+export async function updatePrivacyFields(
+  userId: string,
+  fields: UpdatePrivacyFields,
+  client: SupabaseClient = supabase,
+): Promise<void> {
+  const { error } = await client
+    .from('profiles')
+    .update({
+      ...fields,
+      privacyUpdatedAt: new Date().toISOString(),
+    })
+    .eq('id', userId);
+
+  if (error) {
+    console.error(
+      `[profileRepository.updatePrivacyFields] Supabase error for userId=${userId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
 }
 
 /**
@@ -105,7 +244,37 @@ export async function updateAvatarUrl(
   }
 }
 
+/**
+ * Inserts a privacy audit log entry.
+ * Uses the singleton (service-role) because the privacyAuditLog INSERT policy
+ * requires auth.uid() = userId, which is enforced at the service layer before calling here.
+ */
+export async function insertPrivacyAuditLog(
+  userId: string,
+  previousSettings: PrivacySettingsRow,
+  newSettings: PrivacySettingsRow,
+): Promise<void> {
+  const { error } = await supabase.from('privacyAuditLog').insert({
+    userId,
+    previousSettings,
+    newSettings,
+  });
+
+  if (error) {
+    console.error(
+      `[profileRepository.insertPrivacyAuditLog] Supabase error for userId=${userId}:`,
+      error.message,
+    );
+    // Non-critical: audit log failure should not block the main operation
+    console.warn('[profileRepository.insertPrivacyAuditLog] Audit log write failed — continuing');
+  }
+}
+
 export const profileRepository = {
   getProfileById,
+  getProfileWithPrivacy,
+  getPrivacySettings,
+  updatePrivacyFields,
   updateAvatarUrl,
+  insertPrivacyAuditLog,
 };

--- a/apps/backend/src/services/profileService.ts
+++ b/apps/backend/src/services/profileService.ts
@@ -1,32 +1,61 @@
 /**
- * Profile Service — business logic for player profiles
+ * Profile Service — business logic for player profiles and privacy settings
  *
  * Decision Context:
- * - Why: Services return data only (backend.md). Winrate is computed here, not in the DB,
- *   because `matchesWon` / `matchesPlayed` counters already live on the row and a DB
- *   generated column would not gracefully represent the null-when-zero case.
- * - Caching: TTL = USER_DATA (5 min) matches backend.md guidance "player profiles 5m".
- *   Cache key is scoped per user (`profile:me:<userId>`) so each JWT gets its own entry.
- *   When a mutation lands that updates stats (join match, record result), it MUST call
- *   `cacheDelete(${CACHE_PREFIX.PROFILE_ME}${userId})` to avoid stale stats.
- * - RLS: the service uses `ctx.supabase ?? supabase` so the user-scoped client (created in
- *   the resolver from the caller's JWT) is used for DB reads. The fallback to the singleton
- *   is defensive — `myProfile` always requires auth and the resolver always passes
- *   `ctx.supabase`, but backend.md mandates the pattern for consistency with future services.
- * - Winrate formula: (won / played) * 100, rounded to 2 decimals, or null when played = 0.
- *   Rounding uses Number(fixed(2)) so GraphQL Float stays numeric instead of a string.
+ * - Privacy model (getProfile): when requesterId !== profileId, the service applies
+ *   field-level filtering based on the profile owner's privacy flags:
+ *     · isPublic=false  → only id, displayName, avatarUrl, role; isPrivate=true
+ *     · showStats=false → matchesPlayed, matchesWon, winrate all return null
+ *     · showPosition=false → preferredPosition returns null
+ *     · showDivision=false → division returns null
+ *   The owner always sees all fields (requesterId === profileId path bypasses filtering).
+ * - Why filter in the service and not via RLS: PostgreSQL RLS cannot filter individual
+ *   columns, only rows. A row-level filter on isPublic would let visitors infer privacy
+ *   from a missing row. The backend column-filter approach prevents that information leak.
+ * - Caching: profile:me:<userId> is cached at TTL.USER_DATA (5 min). When privacy
+ *   settings change, we invalidate both the me-cache and the public profile cache.
+ * - updatePrivacy: validates at service layer (Zod), writes with the user-scoped client
+ *   so the RLS UPDATE policy enforces auth.uid() = id. Records an audit log entry after
+ *   a successful update. Invalidates Redis caches so stale data is not served.
+ * - winrate computation: moved into a shared helper to keep both toOwnProfile and
+ *   toPublicProfile consistent.
  * - Previously fixed bugs: none relevant.
  */
 
-import { cacheGetOrSet, CACHE_PREFIX, CACHE_TTL } from '../config/redis.js';
+import { z } from 'zod';
+import { cacheDelete, cacheGetOrSet, CACHE_PREFIX, CACHE_TTL } from '../config/redis.js';
 import { supabase } from '../config/supabase.js';
 import {
   PlayerPosition,
   UserRole,
+  type PrivacySettings,
   type Profile,
 } from '../graphql/generated/graphql.js';
-import { profileRepository, type ProfileRow } from '../repositories/profileRepository.js';
+import {
+  profileRepository,
+  type ProfileRow,
+  type ProfileWithPrivacyRow,
+  type PrivacySettingsRow,
+  type UpdatePrivacyFields,
+} from '../repositories/profileRepository.js';
 import type { ServiceContext } from '../types/context.js';
+
+// =====================================================
+// Validation
+// =====================================================
+
+const UpdatePrivacySchema = z
+  .object({
+    isPublic: z.boolean().optional(),
+    showStats: z.boolean().optional(),
+    showHistory: z.boolean().optional(),
+    showPosition: z.boolean().optional(),
+    showDivision: z.boolean().optional(),
+  })
+  .refine(
+    (data) => Object.values(data).some((v) => v !== undefined),
+    { message: 'Debés proporcionar al menos un campo para actualizar' },
+  );
 
 // =====================================================
 // Enum Mapping (DB -> GraphQL)
@@ -45,16 +74,15 @@ const DB_TO_POSITION: Record<string, PlayerPosition> = {
 };
 
 // =====================================================
-// Data Transformation
+// Data Transformation Helpers
 // =====================================================
 
 function computeWinrate(matchesWon: number, matchesPlayed: number): number | null {
   if (matchesPlayed <= 0) return null;
-  const rate = (matchesWon / matchesPlayed) * 100;
-  return Number(rate.toFixed(2));
+  return Number(((matchesWon / matchesPlayed) * 100).toFixed(2));
 }
 
-function toProfile(row: ProfileRow): Profile {
+function toOwnProfile(row: ProfileRow): Profile {
   return {
     id: row.id,
     displayName: row.displayName,
@@ -67,6 +95,49 @@ function toProfile(row: ProfileRow): Profile {
     matchesPlayed: row.matchesPlayed,
     matchesWon: row.matchesWon,
     winrate: computeWinrate(row.matchesWon, row.matchesPlayed),
+    isPrivate: false,
+  };
+}
+
+function toPublicProfile(row: ProfileWithPrivacyRow): Profile {
+  if (!row.isPublic) {
+    return {
+      id: row.id,
+      displayName: row.displayName,
+      avatarUrl: row.avatarUrl,
+      role: DB_TO_ROLE[row.role] ?? UserRole.Player,
+      preferredPosition: null,
+      division: null,
+      matchesPlayed: null,
+      matchesWon: null,
+      winrate: null,
+      isPrivate: true,
+    };
+  }
+
+  return {
+    id: row.id,
+    displayName: row.displayName,
+    avatarUrl: row.avatarUrl,
+    role: DB_TO_ROLE[row.role] ?? UserRole.Player,
+    preferredPosition: row.showPosition && row.preferredPosition
+      ? (DB_TO_POSITION[row.preferredPosition] ?? null)
+      : null,
+    division: row.showDivision ? row.division : null,
+    matchesPlayed: row.showStats ? row.matchesPlayed : null,
+    matchesWon: row.showStats ? row.matchesWon : null,
+    winrate: row.showStats ? computeWinrate(row.matchesWon, row.matchesPlayed) : null,
+    isPrivate: false,
+  };
+}
+
+function toPrivacySettings(row: PrivacySettingsRow): PrivacySettings {
+  return {
+    isPublic: row.isPublic,
+    showStats: row.showStats,
+    showHistory: row.showHistory,
+    showPosition: row.showPosition,
+    showDivision: row.showDivision,
   };
 }
 
@@ -75,13 +146,12 @@ function toProfile(row: ProfileRow): Profile {
 // =====================================================
 
 /**
- * Returns the authenticated user's profile. Requires `ctx.userId` and should be called
- * with a user-scoped Supabase client for RLS enforcement.
+ * Returns the authenticated user's own profile (all fields, no privacy filtering).
  */
 export async function getMyProfile(ctx: ServiceContext): Promise<Profile> {
   if (!ctx.userId) {
     console.warn('[profileService.getMyProfile] Called without userId');
-    throw new Error('Authentication required');
+    throw new Error('Autenticación requerida');
   }
 
   const db = ctx.supabase ?? supabase;
@@ -95,22 +165,133 @@ export async function getMyProfile(ctx: ServiceContext): Promise<Profile> {
     );
 
     if (!row) {
-      console.warn(
-        `[profileService.getMyProfile] Profile not found for userId=${ctx.userId}`,
-      );
-      throw new Error('Profile not found');
+      console.warn(`[profileService.getMyProfile] Profile not found for userId=${ctx.userId}`);
+      throw new Error('Perfil no encontrado');
     }
 
-    return toProfile(row);
+    return toOwnProfile(row);
+  } catch (error) {
+    console.error(`[profileService.getMyProfile] Failed for userId=${ctx.userId}:`, error);
+    throw error instanceof Error ? error : new Error('Error al obtener el perfil');
+  }
+}
+
+/**
+ * Returns another user's profile, applying privacy filtering.
+ * If requesterId === profileId, returns all fields (same as myProfile).
+ */
+export async function getProfile(
+  profileId: string,
+  requesterId: string | null,
+): Promise<Profile | null> {
+  try {
+    if (requesterId === profileId) {
+      const row = await profileRepository.getProfileById(profileId);
+      if (!row) return null;
+      return toOwnProfile(row);
+    }
+
+    const cacheKey = `profile:public:${profileId}`;
+    const row = await cacheGetOrSet<ProfileWithPrivacyRow | null>(
+      cacheKey,
+      () => profileRepository.getProfileWithPrivacy(profileId),
+      CACHE_TTL.USER_DATA,
+    );
+
+    if (!row) return null;
+    return toPublicProfile(row);
   } catch (error) {
     console.error(
-      `[profileService.getMyProfile] Failed for userId=${ctx.userId}:`,
+      `[profileService.getProfile] Failed for profileId=${profileId}, requesterId=${requesterId}:`,
       error,
     );
-    throw error instanceof Error ? error : new Error('Failed to fetch profile');
+    throw error instanceof Error ? error : new Error('Error al obtener el perfil');
+  }
+}
+
+/**
+ * Returns the privacy settings for the authenticated user.
+ */
+export async function getMySettings(ctx: ServiceContext): Promise<PrivacySettings> {
+  if (!ctx.userId) {
+    throw new Error('Autenticación requerida');
+  }
+
+  const db = ctx.supabase ?? supabase;
+
+  try {
+    const row = await profileRepository.getPrivacySettings(ctx.userId, db);
+    if (!row) {
+      throw new Error('Configuración de privacidad no encontrada');
+    }
+    return toPrivacySettings(row);
+  } catch (error) {
+    console.error(`[profileService.getMySettings] Failed for userId=${ctx.userId}:`, error);
+    throw error instanceof Error ? error : new Error('Error al obtener la configuración');
+  }
+}
+
+/**
+ * Updates the authenticated user's privacy settings.
+ * Validates input with Zod, writes with user-scoped client for RLS enforcement,
+ * records an audit log entry, and invalidates Redis caches.
+ */
+export async function updatePrivacy(
+  input: UpdatePrivacyFields,
+  ctx: ServiceContext,
+): Promise<PrivacySettings> {
+  if (!ctx.userId) {
+    throw new Error('Autenticación requerida');
+  }
+
+  const parsed = UpdatePrivacySchema.safeParse(input);
+  if (!parsed.success) {
+    const msg = parsed.error.issues[0]?.message ?? 'Datos de privacidad inválidos';
+    throw new Error(msg);
+  }
+
+  const db = ctx.supabase ?? supabase;
+
+  try {
+    // Fetch current settings for audit log (before snapshot)
+    const previousRow = await profileRepository.getPrivacySettings(ctx.userId, db);
+    if (!previousRow) {
+      throw new Error('Perfil no encontrado');
+    }
+
+    // Apply the update
+    await profileRepository.updatePrivacyFields(ctx.userId, parsed.data, db);
+
+    // Fetch the updated settings
+    const updatedRow = await profileRepository.getPrivacySettings(ctx.userId, db);
+    if (!updatedRow) {
+      throw new Error('Error al verificar la actualización');
+    }
+
+    // Record audit log (non-blocking failure)
+    await profileRepository.insertPrivacyAuditLog(ctx.userId, previousRow, updatedRow);
+
+    // Invalidate caches
+    await Promise.all([
+      cacheDelete(`${CACHE_PREFIX.PROFILE_ME}${ctx.userId}`),
+      cacheDelete(`profile:public:${ctx.userId}`),
+      // Invalidate match history cache if showHistory changed
+      ...(parsed.data.showHistory !== undefined
+        ? [cacheDelete(`${CACHE_PREFIX.USER_MATCHES}${ctx.userId}`)]
+        : []),
+    ]);
+
+    console.info(`[profileService.updatePrivacy] Privacy updated for userId=${ctx.userId}`);
+    return toPrivacySettings(updatedRow);
+  } catch (error) {
+    console.error(`[profileService.updatePrivacy] Failed for userId=${ctx.userId}:`, error);
+    throw error instanceof Error ? error : new Error('Error al actualizar la privacidad');
   }
 }
 
 export const profileService = {
   getMyProfile,
+  getProfile,
+  getMySettings,
+  updatePrivacy,
 };

--- a/apps/frontend/src/components/settings/PrivacySettingsContainer.tsx
+++ b/apps/frontend/src/components/settings/PrivacySettingsContainer.tsx
@@ -1,0 +1,55 @@
+/**
+ * PrivacySettingsContainer — orchestrates PrivacySettingsForm + ProfilePreviewModal
+ *
+ * Decision Context:
+ * - Why a container: PrivacySettingsForm needs to open ProfilePreviewModal and pass it
+ *   the current (unsaved) settings. Both components share modal-open state and the
+ *   profile data — lifting state here keeps each child focused on a single concern.
+ * - profile prop is fetched SSR and passed from /ajustes.astro so the preview has data
+ *   immediately without an additional client-side fetch.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { useState } from 'react';
+import type { PrivacySettings, Profile } from '../../graphql/operations/profile';
+import PrivacySettingsForm from './PrivacySettingsForm';
+import ProfilePreviewModal from './ProfilePreviewModal';
+
+interface Props {
+  initialSettings: PrivacySettings;
+  profile: Profile | null;
+  accessToken: string;
+  backendUrl: string;
+}
+
+export default function PrivacySettingsContainer({
+  initialSettings,
+  profile,
+  accessToken,
+  backendUrl,
+}: Props) {
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewSettings, setPreviewSettings] = useState<PrivacySettings>(initialSettings);
+
+  function handlePreview(settings: PrivacySettings) {
+    setPreviewSettings(settings);
+    setPreviewOpen(true);
+  }
+
+  return (
+    <>
+      <PrivacySettingsForm
+        initialSettings={initialSettings}
+        accessToken={accessToken}
+        backendUrl={backendUrl}
+        onPreview={handlePreview}
+      />
+      <ProfilePreviewModal
+        isOpen={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        settings={previewSettings}
+        profile={profile}
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/components/settings/PrivacySettingsForm.tsx
+++ b/apps/frontend/src/components/settings/PrivacySettingsForm.tsx
@@ -1,0 +1,444 @@
+/**
+ * PrivacySettingsForm — React island for granular privacy controls
+ *
+ * Decision Context:
+ * - Why React island (client:load): all toggles are interactive and must respond
+ *   immediately. State updates optimistically and the mutation confirms server-side.
+ * - Toggle hierarchy: isPublic acts as a master switch. When isPublic=false, the
+ *   sub-toggles (showStats, showHistory, showPosition, showDivision) are disabled
+ *   visually but still stored on the server so their values are preserved for when
+ *   the user makes their profile public again.
+ * - fetch instead of urql: urql-client.ts reads the token from localStorage (client-side
+ *   only). We use native fetch with the accessToken prop passed from the SSR page.
+ * - Toast feedback: uses a local state flag (saved/error) with a 3-second auto-dismiss
+ *   instead of an external toast library to keep dependencies minimal.
+ * - Preview modal: opened via callback prop to keep the preview concern separate from the
+ *   save concern. The modal receives the *local* (not-yet-saved) settings so users can
+ *   preview before committing.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { Eye, Globe, BarChart3, History, MapPin, Shield, Save, Loader2, Check, X } from 'lucide-react';
+import { useState } from 'react';
+import type { PrivacySettings, UpdatePrivacyInput } from '../../graphql/operations/profile';
+import { UPDATE_PRIVACY } from '../../graphql/operations/profile';
+
+interface Props {
+  initialSettings: PrivacySettings;
+  accessToken: string;
+  backendUrl: string;
+  onPreview: (settings: PrivacySettings) => void;
+}
+
+interface ToastState {
+  type: 'success' | 'error';
+  message: string;
+}
+
+const TOGGLE_CONFIG = [
+  {
+    key: 'showStats' as const,
+    icon: BarChart3,
+    label: 'Estadísticas',
+    tooltip: 'Partidos jugados, victorias y efectividad',
+  },
+  {
+    key: 'showHistory' as const,
+    icon: History,
+    label: 'Historial de partidos',
+    tooltip: 'La lista de partidos completados donde participaste',
+  },
+  {
+    key: 'showPosition' as const,
+    icon: MapPin,
+    label: 'Posición preferida',
+    tooltip: 'Tu posición en la cancha (arquero, defensor, etc.)',
+  },
+  {
+    key: 'showDivision' as const,
+    icon: Shield,
+    label: 'División',
+    tooltip: 'Tu nivel de división actual',
+  },
+] as const;
+
+export default function PrivacySettingsForm({ initialSettings, accessToken, backendUrl, onPreview }: Props) {
+  const [settings, setSettings] = useState<PrivacySettings>(initialSettings);
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const graphqlUrl = `${backendUrl}/graphql`;
+
+  function showToast(type: ToastState['type'], message: string) {
+    setToast({ type, message });
+    setTimeout(() => setToast(null), 3500);
+  }
+
+  function handleToggle(key: keyof PrivacySettings, value: boolean) {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    const input: UpdatePrivacyInput = {
+      isPublic: settings.isPublic,
+      showStats: settings.showStats,
+      showHistory: settings.showHistory,
+      showPosition: settings.showPosition,
+      showDivision: settings.showDivision,
+    };
+
+    try {
+      const res = await fetch(graphqlUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ query: UPDATE_PRIVACY, variables: { input } }),
+      });
+
+      const json = (await res.json()) as {
+        data?: { updatePrivacy: PrivacySettings };
+        errors?: Array<{ message: string }>;
+      };
+
+      if (json.errors?.length) {
+        showToast('error', json.errors[0]?.message ?? 'Error al guardar los cambios');
+      } else if (json.data?.updatePrivacy) {
+        setSettings(json.data.updatePrivacy);
+        showToast('success', 'Configuración de privacidad guardada');
+      }
+    } catch {
+      showToast('error', 'Error de red. Intentá de nuevo.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const isPublicDisabled = !settings.isPublic;
+
+  return (
+    <div className="privacy-form">
+      {toast && (
+        <div className={`toast toast--${toast.type}`} role="alert" aria-live="polite">
+          {toast.type === 'success'
+            ? <Check size={16} strokeWidth={2.5} aria-hidden="true" />
+            : <X size={16} strokeWidth={2.5} aria-hidden="true" />}
+          <span>{toast.message}</span>
+        </div>
+      )}
+
+      {/* Master toggle */}
+      <section className="toggle-section">
+        <div className="section-label-row">
+          <Globe size={16} strokeWidth={2} aria-hidden="true" className="section-icon" />
+          <span className="section-heading">Visibilidad del perfil</span>
+        </div>
+
+        <label className="toggle-row toggle-row--master">
+          <div className="toggle-info">
+            <span className="toggle-label">Perfil público</span>
+            <span className="toggle-tooltip">
+              Cuando está desactivado, solo se muestra tu nombre y foto en los partidos
+            </span>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.isPublic}
+            aria-label="Perfil público"
+            className={`toggle-switch ${settings.isPublic ? 'toggle-switch--on' : ''}`}
+            onClick={() => handleToggle('isPublic', !settings.isPublic)}
+          >
+            <span className="toggle-thumb" />
+          </button>
+        </label>
+      </section>
+
+      {/* Sub-toggles */}
+      <section className={`toggle-section toggle-section--sub ${isPublicDisabled ? 'toggle-section--disabled' : ''}`}>
+        <div className="section-label-row">
+          <span className="section-heading">Qué ven otros jugadores</span>
+          {isPublicDisabled && (
+            <span className="disabled-badge">Perfil privado</span>
+          )}
+        </div>
+
+        {TOGGLE_CONFIG.map(({ key, icon: Icon, label, tooltip }) => (
+          <label key={key} className="toggle-row">
+            <div className="toggle-icon-wrap" aria-hidden="true">
+              <Icon size={16} strokeWidth={2} />
+            </div>
+            <div className="toggle-info">
+              <span className="toggle-label">{label}</span>
+              <span className="toggle-tooltip">{tooltip}</span>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings[key]}
+              aria-label={label}
+              disabled={isPublicDisabled}
+              className={`toggle-switch ${settings[key] && !isPublicDisabled ? 'toggle-switch--on' : ''}`}
+              onClick={() => !isPublicDisabled && handleToggle(key, !settings[key])}
+            >
+              <span className="toggle-thumb" />
+            </button>
+          </label>
+        ))}
+      </section>
+
+      {/* Actions */}
+      <div className="form-actions">
+        <button
+          type="button"
+          className="btn-preview"
+          onClick={() => onPreview(settings)}
+        >
+          <Eye size={16} strokeWidth={2} aria-hidden="true" />
+          Ver como otros me ven
+        </button>
+
+        <button
+          type="button"
+          className="btn-save"
+          onClick={handleSave}
+          disabled={saving}
+          aria-busy={saving}
+        >
+          {saving
+            ? <Loader2 size={16} strokeWidth={2} aria-hidden="true" className="spin" />
+            : <Save size={16} strokeWidth={2} aria-hidden="true" />}
+          {saving ? 'Guardando...' : 'Guardar cambios'}
+        </button>
+      </div>
+
+      <style>{`
+        .privacy-form {
+          position: relative;
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+        }
+
+        /* ---- Toast ---- */
+        .toast {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          padding: 0.75rem 1rem;
+          border-radius: 8px;
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.875rem;
+          font-weight: 500;
+          animation: slideIn 0.2s ease;
+        }
+        .toast--success {
+          background: rgba(34, 197, 94, 0.12);
+          border: 1px solid rgba(34, 197, 94, 0.3);
+          color: hsl(142 71% 65%);
+        }
+        .toast--error {
+          background: rgba(239, 68, 68, 0.12);
+          border: 1px solid rgba(239, 68, 68, 0.3);
+          color: hsl(0 72% 70%);
+        }
+        @keyframes slideIn {
+          from { opacity: 0; transform: translateY(-6px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+
+        /* ---- Section ---- */
+        .toggle-section {
+          background: hsl(220 55% 11%);
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          border-radius: 0.75rem;
+          overflow: hidden;
+        }
+        .toggle-section--disabled {
+          opacity: 0.6;
+        }
+
+        .section-label-row {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          padding: 0.875rem 1.25rem 0.75rem;
+          border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+        }
+        .section-icon {
+          color: hsl(35 100% 55%);
+          flex-shrink: 0;
+        }
+        .section-heading {
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.78rem;
+          font-weight: 700;
+          letter-spacing: 0.15em;
+          text-transform: uppercase;
+          color: hsl(215 20% 65%);
+          flex: 1;
+        }
+        .disabled-badge {
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.7rem;
+          font-weight: 700;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          color: hsl(215 20% 50%);
+          background: rgba(255, 255, 255, 0.06);
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          padding: 0.15rem 0.5rem;
+          border-radius: 4px;
+        }
+
+        /* ---- Toggle row ---- */
+        .toggle-row {
+          display: flex;
+          align-items: center;
+          gap: 0.875rem;
+          padding: 1rem 1.25rem;
+          cursor: pointer;
+          transition: background 0.15s;
+          border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+        }
+        .toggle-row:last-child { border-bottom: none; }
+        .toggle-row--master { padding: 1.1rem 1.25rem; }
+        .toggle-row:hover { background: rgba(255, 255, 255, 0.03); }
+
+        .toggle-icon-wrap {
+          color: hsl(216 85% 60%);
+          flex-shrink: 0;
+          display: flex;
+          align-items: center;
+        }
+        .toggle-info {
+          flex: 1;
+          display: flex;
+          flex-direction: column;
+          gap: 0.2rem;
+          min-width: 0;
+        }
+        .toggle-label {
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.9375rem;
+          font-weight: 600;
+          color: hsl(210 20% 90%);
+        }
+        .toggle-tooltip {
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.8rem;
+          color: hsl(215 20% 50%);
+          line-height: 1.35;
+        }
+
+        /* ---- Toggle switch ---- */
+        .toggle-switch {
+          flex-shrink: 0;
+          width: 48px;
+          height: 28px;
+          border-radius: 14px;
+          background: hsl(220 30% 20%);
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          position: relative;
+          cursor: pointer;
+          transition: background 0.2s, border-color 0.2s;
+          padding: 0;
+          min-width: 48px;
+          min-height: 44px;
+          display: flex;
+          align-items: center;
+        }
+        .toggle-switch--on {
+          background: hsl(35 100% 48%);
+          border-color: hsl(35 100% 48%);
+        }
+        .toggle-switch:disabled {
+          cursor: not-allowed;
+          opacity: 0.5;
+        }
+        .toggle-thumb {
+          position: absolute;
+          left: 3px;
+          width: 20px;
+          height: 20px;
+          border-radius: 50%;
+          background: hsl(215 20% 65%);
+          transition: transform 0.2s, background 0.2s;
+          pointer-events: none;
+        }
+        .toggle-switch--on .toggle-thumb {
+          transform: translateX(20px);
+          background: hsl(220 72% 7%);
+        }
+
+        /* ---- Actions ---- */
+        .form-actions {
+          display: flex;
+          gap: 0.75rem;
+          flex-wrap: wrap;
+        }
+
+        .btn-preview,
+        .btn-save {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.5rem;
+          font-family: 'Barlow Condensed', sans-serif;
+          font-weight: 700;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          font-size: 0.875rem;
+          padding: 0.65rem 1.25rem;
+          border-radius: 8px;
+          cursor: pointer;
+          transition: background 0.15s, color 0.15s, border-color 0.15s;
+          border: none;
+          min-height: 44px;
+        }
+
+        .btn-preview {
+          background: transparent;
+          color: hsl(216 85% 65%);
+          border: 1px solid rgba(99, 155, 255, 0.25);
+          flex: 1;
+          justify-content: center;
+        }
+        .btn-preview:hover {
+          background: rgba(99, 155, 255, 0.08);
+          border-color: rgba(99, 155, 255, 0.4);
+        }
+
+        .btn-save {
+          background: hsl(35 100% 48%);
+          color: hsl(220 72% 7%);
+          flex: 1;
+          justify-content: center;
+        }
+        .btn-save:hover:not(:disabled) {
+          background: hsl(35 100% 55%);
+        }
+        .btn-save:disabled {
+          opacity: 0.7;
+          cursor: not-allowed;
+        }
+
+        .spin {
+          animation: spin 1s linear infinite;
+        }
+        @keyframes spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+
+        @media (max-width: 480px) {
+          .toggle-row { padding: 0.875rem 1rem; }
+          .section-label-row { padding: 0.75rem 1rem; }
+          .form-actions { flex-direction: column; }
+          .btn-preview, .btn-save { flex: unset; width: 100%; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/settings/ProfilePreviewModal.tsx
+++ b/apps/frontend/src/components/settings/ProfilePreviewModal.tsx
@@ -1,0 +1,406 @@
+/**
+ * ProfilePreviewModal — shows how your profile looks to other players
+ *
+ * Decision Context:
+ * - Why: Allows users to preview privacy settings effects before saving (mejora 3).
+ * - The preview applies the *current local settings* (not yet saved) so users can
+ *   make informed decisions without having to save first.
+ * - Fetches the profile data from the backend using the user's own token — the same
+ *   data that other users would see — and applies the local settings overlay for
+ *   fields that would be hidden.
+ * - Mobile: renders full-screen on small screens to maximize preview area.
+ * - Previously fixed bugs: none relevant.
+ */
+
+import { X, User } from 'lucide-react';
+import type { PrivacySettings, Profile } from '../../graphql/operations/profile';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  settings: PrivacySettings;
+  profile: Profile | null;
+}
+
+const POSITION_LABEL: Record<string, string> = {
+  GOALKEEPER: 'Arquero',
+  DEFENDER: 'Defensor',
+  MIDFIELDER: 'Mediocampista',
+  FORWARD: 'Delantero',
+};
+
+function PreviewCard({ profile, settings }: { profile: Profile; settings: PrivacySettings }) {
+  const showStats = settings.isPublic && settings.showStats;
+  const showPosition = settings.isPublic && settings.showPosition;
+  const showDivision = settings.isPublic && settings.showDivision;
+
+  const positionLabel = showPosition && profile.preferredPosition
+    ? (POSITION_LABEL[profile.preferredPosition] ?? null)
+    : null;
+
+  const winrate =
+    showStats && profile.matchesPlayed && profile.matchesPlayed > 0
+      ? ((profile.matchesWon ?? 0) / profile.matchesPlayed) * 100
+      : null;
+
+  return (
+    <article className="preview-card">
+      <div className="preview-card-header">
+        {showDivision && (
+          <span className="preview-div-badge">DIV {profile.division}</span>
+        )}
+        <span className="preview-role-badge">Jugador</span>
+      </div>
+
+      <div className="preview-avatar-ring">
+        {profile.avatarUrl ? (
+          <img
+            src={profile.avatarUrl}
+            alt={`Foto de ${profile.displayName}`}
+            className="preview-avatar-img"
+            width="100"
+            height="100"
+          />
+        ) : (
+          <div className="preview-avatar-placeholder" aria-label="Sin foto">
+            <User size={40} strokeWidth={1.5} aria-hidden="true" />
+          </div>
+        )}
+      </div>
+
+      <div className="preview-identity">
+        <h3 className="preview-name">{profile.displayName}</h3>
+        {positionLabel && (
+          <span className="preview-position">{positionLabel}</span>
+        )}
+        {!settings.isPublic && (
+          <span className="preview-private-badge">Perfil privado</span>
+        )}
+      </div>
+
+      {showStats ? (
+        <div className="preview-stats">
+          <div className="preview-stat">
+            <span className="preview-stat-value">{profile.matchesPlayed ?? 0}</span>
+            <span className="preview-stat-label">Partidos</span>
+          </div>
+          <div className="preview-stat preview-stat--mid">
+            <span className="preview-stat-value">{profile.matchesWon ?? 0}</span>
+            <span className="preview-stat-label">Victorias</span>
+          </div>
+          <div className="preview-stat">
+            <span className="preview-stat-value preview-stat-value--orange">
+              {winrate !== null ? `${winrate.toFixed(1)}%` : '—'}
+            </span>
+            <span className="preview-stat-label">Efectividad</span>
+          </div>
+        </div>
+      ) : (
+        <div className="preview-stats-hidden">
+          <span className="preview-stats-hidden-label">Estadísticas ocultas</span>
+        </div>
+      )}
+
+      <style>{`
+        .preview-card {
+          background: hsl(220 55% 11%);
+          border: 1px solid rgba(255,255,255,0.08);
+          border-radius: 1rem;
+          overflow: hidden;
+          width: 100%;
+          max-width: 300px;
+          margin: 0 auto;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        }
+        .preview-card-header {
+          width: 100%;
+          padding: 0.6rem 1rem;
+          background: linear-gradient(135deg, hsl(216 85% 22%), hsl(220 72% 15%));
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          border-bottom: 1px solid rgba(255,255,255,0.06);
+        }
+        .preview-div-badge {
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: 0.85rem;
+          letter-spacing: 0.1em;
+          color: hsl(35 100% 65%);
+          background: rgba(246,164,0,0.12);
+          border: 1px solid rgba(246,164,0,0.25);
+          padding: 0.1rem 0.5rem;
+          border-radius: 4px;
+        }
+        .preview-role-badge {
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.7rem;
+          font-weight: 700;
+          letter-spacing: 0.14em;
+          text-transform: uppercase;
+          color: hsl(215 20% 60%);
+        }
+        .preview-avatar-ring {
+          margin-top: 1.5rem;
+          width: 100px;
+          height: 100px;
+          border-radius: 50%;
+          padding: 3px;
+          background: linear-gradient(135deg, hsl(35 100% 48%), hsl(216 85% 45%));
+          box-shadow: 0 0 16px rgba(246,164,0,0.15);
+          flex-shrink: 0;
+        }
+        .preview-avatar-img {
+          width: 100%;
+          height: 100%;
+          border-radius: 50%;
+          object-fit: cover;
+          background: hsl(220 40% 16%);
+          display: block;
+        }
+        .preview-avatar-placeholder {
+          width: 100%;
+          height: 100%;
+          border-radius: 50%;
+          background: hsl(220 40% 16%);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          color: hsl(215 20% 40%);
+        }
+        .preview-identity {
+          margin-top: 0.875rem;
+          text-align: center;
+          padding: 0 1rem;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 0.35rem;
+        }
+        .preview-name {
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: 1.6rem;
+          font-weight: 400;
+          letter-spacing: 0.05em;
+          color: #fff;
+          margin: 0;
+          line-height: 1;
+        }
+        .preview-position {
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.72rem;
+          font-weight: 700;
+          letter-spacing: 0.15em;
+          text-transform: uppercase;
+          color: hsl(35 100% 55%);
+          background: rgba(246,164,0,0.1);
+          border: 1px solid rgba(246,164,0,0.2);
+          padding: 0.15rem 0.6rem;
+          border-radius: 20px;
+        }
+        .preview-private-badge {
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.7rem;
+          font-weight: 700;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          color: hsl(215 20% 55%);
+          background: rgba(255,255,255,0.06);
+          border: 1px solid rgba(255,255,255,0.12);
+          padding: 0.15rem 0.6rem;
+          border-radius: 20px;
+        }
+        .preview-stats {
+          width: 100%;
+          margin-top: 1.25rem;
+          padding: 1rem 0;
+          display: grid;
+          grid-template-columns: 1fr 1fr 1fr;
+          border-top: 1px solid rgba(255,255,255,0.06);
+        }
+        .preview-stat {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 0.2rem;
+          padding: 0.2rem 0.4rem;
+        }
+        .preview-stat--mid {
+          border-left: 1px solid rgba(255,255,255,0.06);
+          border-right: 1px solid rgba(255,255,255,0.06);
+        }
+        .preview-stat-value {
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: 1.4rem;
+          color: #fff;
+          line-height: 1;
+        }
+        .preview-stat-value--orange { color: hsl(35 100% 55%); }
+        .preview-stat-label {
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.62rem;
+          font-weight: 600;
+          letter-spacing: 0.13em;
+          text-transform: uppercase;
+          color: hsl(215 20% 50%);
+        }
+        .preview-stats-hidden {
+          width: 100%;
+          margin-top: 1.25rem;
+          padding: 0.875rem 0;
+          border-top: 1px solid rgba(255,255,255,0.06);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .preview-stats-hidden-label {
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.75rem;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          color: hsl(215 20% 40%);
+        }
+      `}</style>
+    </article>
+  );
+}
+
+export default function ProfilePreviewModal({ isOpen, onClose, settings, profile }: Props) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="preview-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Vista previa de tu perfil"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="preview-modal">
+        <div className="preview-modal-header">
+          <div>
+            <p className="preview-modal-eyebrow">Vista previa</p>
+            <h2 className="preview-modal-title">Así te ven otros jugadores</h2>
+          </div>
+          <button
+            type="button"
+            className="preview-close-btn"
+            aria-label="Cerrar vista previa"
+            onClick={onClose}
+          >
+            <X size={20} strokeWidth={2} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="preview-modal-body">
+          {profile ? (
+            <PreviewCard profile={profile} settings={settings} />
+          ) : (
+            <p className="preview-no-data">No se pudo cargar el perfil</p>
+          )}
+        </div>
+
+        <p className="preview-modal-note">
+          Los cambios no están guardados. Usa "Guardar cambios" para aplicarlos.
+        </p>
+      </div>
+
+      <style>{`
+        .preview-overlay {
+          position: fixed;
+          inset: 0;
+          z-index: 200;
+          background: rgba(7, 15, 31, 0.85);
+          backdrop-filter: blur(8px);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 1rem;
+        }
+        .preview-modal {
+          background: hsl(220 55% 11%);
+          border: 1px solid rgba(255,255,255,0.08);
+          border-radius: 1rem;
+          width: 100%;
+          max-width: 400px;
+          overflow: hidden;
+          display: flex;
+          flex-direction: column;
+        }
+        .preview-modal-header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          padding: 1.25rem 1.25rem 1rem;
+          border-bottom: 1px solid rgba(255,255,255,0.06);
+          gap: 1rem;
+        }
+        .preview-modal-eyebrow {
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.72rem;
+          font-weight: 700;
+          letter-spacing: 0.18em;
+          text-transform: uppercase;
+          color: hsl(35 100% 55%);
+          margin: 0 0 0.2rem;
+        }
+        .preview-modal-title {
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: 1.4rem;
+          letter-spacing: 0.04em;
+          color: #fff;
+          margin: 0;
+          line-height: 1;
+        }
+        .preview-close-btn {
+          background: rgba(255,255,255,0.06);
+          border: 1px solid rgba(255,255,255,0.1);
+          border-radius: 8px;
+          color: hsl(215 20% 65%);
+          cursor: pointer;
+          width: 36px;
+          height: 36px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          flex-shrink: 0;
+          transition: background 0.15s, color 0.15s;
+        }
+        .preview-close-btn:hover {
+          background: rgba(255,255,255,0.1);
+          color: #fff;
+        }
+        .preview-modal-body {
+          padding: 1.25rem;
+        }
+        .preview-modal-note {
+          padding: 0.75rem 1.25rem;
+          border-top: 1px solid rgba(255,255,255,0.06);
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.8rem;
+          color: hsl(215 20% 45%);
+          margin: 0;
+          text-align: center;
+        }
+        .preview-no-data {
+          text-align: center;
+          color: hsl(215 20% 50%);
+          font-family: 'Barlow', sans-serif;
+          padding: 2rem 0;
+        }
+
+        @media (max-width: 480px) {
+          .preview-overlay { padding: 0; align-items: flex-end; }
+          .preview-modal {
+            border-radius: 1rem 1rem 0 0;
+            max-width: 100%;
+            border-left: none;
+            border-right: none;
+            border-bottom: none;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/frontend/src/graphql/operations/profile.graphql
+++ b/apps/frontend/src/graphql/operations/profile.graphql
@@ -1,4 +1,4 @@
-# Profile operations — GraphQL source of truth (see matches.graphql pattern)
+# Profile operations — GraphQL source of truth
 
 query GetMyProfile {
   myProfile {
@@ -11,6 +11,42 @@ query GetMyProfile {
     matchesPlayed
     matchesWon
     winrate
+    isPrivate
+  }
+}
+
+query GetProfile($id: ID!) {
+  profile(id: $id) {
+    id
+    displayName
+    avatarUrl
+    role
+    preferredPosition
+    division
+    matchesPlayed
+    matchesWon
+    winrate
+    isPrivate
+  }
+}
+
+query GetMySettings {
+  mySettings {
+    isPublic
+    showStats
+    showHistory
+    showPosition
+    showDivision
+  }
+}
+
+mutation UpdatePrivacy($input: UpdatePrivacyInput!) {
+  updatePrivacy(input: $input) {
+    isPublic
+    showStats
+    showHistory
+    showPosition
+    showDivision
   }
 }
 

--- a/apps/frontend/src/graphql/operations/profile.ts
+++ b/apps/frontend/src/graphql/operations/profile.ts
@@ -3,13 +3,12 @@
  *
  * Decision Context:
  * - Why: frontend.md forbids inline GraphQL inside UI components — operations live here.
- *   Frontend codegen isn't wired up yet, so we keep a hand-typed mirror of the schema
- *   until it is. If you edit the query, update BOTH `profile.graphql` and this file.
- * - Enums mirror the backend schema exactly (`player` → `PLAYER`, etc.) so the frontend
- *   can compare without a runtime mapping layer.
- * - MatchHistoryItem.scoreA/scoreB are always null until "registrar resultado" US is merged.
- *   The types include them as nullable so the UI can conditionally render scores when
- *   that US is eventually implemented.
+ *   Frontend codegen isn't wired up yet, so we keep a hand-typed mirror of the schema.
+ *   If you edit the query, update BOTH `profile.graphql` and this file.
+ * - Privacy fields: Profile fields are nullable when the owner has disabled them.
+ *   `isPrivate` is true when the profile is private and the viewer is not the owner.
+ * - PrivacySettings is only fetched via mySettings (owner only). UpdatePrivacyInput
+ *   allows partial updates — all fields are optional.
  * - Previously fixed bugs: none relevant.
  */
 
@@ -28,11 +27,34 @@ export interface Profile {
   displayName: string;
   avatarUrl: string | null;
   role: UserRole;
+  /** Null if owner set showPosition=false and viewer is not the owner */
   preferredPosition: PlayerPosition | null;
-  division: number;
-  matchesPlayed: number;
-  matchesWon: number;
+  /** Null if owner set showDivision=false and viewer is not the owner */
+  division: number | null;
+  /** Null if owner set showStats=false and viewer is not the owner */
+  matchesPlayed: number | null;
+  /** Null if owner set showStats=false and viewer is not the owner */
+  matchesWon: number | null;
+  /** Null if owner set showStats=false or matchesPlayed=0 */
   winrate: number | null;
+  /** True when this profile is private and the viewer is not the owner */
+  isPrivate: boolean | null;
+}
+
+export interface PrivacySettings {
+  isPublic: boolean;
+  showStats: boolean;
+  showHistory: boolean;
+  showPosition: boolean;
+  showDivision: boolean;
+}
+
+export interface UpdatePrivacyInput {
+  isPublic?: boolean;
+  showStats?: boolean;
+  showHistory?: boolean;
+  showPosition?: boolean;
+  showDivision?: boolean;
 }
 
 export interface MatchHistoryClub {
@@ -80,6 +102,48 @@ export const GET_MY_PROFILE = /* GraphQL */ `
       matchesPlayed
       matchesWon
       winrate
+      isPrivate
+    }
+  }
+`;
+
+export const GET_PROFILE = /* GraphQL */ `
+  query GetProfile($id: ID!) {
+    profile(id: $id) {
+      id
+      displayName
+      avatarUrl
+      role
+      preferredPosition
+      division
+      matchesPlayed
+      matchesWon
+      winrate
+      isPrivate
+    }
+  }
+`;
+
+export const GET_MY_SETTINGS = /* GraphQL */ `
+  query GetMySettings {
+    mySettings {
+      isPublic
+      showStats
+      showHistory
+      showPosition
+      showDivision
+    }
+  }
+`;
+
+export const UPDATE_PRIVACY = /* GraphQL */ `
+  mutation UpdatePrivacy($input: UpdatePrivacyInput!) {
+    updatePrivacy(input: $input) {
+      isPublic
+      showStats
+      showHistory
+      showPosition
+      showDivision
     }
   }
 `;

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -42,7 +42,7 @@ import {
 } from './lib/auth';
 
 /** Rutas que requieren autenticación */
-const PROTECTED_ROUTES: string[] = ['/panel-club', '/perfil', '/partidos/crear', '/torneos/crear'];
+const PROTECTED_ROUTES: string[] = ['/panel-club', '/perfil', '/ajustes', '/partidos/crear', '/torneos/crear'];
 
 /** Rutas restringidas por rol: sólo accesibles para el rol indicado */
 const ROLE_RESTRICTED: Record<string, UserRole> = {

--- a/apps/frontend/src/pages/ajustes.astro
+++ b/apps/frontend/src/pages/ajustes.astro
@@ -1,0 +1,452 @@
+---
+/**
+ * Ajustes — SSR page for account and privacy settings (auth required)
+ *
+ * Decision Context:
+ * - Why SSR: reads privacy settings and profile SSR-side so the form renders with
+ *   data immediately (no client-side loading spinner). Auth is guaranteed by middleware.
+ * - Two parallel fetches: mySettings and myProfile. myProfile is used by the preview
+ *   modal (ProfilePreviewModal) to show the card before committing changes.
+ * - Graceful degradation: if either fetch fails we render the form with safe defaults
+ *   (all public) and show an inline notice. The user can still interact with the form.
+ * - Nav reuses the same topbar pattern from /perfil for visual consistency.
+ * - Currently only the Privacidad section is implemented. Cuenta and Notificaciones
+ *   are placeholder tabs — marked TODO for future sprints.
+ * - Previously fixed bugs: none relevant.
+ */
+export const prerender = false;
+
+import { Volleyball, Lock, User, Bell } from 'lucide-react';
+import Layout from '../layouts/Layout.astro';
+import PrivacySettingsContainer from '@/components/settings/PrivacySettingsContainer';
+import { ACCESS_TOKEN_COOKIE } from '../lib/auth';
+import {
+  GET_MY_SETTINGS,
+  GET_MY_PROFILE,
+  type PrivacySettings,
+  type Profile,
+} from '../graphql/operations/profile';
+
+const backendUrl =
+  import.meta.env.PRIVATE_BACKEND_URL ||
+  process.env.PRIVATE_BACKEND_URL ||
+  'http://localhost:4000';
+const graphqlUrl =
+  import.meta.env.PUBLIC_GRAPHQL_URL ||
+  process.env.PUBLIC_GRAPHQL_URL ||
+  `${backendUrl}/graphql`;
+
+const user = Astro.locals.user;
+const accessToken = Astro.cookies.get(ACCESS_TOKEN_COOKIE)?.value ?? '';
+const displayName = user?.displayName || user?.email || 'Jugador';
+
+const DEFAULT_SETTINGS: PrivacySettings = {
+  isPublic: true,
+  showStats: true,
+  showHistory: true,
+  showPosition: true,
+  showDivision: true,
+};
+
+let settings: PrivacySettings = DEFAULT_SETTINGS;
+let profile: Profile | null = null;
+let fetchError = false;
+
+if (accessToken) {
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  const [settingsRes, profileRes] = await Promise.allSettled([
+    fetch(graphqlUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query: GET_MY_SETTINGS }),
+    }),
+    fetch(graphqlUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query: GET_MY_PROFILE }),
+    }),
+  ]);
+
+  if (settingsRes.status === 'fulfilled') {
+    const json = (await settingsRes.value.json().catch(() => null)) as
+      | { data?: { mySettings: PrivacySettings }; errors?: Array<{ message: string }> }
+      | null;
+    if (json?.data?.mySettings) {
+      settings = json.data.mySettings;
+    } else {
+      fetchError = true;
+    }
+  } else {
+    fetchError = true;
+  }
+
+  if (profileRes.status === 'fulfilled') {
+    const json = (await profileRes.value.json().catch(() => null)) as
+      | { data?: { myProfile: Profile }; errors?: Array<{ message: string }> }
+      | null;
+    if (json?.data?.myProfile) {
+      profile = json.data.myProfile;
+    }
+  }
+}
+---
+
+<Layout title="Ajustes — Sumate Ya">
+  <div class="app-shell">
+    <!-- Top navigation bar -->
+    <nav class="topbar">
+      <div class="topbar-inner">
+        <div class="topbar-brand">
+          <span class="topbar-ball">
+            <Volleyball size={20} strokeWidth={2} aria-hidden="true" />
+          </span>
+          <span class="topbar-name">SUMATE YA</span>
+        </div>
+        <div class="topbar-actions">
+          <a href="/perfil" class="nav-link">Mi perfil</a>
+          <a href="/partidos" class="nav-link">Partidos</a>
+          <span class="user-badge">
+            <span class="user-dot"></span>
+            {displayName}
+          </span>
+          <form method="POST" action="/api/auth/logout">
+            <button type="submit" class="btn-logout">Salir</button>
+          </form>
+        </div>
+      </div>
+      <div class="topbar-accent"></div>
+    </nav>
+
+    <!-- Page content -->
+    <main class="page-content">
+      <header class="section-header">
+        <div class="section-label">CONFIGURACIÓN</div>
+        <h1 class="section-title">Ajustes</h1>
+        <p class="section-sub">Controlá tu privacidad y la configuración de tu cuenta</p>
+      </header>
+
+      {fetchError && (
+        <div class="fetch-notice" role="alert">
+          No pudimos cargar tu configuración actual. Se muestran los valores por defecto.
+          Podés guardar cambios igual.
+        </div>
+      )}
+
+      <div class="settings-layout">
+        <!-- Sidebar nav -->
+        <nav class="settings-nav" aria-label="Secciones de ajustes">
+          <a href="#privacidad" class="settings-nav-item settings-nav-item--active">
+            <Lock size={16} strokeWidth={2} aria-hidden="true" />
+            Privacidad
+          </a>
+          <span class="settings-nav-item settings-nav-item--disabled" aria-disabled="true">
+            <User size={16} strokeWidth={2} aria-hidden="true" />
+            Cuenta
+            <span class="coming-soon">Próximamente</span>
+          </span>
+          <span class="settings-nav-item settings-nav-item--disabled" aria-disabled="true">
+            <Bell size={16} strokeWidth={2} aria-hidden="true" />
+            Notificaciones
+            <span class="coming-soon">Próximamente</span>
+          </span>
+        </nav>
+
+        <!-- Main settings panel -->
+        <div class="settings-panel">
+          <section id="privacidad" class="settings-section">
+            <div class="settings-section-header">
+              <Lock size={18} strokeWidth={2} aria-hidden="true" className="settings-section-icon" />
+              <div>
+                <h2 class="settings-section-title">Privacidad</h2>
+                <p class="settings-section-sub">
+                  Elegí qué información tuya pueden ver otros jugadores
+                </p>
+              </div>
+            </div>
+
+            <PrivacySettingsContainer
+              client:load
+              initialSettings={settings}
+              profile={profile}
+              accessToken={accessToken}
+              backendUrl={backendUrl}
+            />
+          </section>
+        </div>
+      </div>
+    </main>
+  </div>
+</Layout>
+
+<style>
+  .app-shell {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ---- Topbar ---- */
+  .topbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: rgba(7, 15, 31, 0.85);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+  .topbar-inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.25rem;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .topbar-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .topbar-ball {
+    line-height: 1;
+    display: inline-flex;
+    color: hsl(35 100% 55%);
+  }
+  .topbar-name {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.35rem;
+    letter-spacing: 0.1em;
+    color: #ffffff;
+  }
+  .topbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .topbar-accent {
+    height: 2px;
+    background: linear-gradient(90deg, hsl(35 100% 48%), hsl(216 85% 45%), transparent);
+  }
+  .nav-link {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: hsl(215 20% 65%);
+    text-decoration: none;
+    padding: 0.3rem 0.6rem;
+    border-radius: 6px;
+    transition: color 0.15s, background 0.15s;
+  }
+  .nav-link:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: hsl(210 20% 94%);
+  }
+  .user-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(246, 164, 0, 0.12);
+    border: 1px solid rgba(246, 164, 0, 0.25);
+    color: hsl(35 100% 65%);
+    border-radius: 20px;
+    padding: 0.25rem 0.875rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    font-family: 'Barlow Condensed', sans-serif;
+    letter-spacing: 0.03em;
+  }
+  .user-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: hsl(35 100% 55%);
+    box-shadow: 0 0 4px hsl(35 100% 55%);
+  }
+  .btn-logout {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 6px;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.8125rem;
+    font-family: 'Barlow', sans-serif;
+    font-weight: 500;
+    cursor: pointer;
+    color: hsl(215 20% 60%);
+    transition: background 0.15s, color 0.15s;
+  }
+  .btn-logout:hover {
+    background: rgba(255, 255, 255, 0.07);
+    color: hsl(210 20% 90%);
+  }
+
+  /* ---- Page ---- */
+  .page-content {
+    flex: 1;
+    max-width: 1100px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 2.5rem 1.25rem;
+  }
+
+  .section-header {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+  .section-label {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    color: hsl(35 100% 55%);
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+  }
+  .section-title {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 2.5rem;
+    font-weight: 400;
+    letter-spacing: 0.04em;
+    color: #ffffff;
+    margin: 0 0 0.375rem;
+    line-height: 1;
+  }
+  .section-sub {
+    margin: 0;
+    color: hsl(215 20% 50%);
+    font-size: 0.9rem;
+    font-family: 'Barlow', sans-serif;
+  }
+
+  .fetch-notice {
+    background: rgba(246, 164, 0, 0.08);
+    border: 1px solid rgba(246, 164, 0, 0.2);
+    color: hsl(35 100% 65%);
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.875rem;
+    margin-bottom: 1.5rem;
+  }
+
+  /* ---- Layout ---- */
+  .settings-layout {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 2rem;
+    align-items: start;
+  }
+
+  /* ---- Sidebar nav ---- */
+  .settings-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    background: hsl(220 55% 11%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 0.5rem;
+  }
+  .settings-nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.65rem 0.875rem;
+    border-radius: 6px;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: hsl(215 20% 65%);
+    text-decoration: none;
+    transition: background 0.15s, color 0.15s;
+    cursor: pointer;
+  }
+  .settings-nav-item--active {
+    background: rgba(246, 164, 0, 0.1);
+    color: hsl(35 100% 65%);
+    border: 1px solid rgba(246, 164, 0, 0.15);
+  }
+  .settings-nav-item--disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    position: relative;
+    flex-wrap: wrap;
+  }
+  .coming-soon {
+    margin-left: auto;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: hsl(215 20% 40%);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+  }
+
+  /* ---- Section ---- */
+  .settings-section-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.875rem;
+    margin-bottom: 1.5rem;
+  }
+  .settings-section-icon {
+    color: hsl(35 100% 55%);
+    margin-top: 0.15rem;
+    flex-shrink: 0;
+  }
+  .settings-section-title {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.5rem;
+    font-weight: 400;
+    letter-spacing: 0.04em;
+    color: #ffffff;
+    margin: 0 0 0.25rem;
+    line-height: 1;
+  }
+  .settings-section-sub {
+    margin: 0;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.875rem;
+    color: hsl(215 20% 50%);
+  }
+
+  /* ── Responsive ──────────────────────────────────────── */
+  @media (max-width: 767px) {
+    .topbar-actions .nav-link { display: none; }
+    .page-content { padding: 1.25rem 1rem; }
+    .section-header { margin-bottom: 1.25rem; }
+    .section-title { font-size: clamp(1.75rem, 6vw, 2.5rem); }
+    .settings-layout {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+    .settings-nav {
+      flex-direction: row;
+      overflow-x: auto;
+      padding: 0.375rem;
+      gap: 0.25rem;
+    }
+    .settings-nav-item {
+      white-space: nowrap;
+      flex-shrink: 0;
+      padding: 0.5rem 0.75rem;
+    }
+    .coming-soon { display: none; }
+  }
+  @media (min-width: 768px) and (max-width: 1023px) {
+    .page-content { padding: 2rem 1.25rem; }
+    .settings-layout { grid-template-columns: 180px 1fr; }
+  }
+</style>

--- a/apps/frontend/src/pages/perfil.astro
+++ b/apps/frontend/src/pages/perfil.astro
@@ -23,7 +23,7 @@
  */
 export const prerender = false;
 
-import { Volleyball } from 'lucide-react';
+import { Volleyball, Lock, Settings } from 'lucide-react';
 import Layout from '../layouts/Layout.astro';
 import ProfileCard from '@/components/profile/ProfileCard.astro';
 import AvatarUpload from '@/components/profile/AvatarUpload.tsx';
@@ -32,7 +32,9 @@ import { ACCESS_TOKEN_COOKIE } from '../lib/auth';
 import {
   GET_MY_PROFILE,
   GET_MY_MATCHES,
+  GET_MY_SETTINGS,
   type Profile,
+  type PrivacySettings,
   type MatchHistoryConnection,
 } from '../graphql/operations/profile';
 
@@ -56,22 +58,30 @@ const EMPTY_HISTORY: MatchHistoryConnection = {
 let profile: Profile | null = null;
 let errorMessage: string | null = null;
 let historyData: MatchHistoryConnection = EMPTY_HISTORY;
+let privacySettings: PrivacySettings | null = null;
 
 if (!accessToken) {
   // Middleware already redirects on this path, but we keep a defensive guard.
   errorMessage = 'Sesión inválida. Iniciá sesión nuevamente.';
 } else {
-  // Fetch profile and first page of history in parallel
-  const [profileResponse, historyResponse] = await Promise.allSettled([
+  const authHeaders = { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` };
+
+  // Fetch profile, first page of history, and privacy settings in parallel
+  const [profileResponse, historyResponse, settingsResponse] = await Promise.allSettled([
     fetch(graphqlUrl, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+      headers: authHeaders,
       body: JSON.stringify({ query: GET_MY_PROFILE }),
     }),
     fetch(graphqlUrl, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+      headers: authHeaders,
       body: JSON.stringify({ query: GET_MY_MATCHES, variables: { page: 1, pageSize: 10 } }),
+    }),
+    fetch(graphqlUrl, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ query: GET_MY_SETTINGS }),
     }),
   ]);
 
@@ -101,6 +111,15 @@ if (!accessToken) {
     }
     // Graceful degradation: if history fails, historyData stays EMPTY_HISTORY
   }
+
+  if (settingsResponse.status === 'fulfilled') {
+    const settJson = (await settingsResponse.value.json().catch(() => null)) as
+      | { data?: { mySettings?: PrivacySettings }; errors?: Array<{ message: string }> }
+      | null;
+    if (settJson?.data?.mySettings) {
+      privacySettings = settJson.data.mySettings;
+    }
+  }
 }
 ---
 
@@ -115,6 +134,10 @@ if (!accessToken) {
         </div>
         <div class="topbar-actions">
           <a href="/partidos" class="nav-link">Partidos</a>
+          <a href="/ajustes" class="nav-link nav-link--settings" title="Ajustes de privacidad">
+            <Settings size={15} strokeWidth={2} aria-hidden="true" />
+            Ajustes
+          </a>
           <span class="user-badge">
             <span class="user-dot"></span>
             {displayName}
@@ -138,6 +161,14 @@ if (!accessToken) {
       <section class="profile-section">
         {profile ? (
           <div class="profile-card-wrapper">
+            {/* Badge de perfil privado — solo visible para el propio usuario */}
+            {privacySettings?.isPublic === false && (
+              <div class="privacy-notice">
+                <Lock size={14} strokeWidth={2.5} aria-hidden="true" />
+                <span>Tu perfil está privado.</span>
+                <a href="/ajustes" class="privacy-notice-link">Cambiar en Ajustes</a>
+              </div>
+            )}
             <ProfileCard profile={profile} />
             <button id="change-avatar-btn" class="btn-change-avatar" title="Cambiar foto de perfil">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"></path><circle cx="12" cy="13" r="3"></circle></svg>
@@ -280,12 +311,42 @@ if (!accessToken) {
     padding: 0.3rem 0.6rem;
     border-radius: 6px;
     transition: color 0.15s, background 0.15s;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
   }
 
   .nav-link:hover {
     background: rgba(255, 255, 255, 0.06);
     color: hsl(210 20% 94%);
   }
+
+  /* ---- Privacy notice badge ---- */
+  .privacy-notice {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 0.875rem;
+    margin-bottom: 0.75rem;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.85rem;
+    color: hsl(215 20% 60%);
+  }
+  .privacy-notice-link {
+    margin-left: auto;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: hsl(35 100% 55%);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .privacy-notice-link:hover { color: hsl(35 100% 65%); }
 
   .user-badge {
     display: flex;

--- a/apps/frontend/src/pages/perfil/[id].astro
+++ b/apps/frontend/src/pages/perfil/[id].astro
@@ -1,0 +1,582 @@
+---
+/**
+ * Perfil público — /perfil/[id] (SSR, auth required)
+ *
+ * Decision Context:
+ * - Why SSR: the profile(id) query requires auth (the resolver calls requireAuth) and
+ *   the response varies per-viewer (privacy filtering is applied server-side). Static
+ *   rendering would embed a single visitor's filtered view for everyone.
+ * - UUID regex: uses a permissive regex (\w+-\w+-\w+-\w+-\w+) to avoid rejecting valid
+ *   seed UUIDs that may differ from the canonical RFC format.
+ * - Privacy handling: when isPrivate=true (backend returned a limited profile), we render
+ *   only the name + avatar and show the "perfil privado" message. Stats, position, and
+ *   division sections are omitted entirely to avoid empty placeholders confusing the user.
+ * - Own profile redirect: if the authenticated user visits their own /perfil/[id], we
+ *   redirect to /perfil (the full self-view) instead of showing the privacy-filtered view.
+ * - Auth: middleware guarantees an access token is present. We still read the cookie
+ *   directly here to forward it to the backend (same pattern as /perfil.astro).
+ * - Previously fixed bugs: none relevant.
+ */
+export const prerender = false;
+
+import { Volleyball, Lock, ArrowLeft, BarChart3 } from 'lucide-react';
+import Layout from '../../layouts/Layout.astro';
+import { ACCESS_TOKEN_COOKIE } from '../../lib/auth';
+import {
+  GET_PROFILE,
+  type Profile,
+} from '../../graphql/operations/profile';
+
+const { id } = Astro.params;
+
+// Permissive UUID regex — accepts seed UUIDs that may not match strict RFC format
+const UUID_LIKE = /^[\w-]{8,}$/;
+if (!id || !UUID_LIKE.test(id)) {
+  return Astro.redirect('/partidos');
+}
+
+const backendUrl =
+  import.meta.env.PRIVATE_BACKEND_URL ||
+  process.env.PRIVATE_BACKEND_URL ||
+  'http://localhost:4000';
+const graphqlUrl =
+  import.meta.env.PUBLIC_GRAPHQL_URL ||
+  process.env.PUBLIC_GRAPHQL_URL ||
+  `${backendUrl}/graphql`;
+
+const user = Astro.locals.user;
+const accessToken = Astro.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+const displayName = user?.displayName || user?.email || 'Jugador';
+
+// If the user is viewing their own profile, redirect to /perfil (full self-view)
+if (user?.id === id) {
+  return Astro.redirect('/perfil');
+}
+
+const POSITION_LABEL: Record<string, string> = {
+  GOALKEEPER: 'Arquero',
+  DEFENDER: 'Defensor',
+  MIDFIELDER: 'Mediocampista',
+  FORWARD: 'Delantero',
+};
+
+let profile: Profile | null = null;
+let errorMessage: string | null = null;
+
+if (!accessToken) {
+  errorMessage = 'Sesión inválida. Iniciá sesión nuevamente.';
+} else {
+  const res = await fetch(graphqlUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+    body: JSON.stringify({ query: GET_PROFILE, variables: { id } }),
+  });
+
+  const json = (await res.json().catch(() => null)) as
+    | { data?: { profile: Profile | null }; errors?: Array<{ message: string }> }
+    | null;
+
+  if (!json || !res.ok) {
+    errorMessage = 'No pudimos cargar el perfil. Intentá de nuevo en unos segundos.';
+  } else if (json.errors?.length) {
+    errorMessage = json.errors[0]?.message ?? 'Error al cargar el perfil.';
+  } else if (json.data?.profile) {
+    profile = json.data.profile;
+  } else {
+    errorMessage = 'Este jugador no existe o su perfil no está disponible.';
+  }
+}
+
+const positionLabel = profile?.preferredPosition
+  ? (POSITION_LABEL[profile.preferredPosition] ?? null)
+  : null;
+
+const winrateDisplay =
+  profile?.winrate != null
+    ? `${profile.winrate.toFixed(1)}%`
+    : '—';
+---
+
+<Layout title={profile ? `Perfil de ${profile.displayName} — Sumate Ya` : 'Perfil — Sumate Ya'}>
+  <div class="app-shell">
+    <!-- Topbar -->
+    <nav class="topbar">
+      <div class="topbar-inner">
+        <div class="topbar-brand">
+          <span class="topbar-ball">
+            <Volleyball size={20} strokeWidth={2} aria-hidden="true" />
+          </span>
+          <span class="topbar-name">SUMATE YA</span>
+        </div>
+        <div class="topbar-actions">
+          <a href="/partidos" class="nav-link">Partidos</a>
+          <span class="user-badge">
+            <span class="user-dot"></span>
+            {displayName}
+          </span>
+          <form method="POST" action="/api/auth/logout">
+            <button type="submit" class="btn-logout">Salir</button>
+          </form>
+        </div>
+      </div>
+      <div class="topbar-accent"></div>
+    </nav>
+
+    <main class="page-content">
+      <div class="back-row">
+        <a href="/partidos" class="back-link">
+          <ArrowLeft size={16} strokeWidth={2} aria-hidden="true" />
+          Volver
+        </a>
+      </div>
+
+      {profile ? (
+        <div class="profile-view">
+          <!-- Profile card -->
+          <article class="profile-card">
+            <!-- Card header -->
+            <div class="card-header">
+              {profile.division != null && (
+                <span class="division-badge">DIV {profile.division}</span>
+              )}
+              <span class="role-badge">Jugador</span>
+            </div>
+
+            <!-- Avatar -->
+            <div class="avatar-ring">
+              {profile.avatarUrl ? (
+                <img
+                  class="avatar-img"
+                  src={profile.avatarUrl}
+                  alt={`Foto de ${profile.displayName}`}
+                  width="120"
+                  height="120"
+                  loading="eager"
+                />
+              ) : (
+                <div class="avatar-placeholder" aria-label="Sin foto de perfil">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/>
+                  </svg>
+                </div>
+              )}
+            </div>
+
+            <!-- Identity -->
+            <div class="player-identity">
+              <h1 class="player-name">{profile.displayName}</h1>
+              {positionLabel && !profile.isPrivate && (
+                <span class="position-tag">{positionLabel}</span>
+              )}
+              {profile.isPrivate && (
+                <span class="private-tag">
+                  <Lock size={12} strokeWidth={2.5} aria-hidden="true" />
+                  Perfil privado
+                </span>
+              )}
+            </div>
+
+            {profile.isPrivate ? (
+              <!-- Private profile message -->
+              <div class="private-message">
+                <p class="private-message-text">
+                  Este jugador mantiene su perfil privado.
+                </p>
+                <p class="private-message-sub">
+                  Solo se muestra su nombre y foto en los partidos donde participa.
+                </p>
+              </div>
+            ) : (
+              <!-- Stats (visible only if not private and showStats=true) -->
+              {profile.matchesPlayed != null ? (
+                <div class="stats-grid">
+                  <div class="stat-cell">
+                    <span class="stat-value">{profile.matchesPlayed}</span>
+                    <span class="stat-label">Partidos</span>
+                  </div>
+                  <div class="stat-cell stat-divider">
+                    <span class="stat-value">{profile.matchesWon ?? 0}</span>
+                    <span class="stat-label">Victorias</span>
+                  </div>
+                  <div class="stat-cell">
+                    <span class="stat-value winrate">{winrateDisplay}</span>
+                    <span class="stat-label">Efectividad</span>
+                  </div>
+                </div>
+              ) : (
+                <div class="stats-hidden">
+                  <BarChart3 size={16} strokeWidth={2} aria-hidden="true" />
+                  <span>Estadísticas no disponibles</span>
+                </div>
+              )}
+            )}
+          </article>
+        </div>
+      ) : (
+        <div class="error-card" role="alert">
+          <p class="error-title">No pudimos mostrar este perfil</p>
+          <p class="error-body">{errorMessage}</p>
+          <a href="/partidos" class="btn-primary">Ir a partidos</a>
+        </div>
+      )}
+    </main>
+  </div>
+</Layout>
+
+<style>
+  .app-shell {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ---- Topbar ---- */
+  .topbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: rgba(7, 15, 31, 0.85);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+  .topbar-inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.25rem;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .topbar-brand { display: flex; align-items: center; gap: 0.5rem; }
+  .topbar-ball { line-height: 1; display: inline-flex; color: hsl(35 100% 55%); }
+  .topbar-name {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.35rem;
+    letter-spacing: 0.1em;
+    color: #ffffff;
+  }
+  .topbar-actions { display: flex; align-items: center; gap: 0.75rem; }
+  .topbar-accent {
+    height: 2px;
+    background: linear-gradient(90deg, hsl(35 100% 48%), hsl(216 85% 45%), transparent);
+  }
+  .nav-link {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: hsl(215 20% 65%);
+    text-decoration: none;
+    padding: 0.3rem 0.6rem;
+    border-radius: 6px;
+    transition: color 0.15s, background 0.15s;
+  }
+  .nav-link:hover { background: rgba(255,255,255,0.06); color: hsl(210 20% 94%); }
+  .user-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(246, 164, 0, 0.12);
+    border: 1px solid rgba(246, 164, 0, 0.25);
+    color: hsl(35 100% 65%);
+    border-radius: 20px;
+    padding: 0.25rem 0.875rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    font-family: 'Barlow Condensed', sans-serif;
+    letter-spacing: 0.03em;
+  }
+  .user-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: hsl(35 100% 55%);
+    box-shadow: 0 0 4px hsl(35 100% 55%);
+  }
+  .btn-logout {
+    background: transparent;
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 6px;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.8125rem;
+    font-family: 'Barlow', sans-serif;
+    font-weight: 500;
+    cursor: pointer;
+    color: hsl(215 20% 60%);
+    transition: background 0.15s, color 0.15s;
+  }
+  .btn-logout:hover { background: rgba(255,255,255,0.07); color: hsl(210 20% 90%); }
+
+  /* ---- Page ---- */
+  .page-content {
+    flex: 1;
+    max-width: 1100px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 2rem 1.25rem;
+  }
+
+  .back-row {
+    margin-bottom: 1.5rem;
+  }
+  .back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: hsl(215 20% 60%);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .back-link:hover { color: hsl(210 20% 90%); }
+
+  /* ---- Profile card ---- */
+  .profile-view {
+    display: flex;
+    justify-content: center;
+  }
+
+  .profile-card {
+    background: hsl(220 55% 11%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 1rem;
+    overflow: hidden;
+    width: 100%;
+    max-width: 360px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.04) inset;
+  }
+
+  .card-header {
+    width: 100%;
+    padding: 0.75rem 1.25rem;
+    background: linear-gradient(135deg, hsl(216 85% 22%), hsl(220 72% 15%));
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+  }
+  .division-badge {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 0.9rem;
+    letter-spacing: 0.12em;
+    color: hsl(35 100% 65%);
+    background: rgba(246,164,0,0.12);
+    border: 1px solid rgba(246,164,0,0.25);
+    padding: 0.15rem 0.6rem;
+    border-radius: 4px;
+  }
+  .role-badge {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: hsl(215 20% 65%);
+  }
+
+  .avatar-ring {
+    margin-top: 1.75rem;
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    padding: 3px;
+    background: linear-gradient(135deg, hsl(35 100% 48%), hsl(216 85% 45%));
+    box-shadow: 0 0 20px rgba(246,164,0,0.2);
+    flex-shrink: 0;
+  }
+  .avatar-img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+    background: hsl(220 40% 16%);
+    display: block;
+  }
+  .avatar-placeholder {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: hsl(220 40% 16%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: hsl(215 20% 40%);
+  }
+
+  .player-identity {
+    margin-top: 1.1rem;
+    text-align: center;
+    padding: 0 1.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .player-name {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 2rem;
+    font-weight: 400;
+    letter-spacing: 0.05em;
+    color: #ffffff;
+    margin: 0;
+    line-height: 1;
+  }
+  .position-tag {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: hsl(35 100% 55%);
+    background: rgba(246,164,0,0.1);
+    border: 1px solid rgba(246,164,0,0.2);
+    padding: 0.2rem 0.75rem;
+    border-radius: 20px;
+  }
+  .private-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: hsl(215 20% 55%);
+    background: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.12);
+    padding: 0.2rem 0.7rem;
+    border-radius: 20px;
+  }
+
+  /* ---- Private message ---- */
+  .private-message {
+    width: 100%;
+    margin-top: 1.25rem;
+    padding: 1.25rem;
+    border-top: 1px solid rgba(255,255,255,0.06);
+    text-align: center;
+  }
+  .private-message-text {
+    margin: 0 0 0.4rem;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.9375rem;
+    color: hsl(215 20% 70%);
+    font-weight: 500;
+  }
+  .private-message-sub {
+    margin: 0;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.825rem;
+    color: hsl(215 20% 45%);
+    line-height: 1.45;
+  }
+
+  /* ---- Stats ---- */
+  .stats-grid {
+    width: 100%;
+    margin-top: 1.5rem;
+    padding: 1.25rem 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    border-top: 1px solid rgba(255,255,255,0.06);
+  }
+  .stat-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+  }
+  .stat-divider {
+    border-left: 1px solid rgba(255,255,255,0.06);
+    border-right: 1px solid rgba(255,255,255,0.06);
+  }
+  .stat-value {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.6rem;
+    color: #ffffff;
+    line-height: 1;
+  }
+  .stat-value.winrate { color: hsl(35 100% 55%); }
+  .stat-label {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: hsl(215 20% 50%);
+  }
+
+  .stats-hidden {
+    width: 100%;
+    margin-top: 1.25rem;
+    padding: 1rem;
+    border-top: 1px solid rgba(255,255,255,0.06);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.78rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: hsl(215 20% 40%);
+  }
+
+  /* ---- Error ---- */
+  .error-card {
+    max-width: 560px;
+    margin: 2rem auto;
+    text-align: center;
+    padding: 2rem 1.5rem;
+    border-radius: 0.75rem;
+    background: hsl(220 55% 11%);
+    border: 1px solid hsl(0 72% 51% / 0.35);
+  }
+  .error-title {
+    margin: 0 0 0.5rem;
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.5rem;
+    letter-spacing: 0.04em;
+    color: hsl(0 72% 70%);
+  }
+  .error-body {
+    margin: 0 0 1.25rem;
+    color: hsl(215 20% 60%);
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.95rem;
+  }
+  .btn-primary {
+    display: inline-block;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-size: 0.875rem;
+    padding: 0.6rem 1.25rem;
+    border-radius: 6px;
+    background: hsl(35 100% 48%);
+    color: hsl(220 72% 7%);
+    text-decoration: none;
+    transition: background 0.15s;
+  }
+  .btn-primary:hover { background: hsl(35 100% 55%); }
+
+  /* ── Responsive ── */
+  @media (max-width: 767px) {
+    .topbar-actions .nav-link { display: none; }
+    .page-content { padding: 1.25rem 1rem; }
+    .profile-card { max-width: 100%; }
+  }
+</style>

--- a/docs/TESTING-privacy.md
+++ b/docs/TESTING-privacy.md
@@ -1,0 +1,116 @@
+# Testing Manual — Privacidad de Perfil
+
+Rama: `privacidad`  
+Fecha: 2026-05-11
+
+## Casos de prueba
+
+### Funcionalidad básica
+
+1. **Toggle isPublic=false (vista propia)**
+   - Ir a `/ajustes` → sección Privacidad
+   - Desactivar "Perfil público" → guardar
+   - Ir a `/perfil` → debe mostrar badge "Tu perfil está privado. Cambiar en Ajustes"
+   - El perfil propio sigue mostrando todos los datos (nombre, avatar, stats, historial)
+
+2. **Toggle isPublic=false (vista de otro usuario)**
+   - Loguearse con otro usuario → ir a `/perfil/<id-del-usuario-privado>`
+   - Debe mostrar solo nombre + avatar
+   - Mensaje: "Este jugador mantiene su perfil privado."
+   - Sub-mensaje: "Solo se muestra su nombre y foto en los partidos donde participa."
+   - No se ven stats, posición ni división
+
+3. **showStats=false (otro usuario)**
+   - Dejar isPublic=true, desactivar "Estadísticas" → guardar
+   - Otro usuario visita `/perfil/[id]` → sección stats no aparece (texto "Estadísticas no disponibles")
+
+4. **showHistory=false (otro usuario)**
+   - TODO: cuando se implemente `profile(id).myMatches` para perfiles ajenos
+   - Backend ya retorna array vacío cuando showHistory=false para requesterId != profileId
+
+5. **Mutation updatePrivacy actualiza correctamente**
+   - Hacer POST a `/graphql` con mutation `updatePrivacy` y varios campos
+   - Respuesta debe incluir los nuevos valores
+   - Verificar en Supabase: `profiles.showStats`, `profiles.isPublic`, etc. cambiaron
+
+6. **RLS: SELECT de perfiles por usuario autenticado**
+   - Todo usuario autenticado puede leer cualquier fila de `profiles`
+   - Verificar con cliente anon+JWT que la consulta devuelve datos (filtrado de columnas va por el backend)
+
+### UX / Mejoras
+
+7. **Tooltips en cada toggle**
+   - En `/ajustes` → hover/focus cada toggle sub → debe aparecer el texto descriptivo debajo del label
+
+8. **Confirmación visual al guardar**
+   - Hacer cambio → guardar → debe aparecer toast verde "Configuración de privacidad guardada" por ~3.5s
+
+9. **Badge "Perfil privado" en /perfil propio**
+   - Con isPublic=false → `/perfil` muestra el notice con icono de candado y link a `/ajustes`
+   - Con isPublic=true → el notice NO aparece
+
+10. **Mensaje a visitantes de perfiles privados**
+    - Otro usuario visita `/perfil/[id]` con isPublic=false
+    - Mensaje visible: "Este jugador mantiene su perfil privado."
+
+11. **Preview "Ver como otros me ven"**
+    - En `/ajustes`, con isPublic=false → click "Ver como otros me ven"
+    - Modal muestra perfil con solo nombre + avatar + tag "Perfil privado"
+    - Con isPublic=true, showStats=false → modal muestra stats ocultos
+    - Nota al pie: "Los cambios no están guardados."
+
+12. **Perfil en /partidos/[id] siempre visible**
+    - Jugador con perfil privado participa en un partido
+    - En `/partidos/[id]`, su nombre y avatar siguen siendo visibles en el equipo
+    - (Esto es garantizado por el backend: los participantes se exponen via matchParticipants,
+      que incluye displayName y avatarUrl sin restricción de privacidad del perfil)
+
+### Granularidad
+
+13. **Ocultar solo stats sin ocultar historial**
+    - isPublic=true, showStats=false, showHistory=true → guardar
+    - Otro usuario: no ve stats pero sí ve historial (cuando esté implementado el endpoint ajeno)
+
+14. **Owner siempre ve todo**
+    - Con isPublic=false, showStats=false → ir a `/perfil` con el propio usuario
+    - Todos los datos visibles sin restricción
+
+15. **Audit log registra cada cambio**
+    - Cambiar privacidad → verificar en tabla `privacyAuditLog` que hay una nueva fila
+    - La fila tiene: `userId`, `previousSettings` (json), `newSettings` (json), `changedAt`
+
+### Cache
+
+16. **Cache Redis se invalida al cambiar settings**
+    - Con Redis activo: cargar `/perfil` (cache warm)
+    - Cambiar privacidad en `/ajustes`
+    - Recargar `/perfil` → debe reflejar cambios (cache fue invalidado)
+
+### Responsive
+
+17. **Form de privacidad en mobile (375px)**
+    - `/ajustes` en viewport 375px
+    - Nav de secciones cambia a fila horizontal con scroll
+    - Toggles ocupan ancho completo
+    - Botones "Ver como otros" y "Guardar" apiladoss verticalmente
+
+18. **Modal preview en mobile**
+    - Modal aparece desde abajo (bottom-sheet) en viewports ≤ 480px
+    - Se puede cerrar tocando fuera o el botón X
+
+19. **Touch targets >= 44px en mobile**
+    - Los toggle switches tienen `min-height: 44px` para ser accionables en touch
+    - Los botones de acción tienen `min-height: 44px`
+
+20. **Mensajes de error en español al fallar updatePrivacy**
+    - Simular fallo de red → el toast muestra "Error de red. Intentá de nuevo."
+    - Simular error del servidor → el toast muestra el mensaje en español del backend
+
+## Notas técnicas
+
+- La privacidad se filtra en el **service layer** (backend), no por RLS de filas
+- RLS permite SELECT de cualquier fila a usuarios autenticados — el backend decide qué columnas exponer
+- `myProfile` (perfil propio) nunca aplica filtros de privacidad
+- `profile(id)` aplica filtros cuando requesterId !== profileId
+- Audit log usa el cliente service-role (singleton), ya que la verificación de ownership es en el service
+- Cache: `profile:me:<userId>` + `profile:public:<userId>` + `user:matches:<userId>` se invalidan en updatePrivacy

--- a/docs/prompts/p9w3x7kn-prompt-log.md
+++ b/docs/prompts/p9w3x7kn-prompt-log.md
@@ -1,0 +1,26 @@
+# Prompt Log
+
+- Timestamp: 2026-05-11 19:32:00
+- Task ID: p9w3x7kn
+
+## User Prompt
+
+> Sos un desarrollador senior fullstack especializado en Astro 6, GraphQL y Supabase. Necesito que implementes la siguiente User Story en el proyecto sumate-ya. Implementa en la rama / branch: privacidad
+>
+> ## User Story
+> Como jugador, quiero controlar qué información de mi perfil es pública para proteger mi privacidad.
+>
+> ## Subtareas originales
+> - Agregar toggle de perfil público/privado en /ajustes
+> - Mutation GraphQL updatePrivacy(isPublic)
+> - Actualizar profiles.isPublic
+> - Si perfil es privado: ocultar stats y historial a otros usuarios
+> - Mantener visible nombre y avatar en partidos donde participa
+>
+> [... resto del prompt con mejoras, restricciones y resultado esperado — ver prompt original completo]
+
+## Agent Main Actions
+
+- Migración DB vía Supabase MCP: agregó columnas `showStats`, `showHistory`, `showPosition`, `showDivision`, `privacyUpdatedAt` a `profiles`; creó tabla `privacyAuditLog`; actualizó RLS para permitir SELECT de perfiles a usuarios autenticados (backend filtra columnas según privacidad).
+- Backend: actualizó schema GraphQL con tipos `PrivacySettings`, `UpdatePrivacyInput`, query `profile(id)`, `mySettings` y mutation `updatePrivacy`; implementó `profileRepository` con métodos de privacidad y audit log; actualizó `profileService` con lógica de filtrado por privacidad (isPublic, showStats, showHistory, showPosition, showDivision); actualizó resolver y `resolvers/index.ts`.
+- Frontend: creó página `/ajustes.astro` (SSR, protegida) con form de privacidad granular; componentes `PrivacySettingsForm.tsx`, `ProfilePreviewModal.tsx` y `PrivacySettingsContainer.tsx`; página `/perfil/[id].astro` (vista pública con mensaje para perfiles privados); actualizó `/perfil.astro` con badge de perfil privado y link a Ajustes; typecheck pasa limpio (0 errores).


### PR DESCRIPTION
- Added SSR page for privacy settings at /ajustes.astro, allowing users to control profile visibility.
- Created public profile page at /perfil/[id].astro, displaying privacy-filtered information based on user settings.
- Introduced GraphQL mutations and queries for updating and fetching privacy settings.
- Developed testing documentation for privacy features, covering functionality, UX improvements, and responsiveness.
- Updated prompt log with details of the implementation process and changes made to the database and backend.