### PR TITLE
Ver Torneos

### DIFF
--- a/apps/backend/src/config/redis.ts
+++ b/apps/backend/src/config/redis.ts
@@ -49,6 +49,7 @@ export const CACHE_PREFIX = {
   // match:participants:{id} — richer cache entry that includes participant list.
   // Shorter TTL (DYNAMIC_DATA) than MATCH_DETAIL because team rosters change on every join.
   MATCH_PARTICIPANTS: 'match:participants:',
+  TOURNAMENTS_LIST: 'tournaments:list',
   CLUBS_LIST: 'clubs:list',
   CLUB_DETAIL: 'club:',
   // `profile:me:<userId>` — scoped to the owner because RLS differs per-user.

--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -639,6 +639,7 @@ export type Query = {
   profile?: Maybe<Profile>;
   slotAuditLog: Array<SlotAuditLog>;
   slotImpactPreview: SlotImpactPreview;
+  tournaments: Array<Tournament>;
 };
 
 
@@ -809,6 +810,7 @@ export type Tournament = {
   name: Scalars['String']['output'];
   organizerId: Scalars['ID']['output'];
   playersPerTeam: Scalars['Int']['output'];
+  registeredTeamsCount: Scalars['Int']['output'];
   startDate?: Maybe<Scalars['String']['output']>;
   status: TournamentStatus;
   teamCount: Scalars['Int']['output'];
@@ -1489,6 +1491,7 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   profile?: Resolver<Maybe<ResolversTypes['Profile']>, ParentType, ContextType, RequireFields<QueryProfileArgs, 'id'>>;
   slotAuditLog?: Resolver<Array<ResolversTypes['SlotAuditLog']>, ParentType, ContextType, RequireFields<QuerySlotAuditLogArgs, 'slotId'>>;
   slotImpactPreview?: Resolver<ResolversTypes['SlotImpactPreview'], ParentType, ContextType, RequireFields<QuerySlotImpactPreviewArgs, 'slotIds'>>;
+  tournaments?: Resolver<Array<ResolversTypes['Tournament']>, ParentType, ContextType>;
 }>;
 
 export type ScheduleSlotResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['ScheduleSlot'] = ResolversParentTypes['ScheduleSlot']> = ResolversObject<{
@@ -1544,6 +1547,7 @@ export type TournamentResolvers<ContextType = GraphQLContext, ParentType extends
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   organizerId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   playersPerTeam?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  registeredTeamsCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   startDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   status?: Resolver<ResolversTypes['TournamentStatus'], ParentType, ContextType>;
   teamCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/apps/backend/src/graphql/resolvers/domains/tournament.ts
+++ b/apps/backend/src/graphql/resolvers/domains/tournament.ts
@@ -13,7 +13,7 @@ import { createUserClient } from '../../../config/supabase.js';
 import { tournamentService } from '../../../services/tournamentService.js';
 import { requireAuth } from '../../../types/context.js';
 import { MatchFormat } from '../../generated/graphql.js';
-import type { MutationResolvers } from '../../generated/graphql.js';
+import type { MutationResolvers, QueryResolvers } from '../../generated/graphql.js';
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -45,6 +45,10 @@ const RegisterTournamentTeamSchema = z.object({
   tournamentId: z.string().regex(UUID_REGEX, 'tournamentId inválido'),
   name: z.string().trim().min(2, 'El nombre del equipo debe tener al menos 2 caracteres').max(80),
 });
+
+const Query: QueryResolvers = {
+  tournaments: async () => tournamentService.listRegistrationTournaments({}),
+};
 
 const Mutation: MutationResolvers = {
   createTournament: async (_parent, args, ctx) => {
@@ -92,4 +96,4 @@ const Mutation: MutationResolvers = {
   },
 };
 
-export const tournamentResolvers = { Mutation };
+export const tournamentResolvers = { Query, Mutation };

--- a/apps/backend/src/graphql/resolvers/index.ts
+++ b/apps/backend/src/graphql/resolvers/index.ts
@@ -28,6 +28,7 @@ export const resolvers = {
     ...clubSlotResolvers.Query,
     ...clubDashboardResolvers.Query,
     ...clubMatchResolvers.Query,
+    ...tournamentResolvers.Query,
   },
   Mutation: {
     ...matchResolvers.Mutation,

--- a/apps/backend/src/graphql/schema/tournament.graphql
+++ b/apps/backend/src/graphql/schema/tournament.graphql
@@ -50,6 +50,7 @@ type Tournament {
   format: MatchFormat!
   teamCount: Int!
   playersPerTeam: Int!
+  registeredTeamsCount: Int!
   status: TournamentStatus!
   description: String
   startDate: String
@@ -91,6 +92,10 @@ type TournamentTeamRegistrationResult {
 input RegisterTournamentTeamInput {
   tournamentId: ID!
   name: String!
+}
+
+extend type Query {
+  tournaments: [Tournament!]!
 }
 
 extend type Mutation {

--- a/apps/backend/src/repositories/tournamentRepository.ts
+++ b/apps/backend/src/repositories/tournamentRepository.ts
@@ -86,6 +86,10 @@ export interface FixtureMatchRow {
   createdAt: string;
 }
 
+export interface TournamentTeamCountRow {
+  count: number;
+}
+
 export interface TournamentRow {
   id: string;
   organizerId: string;
@@ -101,6 +105,7 @@ export interface TournamentRow {
   createdAt: string;
   clubs?: TournamentClubRow | null;
   fixtureMatches?: FixtureMatchRow[];
+  tournamentTeams?: TournamentTeamCountRow[];
 }
 
 export interface TournamentSlotCourtRow {
@@ -373,7 +378,9 @@ export async function getTournamentById(
 ): Promise<TournamentRow | null> {
   const { data, error } = await client
     .from('tournaments')
-    .select(`${TOURNAMENT_COLUMNS}, clubs(${TOURNAMENT_CLUB_COLUMNS}), fixtureMatches(${FIXTURE_COLUMNS})`)
+    .select(
+      `${TOURNAMENT_COLUMNS}, clubs(${TOURNAMENT_CLUB_COLUMNS}), fixtureMatches(${FIXTURE_COLUMNS}), tournamentTeams(count)`,
+    )
     .eq('id', tournamentId)
     .single();
 
@@ -384,6 +391,24 @@ export async function getTournamentById(
   }
 
   return data as unknown as TournamentRow;
+}
+
+export async function getRegistrationTournaments(
+  client: SupabaseClient = supabase,
+): Promise<TournamentRow[]> {
+  const { data, error } = await client
+    .from('tournaments')
+    .select(`${TOURNAMENT_COLUMNS}, clubs(${TOURNAMENT_CLUB_COLUMNS}), tournamentTeams(count)`)
+    .eq('status', 'registration')
+    .order('startDate', { ascending: true })
+    .order('createdAt', { ascending: false });
+
+  if (error) {
+    console.error('[tournamentRepository.getRegistrationTournaments] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return (data as unknown as TournamentRow[]) ?? [];
 }
 
 export async function getTournamentTeams(
@@ -485,6 +510,7 @@ export const tournamentRepository = {
   registerTournamentTeamRpc,
   insertFixtureMatches,
   getTournamentById,
+  getRegistrationTournaments,
   getTournamentTeams,
   createTournamentTeam,
   createTournamentTeamMember,

--- a/apps/backend/src/services/tournamentService.ts
+++ b/apps/backend/src/services/tournamentService.ts
@@ -10,6 +10,7 @@
  */
 
 import { supabase } from '../config/supabase.js';
+import { cacheDeletePattern, cacheGetOrSet, CACHE_PREFIX, CACHE_TTL } from '../config/redis.js';
 import {
   FixtureMatchStatus,
   MatchFormat,
@@ -70,6 +71,8 @@ const FORMAT_ORDER: Record<string, number> = {
   '11v11': 4,
 };
 
+const TOURNAMENTS_REGISTRATION_CACHE_KEY = `${CACHE_PREFIX.TOURNAMENTS_LIST}:status:registration`;
+
 // =====================================================
 // Helpers
 // =====================================================
@@ -123,6 +126,7 @@ function toTournament(row: TournamentRow): Tournament {
     if (a.round !== b.round) return a.round - b.round;
     return (a.scheduledAt ?? '').localeCompare(b.scheduledAt ?? '');
   });
+  const registeredTeamsCount = row.tournamentTeams?.[0]?.count ?? 0;
 
   return {
     id: row.id,
@@ -131,6 +135,7 @@ function toTournament(row: TournamentRow): Tournament {
     format: DB_TO_FORMAT[row.format] ?? MatchFormat.FiveVsFive,
     teamCount: row.teamCount,
     playersPerTeam: row.playersPerTeam,
+    registeredTeamsCount,
     status: DB_TO_STATUS[row.status] ?? TournamentStatus.Registration,
     description: row.description,
     startDate: row.startDate,
@@ -280,9 +285,23 @@ function buildRoundRobinPairings(teamIds: string[]): Array<{
   return pairings;
 }
 
+async function invalidateTournamentListCaches(): Promise<void> {
+  await cacheDeletePattern(`${CACHE_PREFIX.TOURNAMENTS_LIST}:*`);
+}
+
 // =====================================================
 // Service Functions
 // =====================================================
+
+export async function listRegistrationTournaments(_ctx: ServiceContext): Promise<Tournament[]> {
+  const tournaments = await cacheGetOrSet<TournamentRow[]>(
+    TOURNAMENTS_REGISTRATION_CACHE_KEY,
+    () => tournamentRepository.getRegistrationTournaments(),
+    CACHE_TTL.DYNAMIC_DATA,
+  );
+
+  return tournaments.map(toTournament);
+}
 
 export async function createTournament(
   input: CreateTournamentInput,
@@ -324,6 +343,7 @@ export async function createTournament(
   );
 
   await generateFixtureIfRegistrationComplete({ userId: ctx.userId, supabase: db }, tournamentId);
+  await invalidateTournamentListCaches();
 
   const created = await tournamentRepository.getTournamentById(tournamentId);
   if (!created) throw new Error('No se pudo cargar el torneo creado');
@@ -376,6 +396,7 @@ export async function generateFixtureIfRegistrationComplete(
   );
 
   await tournamentRepository.updateTournamentStatus(tournamentId, 'in_progress', writeClient);
+  await invalidateTournamentListCaches();
   return true;
 }
 
@@ -415,6 +436,7 @@ export async function registerTournamentTeam(
 
   const updatedTournament = await tournamentRepository.getTournamentById(input.tournamentId);
   if (!updatedTournament) throw new Error('No se pudo cargar el torneo actualizado');
+  await invalidateTournamentListCaches();
 
   return {
     success: true,
@@ -425,6 +447,7 @@ export async function registerTournamentTeam(
 }
 
 export const tournamentService = {
+  listRegistrationTournaments,
   createTournament,
   generateFixtureIfRegistrationComplete,
   registerTournamentTeam,

--- a/apps/frontend/src/components/home/HomeScreen.tsx
+++ b/apps/frontend/src/components/home/HomeScreen.tsx
@@ -11,6 +11,7 @@ import {
   Flame,
 } from 'lucide-react';
 import { MatchList } from '@/components/matches';
+import { TournamentList } from '@/components/tournaments/TournamentList';
 
 /**
  * HomeScreen Component
@@ -328,6 +329,31 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           </div>
 
           <MatchList isAuthenticated={isAuthenticated} />
+        </div>
+      </section>
+
+      {/* Torneos disponibles */}
+      <section className="px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <div className="mb-8 flex items-end justify-between gap-4">
+            <div>
+              <p className="flex items-center gap-2 text-xs font-medium uppercase tracking-widest text-primary">
+                <Trophy className="h-4 w-4" aria-hidden="true" />
+                Copas abiertas
+              </p>
+              <h2 className="font-['Bebas_Neue'] text-5xl tracking-wide text-foreground">
+                Torneos Disponibles
+              </h2>
+            </div>
+            <Button variant="outline" size="sm" asChild className="shrink-0">
+              <a href="/torneos">
+                Ver todos
+                <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+              </a>
+            </Button>
+          </div>
+
+          <TournamentList isAuthenticated={isAuthenticated} />
         </div>
       </section>
 

--- a/apps/frontend/src/components/tournaments/TournamentCard.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentCard.tsx
@@ -1,0 +1,218 @@
+/**
+ * TournamentCard - public tournament listing card with team registration affordance.
+ *
+ * Decision Context:
+ * - Mirrors MatchCard's scan-first card pattern, but the capacity metric is registered
+ *   teams instead of players.
+ * - Registration stays inline because there is no tournament detail page yet; a player can
+ *   find a tournament and submit the team name without losing their place in the list.
+ * - Mutations go through /api/graphql-auth so the HttpOnly session cookie can be forwarded.
+ */
+
+import { type SyntheticEvent, useMemo, useState } from 'react';
+import { Calendar, Loader2, MapPin, Trophy, Users } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  REGISTER_TOURNAMENT_TEAM,
+  type TournamentListItem,
+  type TournamentTeamRegistrationResult,
+} from '@/graphql/operations/tournaments';
+import type { MatchFormat } from '@/graphql/operations/matches';
+
+const FORMAT_LABELS: Record<MatchFormat, string> = {
+  FIVE_VS_FIVE: '5v5',
+  SEVEN_VS_SEVEN: '7v7',
+  TEN_VS_TEN: '10v10',
+  ELEVEN_VS_ELEVEN: '11v11',
+};
+
+interface TournamentCardProps {
+  tournament: TournamentListItem;
+  onRegistered: (tournament: TournamentListItem) => void;
+  isAuthenticated?: boolean;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return 'Fecha a confirmar';
+  const [year, month, day] = value.slice(0, 10).split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('es-UY', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  });
+}
+
+function isAuthError(message: string): boolean {
+  return message.toLowerCase().includes('authentication required');
+}
+
+export function TournamentCard({
+  tournament,
+  onRegistered,
+  isAuthenticated = false,
+}: TournamentCardProps) {
+  const [formOpen, setFormOpen] = useState(false);
+  const [teamName, setTeamName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const registeredTeams = Math.min(tournament.registeredTeamsCount, tournament.teamCount);
+  const isFull = registeredTeams >= tournament.teamCount || tournament.status !== 'REGISTRATION';
+  const progress = useMemo(
+    () => (tournament.teamCount > 0 ? Math.round((registeredTeams / tournament.teamCount) * 100) : 0),
+    [registeredTeams, tournament.teamCount],
+  );
+
+  async function handleSubmit(event: SyntheticEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!isAuthenticated) {
+      window.location.href = '/login';
+      return;
+    }
+
+    const name = teamName.trim();
+    if (name.length < 2) {
+      setError('Ingresá al menos 2 caracteres para el equipo.');
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await fetch('/api/graphql-auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: REGISTER_TOURNAMENT_TEAM,
+          variables: { input: { tournamentId: tournament.id, name } },
+        }),
+      });
+
+      const payload = (await response.json()) as {
+        data?: { registerTournamentTeam?: TournamentTeamRegistrationResult };
+        errors?: Array<{ message: string }>;
+      };
+
+      const graphQLError = payload.errors?.[0]?.message;
+      if (graphQLError) {
+        if (isAuthError(graphQLError)) window.location.href = '/login';
+        throw new Error(graphQLError);
+      }
+
+      const result = payload.data?.registerTournamentTeam;
+      if (!result) throw new Error('Respuesta inesperada del servidor');
+      if (!result.success) {
+        const message = result.message ?? 'No se pudo inscribir el equipo';
+        if (isAuthError(message)) window.location.href = '/login';
+        throw new Error(message);
+      }
+      if (result.tournament) onRegistered(result.tournament);
+
+      setSuccess('Equipo anotado.');
+      setTeamName('');
+      setFormOpen(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al inscribir el equipo');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <article className="rounded-xl border border-border bg-card text-card-foreground shadow transition-shadow hover:shadow-lg">
+      <div className="p-5 pb-4">
+        <div className="mb-3 flex flex-wrap items-center gap-1.5">
+          <Badge>{FORMAT_LABELS[tournament.format]}</Badge>
+          <Badge variant="secondary">{tournament.playersPerTeam} por equipo</Badge>
+        </div>
+
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-border bg-muted text-primary">
+            <Trophy className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate font-[Bebas_Neue,sans-serif] text-2xl leading-none tracking-[0.04em] text-foreground">
+              {tournament.name}
+            </h2>
+            {tournament.club && (
+              <p className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
+                <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <span className="truncate">
+                  {tournament.club.name}
+                  {tournament.club.zone && <span> · {tournament.club.zone}</span>}
+                </span>
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="px-5 pb-5">
+        <div className="mb-4 flex flex-col gap-2 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4" aria-hidden="true" />
+            <span>{formatDate(tournament.startDate)}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4" aria-hidden="true" />
+            <span className={isFull ? 'text-muted-foreground' : 'font-medium text-foreground'}>
+              {registeredTeams}/{tournament.teamCount} equipos
+            </span>
+          </div>
+        </div>
+
+        <div className="mb-4 h-2 overflow-hidden rounded-full bg-muted" aria-hidden="true">
+          <div
+            className="h-full rounded-full bg-primary transition-[width]"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+
+        {formOpen && !isFull ? (
+          <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+            <input
+              value={teamName}
+              onChange={(event) => setTeamName(event.target.value)}
+              maxLength={80}
+              placeholder="Nombre del equipo"
+              className="min-h-11 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none transition-colors focus:border-primary"
+            />
+            <div className="flex gap-2">
+              <Button type="submit" size="sm" disabled={submitting} className="flex-1">
+                {submitting && <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />}
+                Anotar
+              </Button>
+              <Button type="button" size="sm" variant="secondary" onClick={() => setFormOpen(false)}>
+                Cancelar
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            variant={isFull ? 'secondary' : 'default'}
+            disabled={isFull}
+            onClick={() => {
+              if (!isAuthenticated) {
+                window.location.href = '/login';
+                return;
+              }
+              setFormOpen(true);
+            }}
+            className="w-full"
+          >
+            {isFull ? 'Completo' : isAuthenticated ? 'Anotar equipo' : 'Iniciar sesión para anotar'}
+          </Button>
+        )}
+
+        {error && <p className="mt-3 text-sm text-destructive" role="alert">{error}</p>}
+        {success && <p className="mt-3 text-sm text-success-foreground" role="status">{success}</p>}
+      </div>
+    </article>
+  );
+}

--- a/apps/frontend/src/components/tournaments/TournamentList.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentList.tsx
@@ -1,0 +1,121 @@
+/**
+ * TournamentList - client-side hydrated public tournament listing.
+ *
+ * Decision Context:
+ * - Public listing shells fetch tournaments from the GraphQL proxy after hydration.
+ * - The backend already returns registration-only tournaments, but the client filters
+ *   defensively after a successful registration because a full tournament can transition
+ *   to IN_PROGRESS immediately.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { AlertCircle, RefreshCw, Trophy } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { GET_TOURNAMENTS, type TournamentListItem } from '@/graphql/operations/tournaments';
+import { TournamentCard } from './TournamentCard';
+
+interface GetTournamentsPayload {
+  tournaments: TournamentListItem[];
+}
+
+function keepRegistrationOnly(tournaments: TournamentListItem[]): TournamentListItem[] {
+  return tournaments.filter((tournament) => tournament.status === 'REGISTRATION');
+}
+
+interface TournamentListProps {
+  isAuthenticated?: boolean;
+}
+
+export function TournamentList({ isAuthenticated = false }: TournamentListProps) {
+  const [tournaments, setTournaments] = useState<TournamentListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetch('/api/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: GET_TOURNAMENTS }),
+    })
+      .then((response) => response.json())
+      .then((payload: { data?: GetTournamentsPayload; errors?: Array<{ message: string }> }) => {
+        if (cancelled) return;
+        const graphQLError = payload.errors?.[0]?.message;
+        if (graphQLError) throw new Error(graphQLError);
+        setTournaments(keepRegistrationOnly(payload.data?.tournaments ?? []));
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Error al cargar torneos');
+          setTournaments([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const handleRegistered = useCallback((updated: TournamentListItem) => {
+    setTournaments((current) =>
+      keepRegistrationOnly(
+        current.map((tournament) => (tournament.id === updated.id ? updated : tournament)),
+      ),
+    );
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {[1, 2, 3].map((item) => (
+          <div key={item} className="h-64 rounded-xl border border-border bg-muted animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-destructive/30 bg-destructive/10 p-6 text-center">
+        <AlertCircle className="mx-auto mb-3 h-7 w-7 text-destructive" aria-hidden="true" />
+        <p className="font-medium text-foreground">No pudimos cargar los torneos</p>
+        <p className="mt-1 text-sm text-muted-foreground">{error}</p>
+        <Button type="button" variant="secondary" className="mt-4" onClick={() => setReloadKey((key) => key + 1)}>
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          Reintentar
+        </Button>
+      </div>
+    );
+  }
+
+  if (tournaments.length === 0) {
+    return (
+      <div className="rounded-xl border border-border bg-card p-8 text-center">
+        <Trophy className="mx-auto mb-3 h-8 w-8 text-primary" aria-hidden="true" />
+        <p className="text-xl font-medium">No hay torneos en inscripción</p>
+        <p className="mt-2 text-muted-foreground">Cuando un club o jugador abra un torneo va a aparecer acá.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {tournaments.map((tournament) => (
+        <TournamentCard
+          key={tournament.id}
+          tournament={tournament}
+          isAuthenticated={isAuthenticated}
+          onRegistered={handleRegistered}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/graphql/operations/tournaments.graphql
+++ b/apps/frontend/src/graphql/operations/tournaments.graphql
@@ -1,5 +1,27 @@
 # Tournament creation
 
+query GetTournaments {
+  tournaments {
+    id
+    name
+    format
+    teamCount
+    playersPerTeam
+    registeredTeamsCount
+    status
+    description
+    startDate
+    endDate
+    club {
+      id
+      name
+      zone
+      address
+      imageUrl
+    }
+  }
+}
+
 mutation CreateTournament($input: CreateTournamentInput!) {
   createTournament(input: $input) {
     success
@@ -12,6 +34,7 @@ mutation CreateTournament($input: CreateTournamentInput!) {
       format
       teamCount
       playersPerTeam
+      registeredTeamsCount
       status
       description
       startDate
@@ -45,7 +68,22 @@ mutation RegisterTournamentTeam($input: RegisterTournamentTeamInput!) {
     message
     tournament {
       id
+      name
+      format
+      teamCount
+      playersPerTeam
+      registeredTeamsCount
       status
+      description
+      startDate
+      endDate
+      club {
+        id
+        name
+        zone
+        address
+        imageUrl
+      }
       fixtureMatches {
         id
         round

--- a/apps/frontend/src/graphql/operations/tournaments.ts
+++ b/apps/frontend/src/graphql/operations/tournaments.ts
@@ -46,6 +46,7 @@ export interface TournamentData {
   format: MatchFormat;
   teamCount: number;
   playersPerTeam: number;
+  registeredTeamsCount: number;
   status: TournamentStatus;
   description: string | null;
   startDate: string | null;
@@ -59,6 +60,26 @@ export interface TournamentData {
     imageUrl: string | null;
   } | null;
   fixtureMatches: TournamentFixtureMatch[];
+}
+
+export interface TournamentListItem {
+  id: string;
+  name: string;
+  format: MatchFormat;
+  teamCount: number;
+  playersPerTeam: number;
+  registeredTeamsCount: number;
+  status: TournamentStatus;
+  description: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  club: {
+    id: string;
+    name: string;
+    zone: string | null;
+    address: string | null;
+    imageUrl: string | null;
+  } | null;
 }
 
 export interface CreateTournamentResult {
@@ -80,6 +101,30 @@ export interface TournamentTeamRegistrationResult {
   tournament: TournamentData | null;
 }
 
+export const GET_TOURNAMENTS = /* GraphQL */ `
+  query GetTournaments {
+    tournaments {
+      id
+      name
+      format
+      teamCount
+      playersPerTeam
+      registeredTeamsCount
+      status
+      description
+      startDate
+      endDate
+      club {
+        id
+        name
+        zone
+        address
+        imageUrl
+      }
+    }
+  }
+`;
+
 export const CREATE_TOURNAMENT = /* GraphQL */ `
   mutation CreateTournament($input: CreateTournamentInput!) {
     createTournament(input: $input) {
@@ -93,6 +138,7 @@ export const CREATE_TOURNAMENT = /* GraphQL */ `
         format
         teamCount
         playersPerTeam
+        registeredTeamsCount
         status
         description
         startDate
@@ -128,7 +174,22 @@ export const REGISTER_TOURNAMENT_TEAM = /* GraphQL */ `
       message
       tournament {
         id
+        name
+        format
+        teamCount
+        playersPerTeam
+        registeredTeamsCount
         status
+        description
+        startDate
+        endDate
+        club {
+          id
+          name
+          zone
+          address
+          imageUrl
+        }
         fixtureMatches {
           id
           round

--- a/apps/frontend/src/pages/torneos/index.astro
+++ b/apps/frontend/src/pages/torneos/index.astro
@@ -1,0 +1,299 @@
+---
+/**
+ * Torneos - public listing with an auth-aware shell and hydrated React island.
+ *
+ * Decision Context:
+ * - Public discovery page, like /partidos: SSR shell reads optional session so the topbar
+ *   can show user actions when logged in; tournament data still loads client-side.
+ * - Auth is only required when registering a team; the card mutation routes through
+ *   /api/graphql-auth and redirects unauthenticated users to /login.
+ */
+export const prerender = false;
+
+import { Trophy, Volleyball } from 'lucide-react';
+import Layout from '../../layouts/Layout.astro';
+import { TournamentList } from '../../components/tournaments/TournamentList';
+
+const user = Astro.locals.user;
+const isAuthenticated = !!user;
+const nombre = user?.displayName || user?.email;
+---
+
+<Layout title="Torneos Disponibles - Sumate Ya">
+  <div class="app-shell">
+    <nav class="topbar">
+      <div class="topbar-inner">
+        <a class="topbar-brand" href="/partidos">
+          <span class="topbar-ball"><Volleyball size={20} strokeWidth={2} aria-hidden="true" /></span>
+          <span class="topbar-name">SUMATE YA</span>
+        </a>
+
+        <div class="topbar-actions">
+          {isAuthenticated ? (
+            <>
+              <a href="/partidos" class="nav-link">Partidos</a>
+              {user?.role === 'player' && (
+                <a href="/partidos/crear" class="btn-secondary-action">Crear partido</a>
+              )}
+              <a href="/torneos/crear" class="btn-crear">Crear torneo</a>
+              {user?.role === 'club_admin' && (
+                <a href="/panel-club" class="btn-secondary-action">Panel de Club</a>
+              )}
+              {user?.role === 'player' && <a href="/perfil" class="nav-link">Mi Perfil</a>}
+              <span class="user-badge">
+                <span class="user-dot"></span>
+                {nombre}
+              </span>
+              <form method="POST" action="/api/auth/logout">
+                <button type="submit" class="btn-logout">Salir</button>
+              </form>
+            </>
+          ) : (
+            <>
+              <a href="/partidos" class="nav-link">Partidos</a>
+              <a href="/login" class="btn-logout">Iniciar Sesión</a>
+            </>
+          )}
+        </div>
+      </div>
+      <div class="topbar-accent"></div>
+    </nav>
+
+    <main class="page-content">
+      <header class="section-header">
+        <div class="section-label">
+          <Trophy size={15} strokeWidth={2} aria-hidden="true" />
+          TORNEOS
+        </div>
+        <h1 class="section-title">Torneos Disponibles</h1>
+        <p class="section-sub">Encontrá una copa abierta y anotá tu equipo</p>
+      </header>
+
+      <section class="tournaments-section">
+        <TournamentList client:visible isAuthenticated={isAuthenticated} />
+      </section>
+    </main>
+  </div>
+</Layout>
+
+<style>
+  .app-shell {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .topbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: rgba(7, 15, 31, 0.85);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .topbar-inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.25rem;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .topbar-brand,
+  .section-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .topbar-brand {
+    text-decoration: none;
+  }
+
+  .topbar-ball,
+  .section-label {
+    color: hsl(42 100% 58%);
+  }
+
+  .topbar-name,
+  .section-title {
+    font-family: 'Bebas Neue', sans-serif;
+    font-weight: 400;
+    color: #fff;
+    line-height: 1;
+  }
+
+  .topbar-name {
+    font-size: 1.35rem;
+    letter-spacing: 0.1em;
+  }
+
+  .topbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .topbar-accent {
+    height: 2px;
+    background: linear-gradient(90deg, hsl(42 100% 55%), hsl(216 85% 45%), transparent);
+  }
+
+  .nav-link,
+  .btn-crear,
+  .btn-secondary-action {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    text-decoration: none;
+    border-radius: 6px;
+  }
+
+  .nav-link {
+    color: hsl(215 20% 65%);
+    padding: 0.3rem 0.6rem;
+  }
+
+  .nav-link:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: hsl(210 20% 92%);
+  }
+
+  .btn-crear,
+  .btn-secondary-action {
+    padding: 0.35rem 0.875rem;
+  }
+
+  .btn-crear {
+    background: hsl(35 100% 48%);
+    color: hsl(220 72% 7%);
+  }
+
+  .btn-crear:hover {
+    background: hsl(35 100% 55%);
+  }
+
+  .btn-secondary-action {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: hsl(210 20% 84%);
+  }
+
+  .btn-secondary-action:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+  }
+
+  .user-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(246, 164, 0, 0.12);
+    border: 1px solid rgba(246, 164, 0, 0.25);
+    color: hsl(35 100% 65%);
+    border-radius: 20px;
+    padding: 0.25rem 0.875rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    font-family: 'Barlow Condensed', sans-serif;
+    letter-spacing: 0.03em;
+  }
+
+  .user-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: hsl(35 100% 55%);
+    box-shadow: 0 0 4px hsl(35 100% 55%);
+  }
+
+  .btn-logout {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 6px;
+    padding: 0.3rem 0.75rem;
+    color: hsl(215 20% 60%);
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.8125rem;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .btn-logout:hover {
+    background: rgba(255, 255, 255, 0.07);
+    color: hsl(210 20% 90%);
+  }
+
+  .page-content {
+    flex: 1;
+    max-width: 1100px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 2.5rem 1.25rem;
+  }
+
+  .section-header {
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .section-label {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    margin-bottom: 0.5rem;
+  }
+
+  .section-title {
+    font-size: clamp(1.75rem, 5vw, 2.5rem);
+    letter-spacing: 0.04em;
+    margin: 0 0 0.375rem;
+  }
+
+  .section-sub {
+    margin: 0;
+    color: hsl(215 20% 50%);
+    font-size: 0.9rem;
+    font-family: 'Barlow', sans-serif;
+  }
+
+  .tournaments-section {
+    min-height: 220px;
+  }
+
+  @media (max-width: 767px) {
+    .topbar-inner {
+      padding: 0 1rem;
+    }
+
+    .nav-link,
+    .btn-crear,
+    .btn-secondary-action {
+      display: none;
+    }
+
+    .user-badge {
+      max-width: 120px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      padding: 0.25rem 0.625rem;
+    }
+
+    .page-content {
+      padding: 1.25rem 1rem;
+    }
+
+    .section-header {
+      margin-bottom: 1.5rem;
+    }
+  }
+</style>

--- a/docs/prompts/n6t4q8kp-prompt-log.md
+++ b/docs/prompts/n6t4q8kp-prompt-log.md
@@ -1,0 +1,19 @@
+# n6t4q8kp - Home y sesión en torneos
+
+## Prompt
+
+Agregar acceso a torneos desde el home de forma similar a "Ver partidos" y hacer que la pantalla `/torneos` detecte si el usuario esta logueado.
+
+## Cambios
+
+- Agregue una seccion "Torneos Disponibles" en el home con `TournamentList` y boton "Ver todos".
+- Pase `isAuthenticated` desde el home al listado de torneos para ajustar el CTA de inscripcion.
+- Actualice `TournamentCard` para redirigir a `/login` antes de abrir el formulario si no hay sesion.
+- Converti `/torneos` en shell SSR publico para leer `Astro.locals.user`.
+- Actualice la topbar de `/torneos` para mostrar acciones de usuario, perfil/panel y logout cuando corresponde.
+
+## Verificacion
+
+- `pnpm.cmd --filter @sumate-ya/frontend typecheck`
+- `GET http://localhost:4321/` devolvio 200.
+- `GET http://localhost:4321/torneos` devolvio 200.

--- a/docs/prompts/q5r8t2vn-prompt-log.md
+++ b/docs/prompts/q5r8t2vn-prompt-log.md
@@ -1,0 +1,21 @@
+# q5r8t2vn - Listado de torneos disponibles
+
+## Prompt
+
+Implementar la user story de jugador para ver torneos disponibles en `/torneos`, basada en la epica de listado de partidos.
+
+## Cambios
+
+- Agregue la query GraphQL `tournaments` para torneos en `registration`.
+- Sume `registeredTeamsCount` al contrato de torneo para mostrar progreso de inscripcion.
+- Implemente repository, service con Redis e invalidacion al crear/registrar equipos, y resolver de query.
+- Cree la pagina estatica `/torneos` con isla React `client:visible`.
+- Cree `TournamentList` y `TournamentCard` con progreso `equipos registrados/total` y alta inline de equipo.
+
+## Verificacion
+
+- `pnpm.cmd --filter @sumate-ya/backend codegen`
+- `pnpm.cmd --filter @sumate-ya/backend typecheck`
+- `pnpm.cmd --filter @sumate-ya/frontend typecheck`
+- `GET http://localhost:4321/torneos` devolvio 200.
+- Query local `tournaments` devolvio torneos en `REGISTRATION` con `registeredTeamsCount`.


### PR DESCRIPTION
Agrega la página `/torneos` con listado público de torneos en inscripción, cards con progreso de equipos registrados y acción para anotar equipo.

También suma la query GraphQL `tournaments`, cache Redis en el service, conteo `registeredTeamsCount`, acceso desde el home y topbar de torneos sensible a sesión.