### PR TITLE
feat(tournaments): add tournament detail page and registration form

### DIFF
--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -639,6 +639,7 @@ export type Query = {
   profile?: Maybe<Profile>;
   slotAuditLog: Array<SlotAuditLog>;
   slotImpactPreview: SlotImpactPreview;
+  tournament?: Maybe<Tournament>;
   tournaments: Array<Tournament>;
 };
 
@@ -710,6 +711,11 @@ export type QuerySlotAuditLogArgs = {
 
 export type QuerySlotImpactPreviewArgs = {
   slotIds: Array<Scalars['ID']['input']>;
+};
+
+
+export type QueryTournamentArgs = {
+  id: Scalars['ID']['input'];
 };
 
 export type RegisterTournamentTeamInput = {
@@ -808,12 +814,14 @@ export type Tournament = {
   format: MatchFormat;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  organizer?: Maybe<TournamentPlayer>;
   organizerId: Scalars['ID']['output'];
   playersPerTeam: Scalars['Int']['output'];
   registeredTeamsCount: Scalars['Int']['output'];
   startDate?: Maybe<Scalars['String']['output']>;
   status: TournamentStatus;
   teamCount: Scalars['Int']['output'];
+  teams: Array<TournamentTeam>;
 };
 
 export type TournamentClub = {
@@ -827,14 +835,26 @@ export type TournamentClub = {
 
 export type TournamentFixtureMatch = {
   __typename?: 'TournamentFixtureMatch';
+  awayTeam?: Maybe<TournamentTeam>;
   awayTeamId?: Maybe<Scalars['ID']['output']>;
   courtId?: Maybe<Scalars['ID']['output']>;
+  homeTeam?: Maybe<TournamentTeam>;
   homeTeamId?: Maybe<Scalars['ID']['output']>;
   id: Scalars['ID']['output'];
   round: Scalars['Int']['output'];
   scheduledAt?: Maybe<Scalars['String']['output']>;
+  scoreAway?: Maybe<Scalars['Int']['output']>;
+  scoreHome?: Maybe<Scalars['Int']['output']>;
   status: FixtureMatchStatus;
   tournamentId: Scalars['ID']['output'];
+};
+
+export type TournamentPlayer = {
+  __typename?: 'TournamentPlayer';
+  avatarUrl?: Maybe<Scalars['String']['output']>;
+  displayName: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  preferredPosition?: Maybe<PlayerPosition>;
 };
 
 export type TournamentScheduleSlotInput = {
@@ -848,6 +868,16 @@ export enum TournamentStatus {
   InProgress = 'IN_PROGRESS',
   Registration = 'REGISTRATION'
 }
+
+export type TournamentTeam = {
+  __typename?: 'TournamentTeam';
+  captain?: Maybe<TournamentPlayer>;
+  captainId: Scalars['ID']['output'];
+  createdAt: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  players: Array<TournamentPlayer>;
+};
 
 export type TournamentTeamRegistrationResult = {
   __typename?: 'TournamentTeamRegistrationResult';
@@ -1057,8 +1087,10 @@ export type ResolversTypes = ResolversObject<{
   Tournament: ResolverTypeWrapper<Tournament>;
   TournamentClub: ResolverTypeWrapper<TournamentClub>;
   TournamentFixtureMatch: ResolverTypeWrapper<TournamentFixtureMatch>;
+  TournamentPlayer: ResolverTypeWrapper<TournamentPlayer>;
   TournamentScheduleSlotInput: TournamentScheduleSlotInput;
   TournamentStatus: TournamentStatus;
+  TournamentTeam: ResolverTypeWrapper<TournamentTeam>;
   TournamentTeamRegistrationResult: ResolverTypeWrapper<TournamentTeamRegistrationResult>;
   UpdateClubSlotInput: UpdateClubSlotInput;
   UpdateCourtPricingInput: UpdateCourtPricingInput;
@@ -1132,7 +1164,9 @@ export type ResolversParentTypes = ResolversObject<{
   Tournament: Tournament;
   TournamentClub: TournamentClub;
   TournamentFixtureMatch: TournamentFixtureMatch;
+  TournamentPlayer: TournamentPlayer;
   TournamentScheduleSlotInput: TournamentScheduleSlotInput;
+  TournamentTeam: TournamentTeam;
   TournamentTeamRegistrationResult: TournamentTeamRegistrationResult;
   UpdateClubSlotInput: UpdateClubSlotInput;
   UpdateCourtPricingInput: UpdateCourtPricingInput;
@@ -1491,6 +1525,7 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   profile?: Resolver<Maybe<ResolversTypes['Profile']>, ParentType, ContextType, RequireFields<QueryProfileArgs, 'id'>>;
   slotAuditLog?: Resolver<Array<ResolversTypes['SlotAuditLog']>, ParentType, ContextType, RequireFields<QuerySlotAuditLogArgs, 'slotId'>>;
   slotImpactPreview?: Resolver<ResolversTypes['SlotImpactPreview'], ParentType, ContextType, RequireFields<QuerySlotImpactPreviewArgs, 'slotIds'>>;
+  tournament?: Resolver<Maybe<ResolversTypes['Tournament']>, ParentType, ContextType, RequireFields<QueryTournamentArgs, 'id'>>;
   tournaments?: Resolver<Array<ResolversTypes['Tournament']>, ParentType, ContextType>;
 }>;
 
@@ -1545,12 +1580,14 @@ export type TournamentResolvers<ContextType = GraphQLContext, ParentType extends
   format?: Resolver<ResolversTypes['MatchFormat'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  organizer?: Resolver<Maybe<ResolversTypes['TournamentPlayer']>, ParentType, ContextType>;
   organizerId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   playersPerTeam?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   registeredTeamsCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   startDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   status?: Resolver<ResolversTypes['TournamentStatus'], ParentType, ContextType>;
   teamCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  teams?: Resolver<Array<ResolversTypes['TournamentTeam']>, ParentType, ContextType>;
 }>;
 
 export type TournamentClubResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TournamentClub'] = ResolversParentTypes['TournamentClub']> = ResolversObject<{
@@ -1562,14 +1599,34 @@ export type TournamentClubResolvers<ContextType = GraphQLContext, ParentType ext
 }>;
 
 export type TournamentFixtureMatchResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TournamentFixtureMatch'] = ResolversParentTypes['TournamentFixtureMatch']> = ResolversObject<{
+  awayTeam?: Resolver<Maybe<ResolversTypes['TournamentTeam']>, ParentType, ContextType>;
   awayTeamId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   courtId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  homeTeam?: Resolver<Maybe<ResolversTypes['TournamentTeam']>, ParentType, ContextType>;
   homeTeamId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   round?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   scheduledAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scoreAway?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  scoreHome?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   status?: Resolver<ResolversTypes['FixtureMatchStatus'], ParentType, ContextType>;
   tournamentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+}>;
+
+export type TournamentPlayerResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TournamentPlayer'] = ResolversParentTypes['TournamentPlayer']> = ResolversObject<{
+  avatarUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  preferredPosition?: Resolver<Maybe<ResolversTypes['PlayerPosition']>, ParentType, ContextType>;
+}>;
+
+export type TournamentTeamResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TournamentTeam'] = ResolversParentTypes['TournamentTeam']> = ResolversObject<{
+  captain?: Resolver<Maybe<ResolversTypes['TournamentPlayer']>, ParentType, ContextType>;
+  captainId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  players?: Resolver<Array<ResolversTypes['TournamentPlayer']>, ParentType, ContextType>;
 }>;
 
 export type TournamentTeamRegistrationResultResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TournamentTeamRegistrationResult'] = ResolversParentTypes['TournamentTeamRegistrationResult']> = ResolversObject<{
@@ -1626,6 +1683,8 @@ export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   Tournament?: TournamentResolvers<ContextType>;
   TournamentClub?: TournamentClubResolvers<ContextType>;
   TournamentFixtureMatch?: TournamentFixtureMatchResolvers<ContextType>;
+  TournamentPlayer?: TournamentPlayerResolvers<ContextType>;
+  TournamentTeam?: TournamentTeamResolvers<ContextType>;
   TournamentTeamRegistrationResult?: TournamentTeamRegistrationResultResolvers<ContextType>;
   VoteSubmissionResult?: VoteSubmissionResultResolvers<ContextType>;
 }>;

--- a/apps/backend/src/graphql/resolvers/domains/tournament.ts
+++ b/apps/backend/src/graphql/resolvers/domains/tournament.ts
@@ -48,6 +48,12 @@ const RegisterTournamentTeamSchema = z.object({
 
 const Query: QueryResolvers = {
   tournaments: async () => tournamentService.listRegistrationTournaments({}),
+  tournament: async (_parent, args) => {
+    const parsed = z.string().regex(UUID_REGEX, 'id invÃ¡lido').safeParse(args.id);
+    if (!parsed.success) return null;
+
+    return tournamentService.getTournamentById({}, parsed.data);
+  },
 };
 
 const Mutation: MutationResolvers = {

--- a/apps/backend/src/graphql/schema/tournament.graphql
+++ b/apps/backend/src/graphql/schema/tournament.graphql
@@ -38,14 +38,35 @@ type TournamentFixtureMatch {
   round: Int!
   homeTeamId: ID
   awayTeamId: ID
+  homeTeam: TournamentTeam
+  awayTeam: TournamentTeam
   courtId: ID
   scheduledAt: String
   status: FixtureMatchStatus!
+  scoreHome: Int
+  scoreAway: Int
+}
+
+type TournamentPlayer {
+  id: ID!
+  displayName: String!
+  avatarUrl: String
+  preferredPosition: PlayerPosition
+}
+
+type TournamentTeam {
+  id: ID!
+  name: String!
+  captainId: ID!
+  captain: TournamentPlayer
+  players: [TournamentPlayer!]!
+  createdAt: String!
 }
 
 type Tournament {
   id: ID!
   organizerId: ID!
+  organizer: TournamentPlayer
   name: String!
   format: MatchFormat!
   teamCount: Int!
@@ -57,6 +78,7 @@ type Tournament {
   endDate: String
   createdAt: String!
   club: TournamentClub
+  teams: [TournamentTeam!]!
   fixtureMatches: [TournamentFixtureMatch!]!
 }
 
@@ -96,6 +118,7 @@ input RegisterTournamentTeamInput {
 
 extend type Query {
   tournaments: [Tournament!]!
+  tournament(id: ID!): Tournament
 }
 
 extend type Mutation {

--- a/apps/backend/src/repositories/tournamentRepository.ts
+++ b/apps/backend/src/repositories/tournamentRepository.ts
@@ -46,6 +46,23 @@ const FIXTURE_COLUMNS = `
   "courtId",
   "scheduledAt",
   status,
+  "scoreHome",
+  "scoreAway",
+  "createdAt"
+`;
+
+const TOURNAMENT_PLAYER_COLUMNS = `
+  id,
+  "displayName",
+  "avatarUrl",
+  "preferredPosition"
+`;
+
+const TOURNAMENT_TEAM_COLUMNS = `
+  id,
+  "tournamentId",
+  name,
+  "captainId",
   "createdAt"
 `;
 
@@ -80,9 +97,13 @@ export interface FixtureMatchRow {
   round: number;
   homeTeamId: string | null;
   awayTeamId: string | null;
+  homeTeam?: TournamentTeamRow | null;
+  awayTeam?: TournamentTeamRow | null;
   courtId: string | null;
   scheduledAt: string | null;
   status: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
   createdAt: string;
 }
 
@@ -104,8 +125,10 @@ export interface TournamentRow {
   endDate: string | null;
   createdAt: string;
   clubs?: TournamentClubRow | null;
+  organizer?: TournamentPlayerRow | null;
   fixtureMatches?: FixtureMatchRow[];
-  tournamentTeams?: TournamentTeamCountRow[];
+  registeredTeams?: TournamentTeamCountRow[];
+  tournamentTeams?: TournamentTeamRow[];
 }
 
 export interface TournamentSlotCourtRow {
@@ -180,8 +203,23 @@ export interface TournamentTeamRow {
   id: string;
   tournamentId?: string;
   name: string;
-  captainId?: string;
-  createdAt?: string;
+  captainId: string;
+  captain?: TournamentPlayerRow | null;
+  members?: TournamentTeamMemberRow[];
+  createdAt: string;
+}
+
+export interface TournamentPlayerRow {
+  id: string;
+  displayName: string;
+  avatarUrl: string | null;
+  preferredPosition: string | null;
+}
+
+export interface TournamentTeamMemberRow {
+  id: string;
+  joinedAt: string;
+  player: TournamentPlayerRow | null;
 }
 
 function isMissingTournamentRpcError(message: string): boolean {
@@ -379,7 +417,26 @@ export async function getTournamentById(
   const { data, error } = await client
     .from('tournaments')
     .select(
-      `${TOURNAMENT_COLUMNS}, clubs(${TOURNAMENT_CLUB_COLUMNS}), fixtureMatches(${FIXTURE_COLUMNS}), tournamentTeams(count)`,
+      `
+        ${TOURNAMENT_COLUMNS},
+        clubs(${TOURNAMENT_CLUB_COLUMNS}),
+        organizer:profiles!tournaments_organizerId_fkey(${TOURNAMENT_PLAYER_COLUMNS}),
+        registeredTeams:tournamentTeams(count),
+        tournamentTeams(
+          ${TOURNAMENT_TEAM_COLUMNS},
+          captain:profiles!tournamentTeams_captainId_fkey(${TOURNAMENT_PLAYER_COLUMNS}),
+          members:tournamentTeamMembers(
+            id,
+            "joinedAt",
+            player:profiles!tournamentTeamMembers_playerId_fkey(${TOURNAMENT_PLAYER_COLUMNS})
+          )
+        ),
+        fixtureMatches(
+          ${FIXTURE_COLUMNS},
+          homeTeam:tournamentTeams!fixtureMatches_homeTeamId_fkey(id, name, "captainId", "createdAt"),
+          awayTeam:tournamentTeams!fixtureMatches_awayTeamId_fkey(id, name, "captainId", "createdAt")
+        )
+      `,
     )
     .eq('id', tournamentId)
     .single();
@@ -398,7 +455,7 @@ export async function getRegistrationTournaments(
 ): Promise<TournamentRow[]> {
   const { data, error } = await client
     .from('tournaments')
-    .select(`${TOURNAMENT_COLUMNS}, clubs(${TOURNAMENT_CLUB_COLUMNS}), tournamentTeams(count)`)
+    .select(`${TOURNAMENT_COLUMNS}, clubs(${TOURNAMENT_CLUB_COLUMNS}), registeredTeams:tournamentTeams(count)`)
     .eq('status', 'registration')
     .order('startDate', { ascending: true })
     .order('createdAt', { ascending: false });
@@ -417,7 +474,7 @@ export async function getTournamentTeams(
 ): Promise<TournamentTeamRow[]> {
   const { data, error } = await client
     .from('tournamentTeams')
-    .select('id, name')
+    .select('id, "tournamentId", name, "captainId", "createdAt"')
     .eq('tournamentId', tournamentId)
     .order('createdAt', { ascending: true });
 

--- a/apps/backend/src/services/tournamentService.ts
+++ b/apps/backend/src/services/tournamentService.ts
@@ -14,19 +14,24 @@ import { cacheDeletePattern, cacheGetOrSet, CACHE_PREFIX, CACHE_TTL } from '../c
 import {
   FixtureMatchStatus,
   MatchFormat,
+  PlayerPosition,
   TournamentStatus,
   type CreateTournamentInput,
   type CreateTournamentResult,
   type RegisterTournamentTeamInput,
   type Tournament,
   type TournamentFixtureMatch,
+  type TournamentPlayer,
+  type TournamentTeam,
   type TournamentTeamRegistrationResult,
 } from '../graphql/generated/graphql.js';
 import {
   tournamentRepository,
   type FixtureMatchRow,
+  type TournamentPlayerRow,
   type TournamentRow,
   type TournamentSlotRow,
+  type TournamentTeamRow,
 } from '../repositories/tournamentRepository.js';
 import { clubRepository } from '../repositories/clubRepository.js';
 import { dateToDayOfWeek } from './clubService.js';
@@ -64,6 +69,13 @@ const DB_TO_FIXTURE_STATUS: Record<string, FixtureMatchStatus> = {
   cancelled: FixtureMatchStatus.Cancelled,
 };
 
+const DB_TO_PLAYER_POSITION: Record<string, PlayerPosition> = {
+  goalkeeper: PlayerPosition.Goalkeeper,
+  defender: PlayerPosition.Defender,
+  midfielder: PlayerPosition.Midfielder,
+  forward: PlayerPosition.Forward,
+};
+
 const FORMAT_ORDER: Record<string, number> = {
   '5v5': 1,
   '7v7': 2,
@@ -72,6 +84,7 @@ const FORMAT_ORDER: Record<string, number> = {
 };
 
 const TOURNAMENTS_REGISTRATION_CACHE_KEY = `${CACHE_PREFIX.TOURNAMENTS_LIST}:status:registration`;
+const TOURNAMENT_DETAIL_CACHE_PREFIX = `${CACHE_PREFIX.TOURNAMENTS_LIST}:detail:`;
 
 // =====================================================
 // Helpers
@@ -108,6 +121,32 @@ function slotTimeKey(courtId: string | null | undefined, scheduledAt: string | n
   return `${courtId ?? ''}|${dateFromTimestamp(scheduledAt)}|${timeFromTimestamp(scheduledAt)}`;
 }
 
+function toTournamentPlayer(row: TournamentPlayerRow | null | undefined): TournamentPlayer | null {
+  if (!row) return null;
+
+  return {
+    id: row.id,
+    displayName: row.displayName,
+    avatarUrl: row.avatarUrl,
+    preferredPosition: row.preferredPosition ? (DB_TO_PLAYER_POSITION[row.preferredPosition] ?? null) : null,
+  };
+}
+
+function toTournamentTeam(row: TournamentTeamRow): TournamentTeam {
+  const players = (row.members ?? [])
+    .map((member) => toTournamentPlayer(member.player))
+    .filter((player): player is TournamentPlayer => Boolean(player));
+
+  return {
+    id: row.id,
+    name: row.name,
+    captainId: row.captainId,
+    captain: toTournamentPlayer(row.captain),
+    players,
+    createdAt: row.createdAt,
+  };
+}
+
 function toFixtureMatch(row: FixtureMatchRow): TournamentFixtureMatch {
   return {
     id: row.id,
@@ -115,9 +154,13 @@ function toFixtureMatch(row: FixtureMatchRow): TournamentFixtureMatch {
     round: row.round,
     homeTeamId: row.homeTeamId,
     awayTeamId: row.awayTeamId,
+    homeTeam: row.homeTeam ? toTournamentTeam(row.homeTeam) : null,
+    awayTeam: row.awayTeam ? toTournamentTeam(row.awayTeam) : null,
     courtId: row.courtId,
     scheduledAt: row.scheduledAt,
     status: DB_TO_FIXTURE_STATUS[row.status] ?? FixtureMatchStatus.Scheduled,
+    scoreHome: row.scoreHome,
+    scoreAway: row.scoreAway,
   };
 }
 
@@ -126,11 +169,12 @@ function toTournament(row: TournamentRow): Tournament {
     if (a.round !== b.round) return a.round - b.round;
     return (a.scheduledAt ?? '').localeCompare(b.scheduledAt ?? '');
   });
-  const registeredTeamsCount = row.tournamentTeams?.[0]?.count ?? 0;
+  const registeredTeamsCount = row.registeredTeams?.[0]?.count ?? row.tournamentTeams?.length ?? 0;
 
   return {
     id: row.id,
     organizerId: row.organizerId,
+    organizer: toTournamentPlayer(row.organizer),
     name: row.name,
     format: DB_TO_FORMAT[row.format] ?? MatchFormat.FiveVsFive,
     teamCount: row.teamCount,
@@ -150,6 +194,7 @@ function toTournament(row: TournamentRow): Tournament {
           imageUrl: row.clubs.imageUrl,
         }
       : null,
+    teams: (row.tournamentTeams ?? []).map(toTournamentTeam),
     fixtureMatches: fixtureMatches.map(toFixtureMatch),
   };
 }
@@ -303,6 +348,19 @@ export async function listRegistrationTournaments(_ctx: ServiceContext): Promise
   return tournaments.map(toTournament);
 }
 
+export async function getTournamentById(
+  _ctx: ServiceContext,
+  tournamentId: string,
+): Promise<Tournament | null> {
+  const tournament = await cacheGetOrSet<TournamentRow | null>(
+    `${TOURNAMENT_DETAIL_CACHE_PREFIX}${tournamentId}`,
+    () => tournamentRepository.getTournamentById(tournamentId),
+    CACHE_TTL.DYNAMIC_DATA,
+  );
+
+  return tournament ? toTournament(tournament) : null;
+}
+
 export async function createTournament(
   input: CreateTournamentInput,
   ctx: ServiceContext,
@@ -448,6 +506,7 @@ export async function registerTournamentTeam(
 
 export const tournamentService = {
   listRegistrationTournaments,
+  getTournamentById,
   createTournament,
   generateFixtureIfRegistrationComplete,
   registerTournamentTeam,

--- a/apps/frontend/src/components/tournaments/TournamentCard.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentCard.tsx
@@ -135,8 +135,10 @@ export function TournamentCard({
             <Trophy className="h-5 w-5" aria-hidden="true" />
           </div>
           <div className="min-w-0 flex-1">
-            <h2 className="truncate font-[Bebas_Neue,sans-serif] text-2xl leading-none tracking-[0.04em] text-foreground">
-              {tournament.name}
+            <h2 className="truncate font-[Bebas_Neue,sans-serif] text-2xl leading-none tracking-[0.04em]">
+              <a href={`/torneos/${tournament.id}`} className="text-foreground hover:text-primary">
+                {tournament.name}
+              </a>
             </h2>
             {tournament.club && (
               <p className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
@@ -209,6 +211,13 @@ export function TournamentCard({
             {isFull ? 'Completo' : isAuthenticated ? 'Anotar equipo' : 'Iniciar sesión para anotar'}
           </Button>
         )}
+
+        <a
+          href={`/torneos/${tournament.id}`}
+          className="mt-2 block rounded-md border border-border px-3 py-2 text-center text-sm font-semibold text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
+        >
+          Ver detalle
+        </a>
 
         {error && <p className="mt-3 text-sm text-destructive" role="alert">{error}</p>}
         {success && <p className="mt-3 text-sm text-success-foreground" role="status">{success}</p>}

--- a/apps/frontend/src/components/tournaments/TournamentRegistrationForm.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentRegistrationForm.tsx
@@ -1,0 +1,124 @@
+import { type SyntheticEvent, useState } from 'react';
+import { Loader2, LogIn, UserPlus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  REGISTER_TOURNAMENT_TEAM,
+  type TournamentTeamRegistrationResult,
+} from '@/graphql/operations/tournaments';
+
+interface TournamentRegistrationFormProps {
+  tournamentId: string;
+  isAuthenticated: boolean;
+  canRegister: boolean;
+}
+
+function isAuthError(message: string): boolean {
+  return message.toLowerCase().includes('authentication required');
+}
+
+export function TournamentRegistrationForm({
+  tournamentId,
+  isAuthenticated,
+  canRegister,
+}: TournamentRegistrationFormProps) {
+  const [teamName, setTeamName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: SyntheticEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!isAuthenticated) {
+      window.location.href = '/login';
+      return;
+    }
+
+    const name = teamName.trim();
+    if (name.length < 2) {
+      setError('Ingresá al menos 2 caracteres para el equipo.');
+      return;
+    }
+
+    setSubmitting(true);
+    setMessage(null);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/graphql-auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: REGISTER_TOURNAMENT_TEAM,
+          variables: { input: { tournamentId, name } },
+        }),
+      });
+
+      const payload = (await response.json()) as {
+        data?: { registerTournamentTeam?: TournamentTeamRegistrationResult };
+        errors?: Array<{ message: string }>;
+      };
+
+      const graphQLError = payload.errors?.[0]?.message;
+      if (graphQLError) {
+        if (isAuthError(graphQLError)) window.location.href = '/login';
+        throw new Error(graphQLError);
+      }
+
+      const result = payload.data?.registerTournamentTeam;
+      if (!result) throw new Error('Respuesta inesperada del servidor');
+      if (!result.success) {
+        const resultMessage = result.message ?? 'No se pudo inscribir el equipo';
+        if (isAuthError(resultMessage)) window.location.href = '/login';
+        throw new Error(resultMessage);
+      }
+
+      setMessage('Equipo anotado. Actualizando torneo...');
+      window.location.reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al inscribir el equipo');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!canRegister) {
+    return (
+      <div className="registration-closed" role="status">
+        <span>Inscripción cerrada o cupos completos</span>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <a className="detail-login-button" href="/login">
+        <LogIn className="h-4 w-4" aria-hidden="true" />
+        Iniciar sesión para anotar equipo
+      </a>
+    );
+  }
+
+  return (
+    <form className="detail-register-form" onSubmit={handleSubmit}>
+      <label className="sr-only" htmlFor="teamName">Nombre del equipo</label>
+      <input
+        id="teamName"
+        value={teamName}
+        onChange={(event) => setTeamName(event.target.value)}
+        maxLength={80}
+        placeholder="Nombre del equipo"
+        className="detail-team-input"
+      />
+      <Button type="submit" disabled={submitting}>
+        {submitting ? (
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        ) : (
+          <UserPlus className="h-4 w-4" aria-hidden="true" />
+        )}
+        Anotar equipo
+      </Button>
+      {error && <p className="detail-form-error" role="alert">{error}</p>}
+      {message && <p className="detail-form-message" role="status">{message}</p>}
+    </form>
+  );
+}

--- a/apps/frontend/src/graphql/operations/tournaments.graphql
+++ b/apps/frontend/src/graphql/operations/tournaments.graphql
@@ -22,6 +22,74 @@ query GetTournaments {
   }
 }
 
+query GetTournamentDetail($id: ID!) {
+  tournament(id: $id) {
+    id
+    organizerId
+    organizer {
+      id
+      displayName
+      avatarUrl
+      preferredPosition
+    }
+    name
+    format
+    teamCount
+    playersPerTeam
+    registeredTeamsCount
+    status
+    description
+    startDate
+    endDate
+    createdAt
+    club {
+      id
+      name
+      zone
+      address
+      imageUrl
+    }
+    teams {
+      id
+      name
+      captainId
+      captain {
+        id
+        displayName
+        avatarUrl
+        preferredPosition
+      }
+      players {
+        id
+        displayName
+        avatarUrl
+        preferredPosition
+      }
+      createdAt
+    }
+    fixtureMatches {
+      id
+      tournamentId
+      round
+      homeTeamId
+      awayTeamId
+      homeTeam {
+        id
+        name
+      }
+      awayTeam {
+        id
+        name
+      }
+      courtId
+      scheduledAt
+      status
+      scoreHome
+      scoreAway
+    }
+  }
+}
+
 mutation CreateTournament($input: CreateTournamentInput!) {
   createTournament(input: $input) {
     success
@@ -30,6 +98,12 @@ mutation CreateTournament($input: CreateTournamentInput!) {
     tournament {
       id
       organizerId
+      organizer {
+        id
+        displayName
+        avatarUrl
+        preferredPosition
+      }
       name
       format
       teamCount
@@ -53,9 +127,19 @@ mutation CreateTournament($input: CreateTournamentInput!) {
         round
         homeTeamId
         awayTeamId
+        homeTeam {
+          id
+          name
+        }
+        awayTeam {
+          id
+          name
+        }
         courtId
         scheduledAt
         status
+        scoreHome
+        scoreAway
       }
     }
   }
@@ -86,11 +170,23 @@ mutation RegisterTournamentTeam($input: RegisterTournamentTeamInput!) {
       }
       fixtureMatches {
         id
+        tournamentId
         round
         homeTeamId
         awayTeamId
+        homeTeam {
+          id
+          name
+        }
+        awayTeam {
+          id
+          name
+        }
+        courtId
         scheduledAt
         status
+        scoreHome
+        scoreAway
       }
     }
   }

--- a/apps/frontend/src/graphql/operations/tournaments.ts
+++ b/apps/frontend/src/graphql/operations/tournaments.ts
@@ -34,14 +34,40 @@ export interface TournamentFixtureMatch {
   round: number;
   homeTeamId: string | null;
   awayTeamId: string | null;
+  homeTeam: TournamentFixtureTeam | null;
+  awayTeam: TournamentFixtureTeam | null;
   courtId: string | null;
   scheduledAt: string | null;
   status: FixtureMatchStatus;
+  scoreHome: number | null;
+  scoreAway: number | null;
+}
+
+export interface TournamentPlayer {
+  id: string;
+  displayName: string;
+  avatarUrl: string | null;
+  preferredPosition: 'GOALKEEPER' | 'DEFENDER' | 'MIDFIELDER' | 'FORWARD' | null;
+}
+
+export interface TournamentFixtureTeam {
+  id: string;
+  name: string;
+}
+
+export interface TournamentTeam {
+  id: string;
+  name: string;
+  captainId: string;
+  captain: TournamentPlayer | null;
+  players: TournamentPlayer[];
+  createdAt: string;
 }
 
 export interface TournamentData {
   id: string;
   organizerId: string;
+  organizer: TournamentPlayer | null;
   name: string;
   format: MatchFormat;
   teamCount: number;
@@ -59,6 +85,7 @@ export interface TournamentData {
     address: string | null;
     imageUrl: string | null;
   } | null;
+  teams: TournamentTeam[];
   fixtureMatches: TournamentFixtureMatch[];
 }
 
@@ -125,6 +152,76 @@ export const GET_TOURNAMENTS = /* GraphQL */ `
   }
 `;
 
+export const GET_TOURNAMENT_DETAIL = /* GraphQL */ `
+  query GetTournamentDetail($id: ID!) {
+    tournament(id: $id) {
+      id
+      organizerId
+      organizer {
+        id
+        displayName
+        avatarUrl
+        preferredPosition
+      }
+      name
+      format
+      teamCount
+      playersPerTeam
+      registeredTeamsCount
+      status
+      description
+      startDate
+      endDate
+      createdAt
+      club {
+        id
+        name
+        zone
+        address
+        imageUrl
+      }
+      teams {
+        id
+        name
+        captainId
+        captain {
+          id
+          displayName
+          avatarUrl
+          preferredPosition
+        }
+        players {
+          id
+          displayName
+          avatarUrl
+          preferredPosition
+        }
+        createdAt
+      }
+      fixtureMatches {
+        id
+        tournamentId
+        round
+        homeTeamId
+        awayTeamId
+        homeTeam {
+          id
+          name
+        }
+        awayTeam {
+          id
+          name
+        }
+        courtId
+        scheduledAt
+        status
+        scoreHome
+        scoreAway
+      }
+    }
+  }
+`;
+
 export const CREATE_TOURNAMENT = /* GraphQL */ `
   mutation CreateTournament($input: CreateTournamentInput!) {
     createTournament(input: $input) {
@@ -134,6 +231,12 @@ export const CREATE_TOURNAMENT = /* GraphQL */ `
       tournament {
         id
         organizerId
+        organizer {
+          id
+          displayName
+          avatarUrl
+          preferredPosition
+        }
         name
         format
         teamCount
@@ -157,9 +260,19 @@ export const CREATE_TOURNAMENT = /* GraphQL */ `
           round
           homeTeamId
           awayTeamId
+          homeTeam {
+            id
+            name
+          }
+          awayTeam {
+            id
+            name
+          }
           courtId
           scheduledAt
           status
+          scoreHome
+          scoreAway
         }
       }
     }
@@ -192,11 +305,23 @@ export const REGISTER_TOURNAMENT_TEAM = /* GraphQL */ `
         }
         fixtureMatches {
           id
+          tournamentId
           round
           homeTeamId
           awayTeamId
+          homeTeam {
+            id
+            name
+          }
+          awayTeam {
+            id
+            name
+          }
+          courtId
           scheduledAt
           status
+          scoreHome
+          scoreAway
         }
       }
     }

--- a/apps/frontend/src/pages/torneos/[id].astro
+++ b/apps/frontend/src/pages/torneos/[id].astro
@@ -1,0 +1,383 @@
+---
+/**
+ * /torneos/[id] - Detalle publico de torneo.
+ *
+ * Decision Context:
+ * - SSR: el detalle debe mostrar equipos, fixture y resultados con datos frescos desde
+ *   GraphQL. La pagina es publica y solo el CTA de inscripcion exige sesion.
+ * - La inscripcion queda en una isla React pequeña para reutilizar /api/graphql-auth y
+ *   el cookie HttpOnly sin exponer credenciales en el cliente.
+ */
+export const prerender = false;
+
+import {
+  CalendarDays,
+  CheckCircle,
+  Clock,
+  MapPin,
+  Shield,
+  Trophy,
+  UserRound,
+  Users,
+  Volleyball,
+} from 'lucide-react';
+import Layout from '../../layouts/Layout.astro';
+import { TournamentRegistrationForm } from '../../components/tournaments/TournamentRegistrationForm';
+import { GET_TOURNAMENT_DETAIL, type TournamentData, type TournamentFixtureMatch } from '../../graphql/operations/tournaments';
+import { readAccessToken } from '../../lib/auth';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const id = Astro.params.id ?? Astro.url.pathname.split('/').filter(Boolean).at(-1);
+if (!id || !UUID_REGEX.test(id)) {
+  return Astro.redirect('/torneos');
+}
+
+const user = Astro.locals.user;
+const isAuthenticated = !!user;
+const nombre = user?.displayName || user?.email;
+const accessToken = readAccessToken(Astro.cookies) ?? '';
+const backendUrl =
+  import.meta.env.PRIVATE_BACKEND_URL ||
+  (typeof process !== 'undefined' ? process.env.PRIVATE_BACKEND_URL : undefined) ||
+  'http://localhost:4000';
+
+let tournament: TournamentData | null = null;
+let fetchError: string | null = null;
+
+try {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+
+  const response = await fetch(`${backendUrl}/graphql`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query: GET_TOURNAMENT_DETAIL, variables: { id } }),
+  });
+
+  const json = await response.json() as {
+    data?: { tournament: TournamentData | null };
+    errors?: Array<{ message: string }>;
+  };
+
+  if (json.errors?.length) fetchError = json.errors[0].message;
+  else tournament = json.data?.tournament ?? null;
+} catch {
+  fetchError = 'Error de red al cargar el torneo.';
+}
+
+const formatLabels = {
+  FIVE_VS_FIVE: '5v5',
+  SEVEN_VS_SEVEN: '7v7',
+  TEN_VS_TEN: '10v10',
+  ELEVEN_VS_ELEVEN: '11v11',
+};
+
+const statusLabels = {
+  REGISTRATION: 'Inscripcion abierta',
+  IN_PROGRESS: 'En juego',
+  COMPLETED: 'Finalizado',
+  CANCELLED: 'Cancelado',
+};
+
+function formatDate(value: string | null): string {
+  if (!value) return 'A confirmar';
+  const [year, month, day] = value.slice(0, 10).split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('es-UY', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return 'Horario a confirmar';
+  return new Date(value).toLocaleString('es-UY', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function initials(name: string): string {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('');
+}
+
+function teamName(match: TournamentFixtureMatch, side: 'home' | 'away'): string {
+  const team = side === 'home' ? match.homeTeam : match.awayTeam;
+  if (team?.name) return team.name;
+  return 'Equipo por definir';
+}
+
+const registeredTeams = tournament ? Math.min(tournament.registeredTeamsCount, tournament.teamCount) : 0;
+const canRegister = Boolean(
+  tournament &&
+    tournament.status === 'REGISTRATION' &&
+    tournament.registeredTeamsCount < tournament.teamCount,
+);
+const progress = tournament?.teamCount ? Math.round((registeredTeams / tournament.teamCount) * 100) : 0;
+const fixtureByRound = new Map<number, TournamentFixtureMatch[]>();
+for (const match of tournament?.fixtureMatches ?? []) {
+  const matches = fixtureByRound.get(match.round) ?? [];
+  matches.push(match);
+  fixtureByRound.set(match.round, matches);
+}
+---
+
+<Layout title={tournament ? `${tournament.name} - Sumate Ya` : 'Torneo - Sumate Ya'}>
+  <div class="app-shell">
+    <nav class="topbar">
+      <div class="topbar-inner">
+        <a class="topbar-brand" href="/partidos">
+          <span class="topbar-ball"><Volleyball size={20} strokeWidth={2} aria-hidden="true" /></span>
+          <span class="topbar-name">SUMATE YA</span>
+        </a>
+
+        <div class="topbar-actions">
+          {isAuthenticated ? (
+            <>
+              <a href="/partidos" class="nav-link">Partidos</a>
+              <a href="/torneos" class="nav-link">Torneos</a>
+              <a href="/torneos/crear" class="btn-crear">Crear torneo</a>
+              {user?.role === 'player' && <a href="/perfil" class="nav-link">Mi Perfil</a>}
+              <span class="user-badge"><span class="user-dot"></span>{nombre}</span>
+              <form method="POST" action="/api/auth/logout">
+                <button type="submit" class="btn-logout">Salir</button>
+              </form>
+            </>
+          ) : (
+            <>
+              <a href="/partidos" class="nav-link">Partidos</a>
+              <a href="/torneos" class="nav-link">Torneos</a>
+              <a href="/login" class="btn-logout">Iniciar Sesion</a>
+            </>
+          )}
+        </div>
+      </div>
+      <div class="topbar-accent"></div>
+    </nav>
+
+    <main class="page-content">
+      {(!tournament || fetchError) && (
+        <section class="not-found">
+          <p class="nf-title">{fetchError ? 'Error al cargar' : 'Torneo no encontrado'}</p>
+          <p class="nf-sub">{fetchError ?? 'Puede que el torneo ya no este disponible.'}</p>
+          <a href="/torneos" class="btn-back">Volver a torneos</a>
+        </section>
+      )}
+
+      {tournament && (
+        <div class="tournament-detail">
+          <a href="/torneos" class="link-back">Volver a torneos</a>
+
+          <section class="hero-panel">
+            <div class="hero-main">
+              <div class="eyebrow"><Trophy size={15} strokeWidth={2} aria-hidden="true" /> TORNEO</div>
+              <h1>{tournament.name}</h1>
+              <p class="hero-description">
+                {tournament.description || 'Torneo abierto para equipos que quieren competir con fixture organizado y resultados visibles.'}
+              </p>
+              <div class="hero-meta">
+                <span><Shield size={15} aria-hidden="true" /> {formatLabels[tournament.format]}</span>
+                <span><MapPin size={15} aria-hidden="true" /> {tournament.club?.name ?? 'Club a confirmar'}</span>
+                <span><UserRound size={15} aria-hidden="true" /> {tournament.organizer?.displayName ?? 'Organizador'}</span>
+              </div>
+            </div>
+
+            <aside class="signup-panel" aria-label="Inscripcion del torneo">
+              <div class="status-pill">{statusLabels[tournament.status]}</div>
+              <div class="capacity-number">{registeredTeams}<span>/{tournament.teamCount}</span></div>
+              <p>equipos inscriptos</p>
+              <div class="capacity-bar" aria-hidden="true"><span style={`width: ${progress}%`}></span></div>
+              <TournamentRegistrationForm
+                client:load
+                tournamentId={tournament.id}
+                isAuthenticated={isAuthenticated}
+                canRegister={canRegister}
+              />
+            </aside>
+          </section>
+
+          <section class="info-grid" aria-label="Datos del torneo">
+            <div class="info-item">
+              <CalendarDays size={18} aria-hidden="true" />
+              <div><span>Fechas</span><strong>{formatDate(tournament.startDate)} - {formatDate(tournament.endDate)}</strong></div>
+            </div>
+            <div class="info-item">
+              <Users size={18} aria-hidden="true" />
+              <div><span>Formato</span><strong>{tournament.playersPerTeam} jugadores por equipo</strong></div>
+            </div>
+            <div class="info-item">
+              <MapPin size={18} aria-hidden="true" />
+              <div><span>Club</span><strong>{tournament.club?.address ?? tournament.club?.zone ?? 'Ubicacion a confirmar'}</strong></div>
+            </div>
+          </section>
+
+          <section class="content-grid">
+            <div class="detail-section">
+              <div class="section-heading">
+                <h2>Equipos inscriptos</h2>
+                <span>{registeredTeams} de {tournament.teamCount}</span>
+              </div>
+
+              {tournament.teams.length === 0 ? (
+                <div class="empty-state">Todavia no hay equipos anotados.</div>
+              ) : (
+                <div class="teams-list">
+                  {tournament.teams.map((team) => (
+                    <article class="team-row">
+                      <div class="team-title">
+                        <div class="team-mark">{initials(team.name) || 'EQ'}</div>
+                        <div>
+                          <h3>{team.name}</h3>
+                          <p>Capitan: {team.captain?.displayName ?? 'Sin datos'}</p>
+                        </div>
+                      </div>
+                      <ul class="players-mini" aria-label={`Jugadores de ${team.name}`}>
+                        {team.players.map((player) => (
+                          <li>
+                            <span class="player-dot">{initials(player.displayName) || 'J'}</span>
+                            {player.displayName}
+                          </li>
+                        ))}
+                      </ul>
+                    </article>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div class="detail-section fixture-section">
+              <div class="section-heading">
+                <h2>Fixture</h2>
+                <span>{tournament.fixtureMatches.length} partidos</span>
+              </div>
+
+              {tournament.fixtureMatches.length === 0 ? (
+                <div class="empty-state">El fixture todavia no fue generado.</div>
+              ) : (
+                <div class="rounds-list">
+                  {[...fixtureByRound.entries()].map(([round, matches]) => (
+                    <section class="round-block">
+                      <h3>Fecha {round}</h3>
+                      <div class="matches-stack">
+                        {matches.map((match) => {
+                          const played = match.status === 'COMPLETED';
+                          return (
+                            <article class={`fixture-match ${played ? 'fixture-match--played' : ''}`}>
+                              <div class="fixture-time">
+                                <Clock size={14} aria-hidden="true" />
+                                {formatDateTime(match.scheduledAt)}
+                              </div>
+                              <div class="fixture-line">
+                                <span>{teamName(match, 'home')}</span>
+                                <strong>
+                                  {played && match.scoreHome !== null && match.scoreAway !== null
+                                    ? `${match.scoreHome} - ${match.scoreAway}`
+                                    : 'vs'}
+                                </strong>
+                                <span>{teamName(match, 'away')}</span>
+                              </div>
+                              {played && <div class="played-mark"><CheckCircle size={13} aria-hidden="true" /> Jugado</div>}
+                            </article>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  ))}
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+      )}
+    </main>
+  </div>
+</Layout>
+
+<style>
+  .app-shell { min-height: 100vh; display: flex; flex-direction: column; }
+  .topbar { position: sticky; top: 0; z-index: 50; background: rgba(7,15,31,0.85); backdrop-filter: blur(16px); border-bottom: 1px solid rgba(255,255,255,0.06); }
+  .topbar-inner { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; height: 56px; display: flex; align-items: center; justify-content: space-between; }
+  .topbar-brand { display: flex; align-items: center; gap: 0.5rem; text-decoration: none; }
+  .topbar-ball { color: hsl(35 100% 55%); display: inline-flex; }
+  .topbar-name { font-family: 'Bebas Neue', sans-serif; font-size: 1.35rem; letter-spacing: 0.1em; color: #fff; }
+  .topbar-actions { display: flex; align-items: center; gap: 0.75rem; }
+  .topbar-accent { height: 2px; background: linear-gradient(90deg, hsl(35 100% 48%), hsl(216 85% 45%), transparent); }
+  .nav-link, .btn-crear { font-family: 'Barlow Condensed', sans-serif; font-size: 0.85rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; text-decoration: none; border-radius: 6px; }
+  .nav-link { color: hsl(215 20% 65%); padding: 0.3rem 0.6rem; }
+  .nav-link:hover { background: rgba(255,255,255,0.06); color: hsl(210 20% 92%); }
+  .btn-crear { padding: 0.35rem 0.875rem; background: hsl(35 100% 48%); color: hsl(220 72% 7%); }
+  .btn-logout { background: transparent; border: 1px solid rgba(255,255,255,0.12); border-radius: 6px; padding: 0.3rem 0.75rem; color: hsl(215 20% 60%); font-family: 'Barlow', sans-serif; font-size: 0.8125rem; text-decoration: none; cursor: pointer; }
+  .user-badge { display: flex; align-items: center; gap: 0.4rem; border: 1px solid rgba(246,164,0,0.25); color: hsl(35 100% 65%); border-radius: 20px; padding: 0.25rem 0.875rem; font-size: 0.8125rem; font-weight: 600; }
+  .user-dot { width: 6px; height: 6px; border-radius: 50%; background: hsl(35 100% 55%); }
+  .page-content { flex: 1; max-width: 1100px; width: 100%; margin: 0 auto; padding: 2.5rem 1.25rem; }
+  .tournament-detail { display: flex; flex-direction: column; gap: 1.25rem; }
+  .link-back, .btn-back { font-family: 'Barlow Condensed', sans-serif; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: hsl(35 100% 55%); text-decoration: none; width: fit-content; }
+  .hero-panel { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 1rem; align-items: stretch; }
+  .hero-main, .signup-panel, .info-item, .detail-section { background: hsl(220 55% 11%); border: 1px solid rgba(255,255,255,0.08); border-radius: 12px; }
+  .hero-main { padding: 2rem; min-height: 270px; display: flex; flex-direction: column; justify-content: flex-end; background-image: linear-gradient(135deg, rgba(246,164,0,0.14), transparent 42%), linear-gradient(180deg, hsl(220 55% 13%), hsl(220 55% 9%)); }
+  .eyebrow { display: flex; align-items: center; gap: 0.45rem; font-family: 'Barlow Condensed', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.18em; color: hsl(42 100% 62%); margin-bottom: 0.75rem; }
+  h1 { margin: 0; font-family: 'Bebas Neue', sans-serif; font-size: clamp(2.5rem, 9vw, 5.5rem); line-height: 0.9; letter-spacing: 0.03em; color: white; }
+  .hero-description { max-width: 680px; margin: 0.9rem 0 0; color: hsl(215 20% 72%); font-size: 1rem; line-height: 1.55; }
+  .hero-meta { display: flex; flex-wrap: wrap; gap: 0.65rem; margin-top: 1.25rem; }
+  .hero-meta span { display: inline-flex; align-items: center; gap: 0.4rem; color: hsl(210 20% 90%); background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.09); border-radius: 999px; padding: 0.4rem 0.7rem; font-size: 0.875rem; }
+  .signup-panel { padding: 1.25rem; display: flex; flex-direction: column; justify-content: center; gap: 0.85rem; }
+  .status-pill { width: fit-content; border: 1px solid rgba(246,164,0,0.35); color: hsl(42 100% 65%); border-radius: 999px; padding: 0.3rem 0.7rem; font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; }
+  .capacity-number { font-family: 'Bebas Neue', sans-serif; color: white; font-size: 4rem; line-height: 0.9; }
+  .capacity-number span { color: hsl(215 20% 50%); font-size: 2rem; }
+  .signup-panel p { margin: 0; color: hsl(215 20% 60%); }
+  .capacity-bar { height: 8px; background: hsl(220 45% 18%); border-radius: 999px; overflow: hidden; }
+  .capacity-bar span { display: block; height: 100%; background: hsl(35 100% 50%); border-radius: inherit; }
+  :global(.detail-register-form) { display: grid; gap: 0.65rem; margin-top: 0.35rem; }
+  :global(.detail-team-input) { min-height: 42px; border: 1px solid rgba(255,255,255,0.12); background: hsl(220 55% 8%); color: white; border-radius: 8px; padding: 0 0.8rem; outline: none; }
+  :global(.detail-form-error) { margin: 0; color: hsl(0 72% 70%); font-size: 0.85rem; }
+  :global(.detail-form-message) { margin: 0; color: hsl(142 72% 65%); font-size: 0.85rem; }
+  :global(.detail-login-button), :global(.registration-closed) { display: inline-flex; align-items: center; justify-content: center; gap: 0.45rem; min-height: 42px; border-radius: 8px; text-decoration: none; font-weight: 700; }
+  :global(.detail-login-button) { background: hsl(35 100% 48%); color: hsl(220 72% 7%); }
+  :global(.registration-closed) { background: rgba(255,255,255,0.06); color: hsl(215 20% 62%); padding: 0 0.75rem; }
+  .info-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+  .info-item { padding: 1rem; display: flex; align-items: flex-start; gap: 0.85rem; color: hsl(35 100% 55%); }
+  .info-item span { display: block; color: hsl(215 20% 50%); font-size: 0.8rem; margin-bottom: 0.25rem; }
+  .info-item strong { color: hsl(210 20% 90%); font-size: 0.95rem; font-weight: 600; }
+  .content-grid { display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr); gap: 1rem; align-items: start; }
+  .detail-section { padding: 1.25rem; }
+  .section-heading { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; margin-bottom: 1rem; }
+  .section-heading h2 { margin: 0; font-family: 'Bebas Neue', sans-serif; color: white; font-size: 2rem; letter-spacing: 0.04em; }
+  .section-heading span { color: hsl(215 20% 50%); font-size: 0.85rem; }
+  .teams-list, .rounds-list, .matches-stack { display: flex; flex-direction: column; gap: 0.75rem; }
+  .team-row { border: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.035); border-radius: 10px; padding: 0.9rem; }
+  .team-title { display: flex; align-items: center; gap: 0.8rem; }
+  .team-mark, .player-dot { display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; flex-shrink: 0; }
+  .team-mark { width: 42px; height: 42px; background: hsl(35 100% 48%); color: hsl(220 72% 7%); font-weight: 800; }
+  .team-title h3 { margin: 0; color: white; font-size: 1rem; }
+  .team-title p { margin: 0.2rem 0 0; color: hsl(215 20% 58%); font-size: 0.86rem; }
+  .players-mini { list-style: none; padding: 0.75rem 0 0; margin: 0; display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .players-mini li { display: inline-flex; align-items: center; gap: 0.4rem; color: hsl(215 20% 75%); font-size: 0.85rem; }
+  .player-dot { width: 24px; height: 24px; background: hsl(220 45% 18%); color: hsl(35 100% 62%); font-size: 0.68rem; font-weight: 800; }
+  .round-block h3 { margin: 0 0 0.55rem; color: hsl(35 100% 62%); font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.1em; }
+  .fixture-match { border: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.035); border-radius: 10px; padding: 0.85rem; }
+  .fixture-match--played { border-color: rgba(34,197,94,0.28); }
+  .fixture-time, .played-mark { display: flex; align-items: center; gap: 0.4rem; color: hsl(215 20% 55%); font-size: 0.8rem; }
+  .fixture-line { display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr); align-items: center; gap: 0.7rem; margin-top: 0.55rem; color: white; }
+  .fixture-line span { min-width: 0; overflow-wrap: anywhere; }
+  .fixture-line span:last-child { text-align: right; }
+  .fixture-line strong { color: hsl(35 100% 58%); font-family: 'Bebas Neue', sans-serif; font-size: 1.5rem; letter-spacing: 0.05em; }
+  .played-mark { margin-top: 0.45rem; color: hsl(142 72% 65%); }
+  .empty-state, .not-found { color: hsl(215 20% 55%); border: 1px dashed rgba(255,255,255,0.14); border-radius: 10px; padding: 1.5rem; text-align: center; }
+  .nf-title { font-family: 'Bebas Neue', sans-serif; color: white; font-size: 2rem; margin: 0 0 0.35rem; }
+  .nf-sub { margin: 0 0 1rem; }
+  @media (max-width: 850px) {
+    .hero-panel, .content-grid, .info-grid { grid-template-columns: 1fr; }
+    .topbar-actions .nav-link, .topbar-actions .btn-crear, .user-badge { display: none; }
+    .page-content { padding: 1.25rem 1rem; }
+    .hero-main { padding: 1.35rem; min-height: 230px; }
+  }
+</style>


### PR DESCRIPTION
- Implemented a new TournamentDetail page to display tournament information, teams, and fixtures.
- Added a TournamentRegistrationForm component for team registration.
- Enhanced GraphQL queries to fetch detailed tournament data, including teams and match fixtures.
- Updated tournament service to support fetching tournament details by ID.
- Improved UI for tournament cards to link to tournament details.