### PR TITLE
feat(tournament): add join tournament functionality and team member m…

### DIFF
--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -329,6 +329,12 @@ export type JoinMatchResult = {
   success: Scalars['Boolean']['output'];
 };
 
+export type JoinTournamentInput = {
+  memberIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  teamName: Scalars['String']['input'];
+  tournamentId: Scalars['ID']['input'];
+};
+
 export type LeaveMatchInput = {
   matchId: Scalars['ID']['input'];
 };
@@ -477,6 +483,7 @@ export enum MatchUserResult {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  addTournamentTeamMember: TournamentTeamRegistrationResult;
   bulkBlockSlots: BulkSlotMutationResult;
   bulkCreateClubMatches: BulkClubMatchResult;
   createClubMatch: CreateClubMatchResult;
@@ -485,14 +492,21 @@ export type Mutation = {
   createTournament: CreateTournamentResult;
   deleteClubSlot: ClubSlotMutationResult;
   joinMatch: JoinMatchResult;
+  joinTournament: TournamentTeamRegistrationResult;
   leaveMatch: LeaveMatchResult;
   proposeMatchResult: MatchResultSubmission;
   registerTournamentTeam: TournamentTeamRegistrationResult;
+  removeTournamentTeamMember: TournamentTeamRegistrationResult;
   toggleSlotBlock: ClubSlotMutationResult;
   updateClubSlot: ClubSlotMutationResult;
   updateCourtPricing: CourtPricingMutationResult;
   updatePrivacy: PrivacySettings;
   voteMatchResult: VoteSubmissionResult;
+};
+
+
+export type MutationAddTournamentTeamMemberArgs = {
+  input: TournamentTeamMemberInput;
 };
 
 
@@ -536,6 +550,11 @@ export type MutationJoinMatchArgs = {
 };
 
 
+export type MutationJoinTournamentArgs = {
+  input: JoinTournamentInput;
+};
+
+
 export type MutationLeaveMatchArgs = {
   input: LeaveMatchInput;
 };
@@ -548,6 +567,11 @@ export type MutationProposeMatchResultArgs = {
 
 export type MutationRegisterTournamentTeamArgs = {
   input: RegisterTournamentTeamInput;
+};
+
+
+export type MutationRemoveTournamentTeamMemberArgs = {
+  input: TournamentTeamMemberInput;
 };
 
 
@@ -640,6 +664,7 @@ export type Query = {
   slotAuditLog: Array<SlotAuditLog>;
   slotImpactPreview: SlotImpactPreview;
   tournament?: Maybe<Tournament>;
+  tournamentEligiblePlayers: Array<TournamentPlayer>;
   tournaments: Array<Tournament>;
 };
 
@@ -716,6 +741,12 @@ export type QuerySlotImpactPreviewArgs = {
 
 export type QueryTournamentArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type QueryTournamentEligiblePlayersArgs = {
+  search?: InputMaybe<Scalars['String']['input']>;
+  tournamentId: Scalars['ID']['input'];
 };
 
 export type RegisterTournamentTeamInput = {
@@ -877,6 +908,12 @@ export type TournamentTeam = {
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
   players: Array<TournamentPlayer>;
+};
+
+export type TournamentTeamMemberInput = {
+  playerId: Scalars['ID']['input'];
+  teamId: Scalars['ID']['input'];
+  tournamentId: Scalars['ID']['input'];
 };
 
 export type TournamentTeamRegistrationResult = {
@@ -1053,6 +1090,7 @@ export type ResolversTypes = ResolversObject<{
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   JoinMatchInput: JoinMatchInput;
   JoinMatchResult: ResolverTypeWrapper<JoinMatchResult>;
+  JoinTournamentInput: JoinTournamentInput;
   LeaveMatchInput: LeaveMatchInput;
   LeaveMatchResult: ResolverTypeWrapper<LeaveMatchResult>;
   ManagedClubSlot: ResolverTypeWrapper<ManagedClubSlot>;
@@ -1091,6 +1129,7 @@ export type ResolversTypes = ResolversObject<{
   TournamentScheduleSlotInput: TournamentScheduleSlotInput;
   TournamentStatus: TournamentStatus;
   TournamentTeam: ResolverTypeWrapper<TournamentTeam>;
+  TournamentTeamMemberInput: TournamentTeamMemberInput;
   TournamentTeamRegistrationResult: ResolverTypeWrapper<TournamentTeamRegistrationResult>;
   UpdateClubSlotInput: UpdateClubSlotInput;
   UpdateCourtPricingInput: UpdateCourtPricingInput;
@@ -1139,6 +1178,7 @@ export type ResolversParentTypes = ResolversObject<{
   Int: Scalars['Int']['output'];
   JoinMatchInput: JoinMatchInput;
   JoinMatchResult: JoinMatchResult;
+  JoinTournamentInput: JoinTournamentInput;
   LeaveMatchInput: LeaveMatchInput;
   LeaveMatchResult: LeaveMatchResult;
   ManagedClubSlot: ManagedClubSlot;
@@ -1167,6 +1207,7 @@ export type ResolversParentTypes = ResolversObject<{
   TournamentPlayer: TournamentPlayer;
   TournamentScheduleSlotInput: TournamentScheduleSlotInput;
   TournamentTeam: TournamentTeam;
+  TournamentTeamMemberInput: TournamentTeamMemberInput;
   TournamentTeamRegistrationResult: TournamentTeamRegistrationResult;
   UpdateClubSlotInput: UpdateClubSlotInput;
   UpdateCourtPricingInput: UpdateCourtPricingInput;
@@ -1461,6 +1502,7 @@ export type MatchResultVoteResolvers<ContextType = GraphQLContext, ParentType ex
 }>;
 
 export type MutationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = ResolversObject<{
+  addTournamentTeamMember?: Resolver<ResolversTypes['TournamentTeamRegistrationResult'], ParentType, ContextType, RequireFields<MutationAddTournamentTeamMemberArgs, 'input'>>;
   bulkBlockSlots?: Resolver<ResolversTypes['BulkSlotMutationResult'], ParentType, ContextType, RequireFields<MutationBulkBlockSlotsArgs, 'input'>>;
   bulkCreateClubMatches?: Resolver<ResolversTypes['BulkClubMatchResult'], ParentType, ContextType, RequireFields<MutationBulkCreateClubMatchesArgs, 'input'>>;
   createClubMatch?: Resolver<ResolversTypes['CreateClubMatchResult'], ParentType, ContextType, RequireFields<MutationCreateClubMatchArgs, 'input'>>;
@@ -1469,9 +1511,11 @@ export type MutationResolvers<ContextType = GraphQLContext, ParentType extends R
   createTournament?: Resolver<ResolversTypes['CreateTournamentResult'], ParentType, ContextType, RequireFields<MutationCreateTournamentArgs, 'input'>>;
   deleteClubSlot?: Resolver<ResolversTypes['ClubSlotMutationResult'], ParentType, ContextType, RequireFields<MutationDeleteClubSlotArgs, 'slotId'>>;
   joinMatch?: Resolver<ResolversTypes['JoinMatchResult'], ParentType, ContextType, RequireFields<MutationJoinMatchArgs, 'input'>>;
+  joinTournament?: Resolver<ResolversTypes['TournamentTeamRegistrationResult'], ParentType, ContextType, RequireFields<MutationJoinTournamentArgs, 'input'>>;
   leaveMatch?: Resolver<ResolversTypes['LeaveMatchResult'], ParentType, ContextType, RequireFields<MutationLeaveMatchArgs, 'input'>>;
   proposeMatchResult?: Resolver<ResolversTypes['MatchResultSubmission'], ParentType, ContextType, RequireFields<MutationProposeMatchResultArgs, 'input'>>;
   registerTournamentTeam?: Resolver<ResolversTypes['TournamentTeamRegistrationResult'], ParentType, ContextType, RequireFields<MutationRegisterTournamentTeamArgs, 'input'>>;
+  removeTournamentTeamMember?: Resolver<ResolversTypes['TournamentTeamRegistrationResult'], ParentType, ContextType, RequireFields<MutationRemoveTournamentTeamMemberArgs, 'input'>>;
   toggleSlotBlock?: Resolver<ResolversTypes['ClubSlotMutationResult'], ParentType, ContextType, RequireFields<MutationToggleSlotBlockArgs, 'input'>>;
   updateClubSlot?: Resolver<ResolversTypes['ClubSlotMutationResult'], ParentType, ContextType, RequireFields<MutationUpdateClubSlotArgs, 'input'>>;
   updateCourtPricing?: Resolver<ResolversTypes['CourtPricingMutationResult'], ParentType, ContextType, RequireFields<MutationUpdateCourtPricingArgs, 'input'>>;
@@ -1526,6 +1570,7 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   slotAuditLog?: Resolver<Array<ResolversTypes['SlotAuditLog']>, ParentType, ContextType, RequireFields<QuerySlotAuditLogArgs, 'slotId'>>;
   slotImpactPreview?: Resolver<ResolversTypes['SlotImpactPreview'], ParentType, ContextType, RequireFields<QuerySlotImpactPreviewArgs, 'slotIds'>>;
   tournament?: Resolver<Maybe<ResolversTypes['Tournament']>, ParentType, ContextType, RequireFields<QueryTournamentArgs, 'id'>>;
+  tournamentEligiblePlayers?: Resolver<Array<ResolversTypes['TournamentPlayer']>, ParentType, ContextType, RequireFields<QueryTournamentEligiblePlayersArgs, 'tournamentId'>>;
   tournaments?: Resolver<Array<ResolversTypes['Tournament']>, ParentType, ContextType>;
 }>;
 

--- a/apps/backend/src/graphql/resolvers/domains/tournament.ts
+++ b/apps/backend/src/graphql/resolvers/domains/tournament.ts
@@ -1,11 +1,5 @@
 /**
- * Tournament Resolver - GraphQL mutation for tournament creation.
- *
- * Decision Context:
- * - Both players and club_admins can create tournaments, so the resolver only requires
- *   authentication and delegates business authorization to the service.
- * - User-scoped client is passed into writes so RLS can enforce organizerId = auth.uid().
- * - Errors are returned in the CreateTournamentResult shape for consistent form UX.
+ * Tournament Resolver - GraphQL queries and mutations for tournament flows.
  */
 
 import { z } from 'zod';
@@ -19,7 +13,7 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 const CreateTournamentSchema = z.object({
-  clubId: z.string().regex(UUID_REGEX, 'clubId inválido'),
+  clubId: z.string().regex(UUID_REGEX, 'clubId invalido'),
   name: z.string().trim().min(3, 'El nombre debe tener al menos 3 caracteres').max(120),
   format: z.enum([
     MatchFormat.FiveVsFive,
@@ -27,32 +21,57 @@ const CreateTournamentSchema = z.object({
     MatchFormat.TenVsTen,
     MatchFormat.ElevenVsEleven,
   ]),
-  teamCount: z.number().int().min(2, 'Mínimo 2 equipos').max(32, 'Máximo 32 equipos'),
-  playersPerTeam: z.number().int().min(1, 'Mínimo 1 jugador por equipo').max(30),
-  description: z.string().max(700, 'La descripción no puede superar 700 caracteres').optional().nullable(),
+  teamCount: z.number().int().min(2, 'Minimo 2 equipos').max(32, 'Maximo 32 equipos'),
+  playersPerTeam: z.number().int().min(1, 'Minimo 1 jugador por equipo').max(30),
+  description: z.string().max(700, 'La descripcion no puede superar 700 caracteres').optional().nullable(),
   schedule: z
     .array(
       z.object({
-        slotId: z.string().regex(UUID_REGEX, 'slotId inválido'),
+        slotId: z.string().regex(UUID_REGEX, 'slotId invalido'),
         date: z.string().regex(DATE_REGEX, 'date debe ser YYYY-MM-DD'),
       }),
     )
-    .min(1, 'Seleccioná al menos un horario')
+    .min(1, 'Selecciona al menos un horario')
     .max(256, 'Demasiados horarios seleccionados'),
 });
 
 const RegisterTournamentTeamSchema = z.object({
-  tournamentId: z.string().regex(UUID_REGEX, 'tournamentId inválido'),
+  tournamentId: z.string().regex(UUID_REGEX, 'tournamentId invalido'),
   name: z.string().trim().min(2, 'El nombre del equipo debe tener al menos 2 caracteres').max(80),
 });
 
+const JoinTournamentSchema = z.object({
+  tournamentId: z.string().regex(UUID_REGEX, 'tournamentId invalido'),
+  teamName: z.string().trim().min(2, 'El nombre del equipo debe tener al menos 2 caracteres').max(80),
+  memberIds: z.array(z.string().regex(UUID_REGEX, 'memberId invalido')).max(30).optional().nullable(),
+});
+
+const TournamentTeamMemberSchema = z.object({
+  tournamentId: z.string().regex(UUID_REGEX, 'tournamentId invalido'),
+  teamId: z.string().regex(UUID_REGEX, 'teamId invalido'),
+  playerId: z.string().regex(UUID_REGEX, 'playerId invalido'),
+});
+
+function invalidTeamResult(message: string) {
+  return { success: false, teamId: null, message: `Datos invalidos: ${message}`, tournament: null };
+}
+
 const Query: QueryResolvers = {
   tournaments: async () => tournamentService.listRegistrationTournaments({}),
+
   tournament: async (_parent, args) => {
-    const parsed = z.string().regex(UUID_REGEX, 'id invÃ¡lido').safeParse(args.id);
+    const parsed = z.string().regex(UUID_REGEX, 'id invalido').safeParse(args.id);
     if (!parsed.success) return null;
 
     return tournamentService.getTournamentById({}, parsed.data);
+  },
+
+  tournamentEligiblePlayers: async (_parent, args, ctx) => {
+    requireAuth(ctx);
+    const parsed = z.string().regex(UUID_REGEX, 'tournamentId invalido').safeParse(args.tournamentId);
+    if (!parsed.success) return [];
+
+    return tournamentService.searchTournamentEligiblePlayers({}, parsed.data, args.search ?? null);
   },
 };
 
@@ -64,7 +83,7 @@ const Mutation: MutationResolvers = {
     const parsed = CreateTournamentSchema.safeParse(args.input);
     if (!parsed.success) {
       const message = parsed.error.issues.map((issue) => issue.message).join('; ');
-      return { success: false, tournamentId: null, message: `Datos inválidos: ${message}`, tournament: null };
+      return { success: false, tournamentId: null, message: `Datos invalidos: ${message}`, tournament: null };
     }
 
     try {
@@ -81,22 +100,75 @@ const Mutation: MutationResolvers = {
 
   registerTournamentTeam: async (_parent, args, ctx) => {
     const user = requireAuth(ctx);
-    const userClient = ctx.accessToken ? createUserClient(ctx.accessToken) : undefined;
 
     const parsed = RegisterTournamentTeamSchema.safeParse(args.input);
     if (!parsed.success) {
       const message = parsed.error.issues.map((issue) => issue.message).join('; ');
-      return { success: false, teamId: null, message: `Datos inválidos: ${message}`, tournament: null };
+      return invalidTeamResult(message);
     }
 
     try {
-      return await tournamentService.registerTournamentTeam(parsed.data, {
-        userId: user.id,
-        supabase: userClient,
-      });
+      return await tournamentService.registerTournamentTeam(parsed.data, { userId: user.id });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Error al inscribir el equipo';
       console.error(`[tournamentResolver.registerTournamentTeam] Failed for userId=${user.id}:`, error);
+      return { success: false, teamId: null, message, tournament: null };
+    }
+  },
+
+  joinTournament: async (_parent, args, ctx) => {
+    const user = requireAuth(ctx);
+
+    const parsed = JoinTournamentSchema.safeParse(args.input);
+    if (!parsed.success) {
+      const message = parsed.error.issues.map((issue) => issue.message).join('; ');
+      return invalidTeamResult(message);
+    }
+
+    try {
+      return await tournamentService.joinTournament(
+        { ...parsed.data, memberIds: parsed.data.memberIds ?? [] },
+        { userId: user.id },
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error al inscribir el equipo';
+      console.error(`[tournamentResolver.joinTournament] Failed for userId=${user.id}:`, error);
+      return { success: false, teamId: null, message, tournament: null };
+    }
+  },
+
+  addTournamentTeamMember: async (_parent, args, ctx) => {
+    const user = requireAuth(ctx);
+
+    const parsed = TournamentTeamMemberSchema.safeParse(args.input);
+    if (!parsed.success) {
+      const message = parsed.error.issues.map((issue) => issue.message).join('; ');
+      return invalidTeamResult(message);
+    }
+
+    try {
+      return await tournamentService.addTournamentTeamMember(parsed.data, { userId: user.id });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error al agregar jugador';
+      console.error(`[tournamentResolver.addTournamentTeamMember] Failed for userId=${user.id}:`, error);
+      return { success: false, teamId: null, message, tournament: null };
+    }
+  },
+
+  removeTournamentTeamMember: async (_parent, args, ctx) => {
+    const user = requireAuth(ctx);
+
+    const parsed = TournamentTeamMemberSchema.safeParse(args.input);
+    if (!parsed.success) {
+      const message = parsed.error.issues.map((issue) => issue.message).join('; ');
+      return invalidTeamResult(message);
+    }
+
+    try {
+      return await tournamentService.removeTournamentTeamMember(parsed.data, { userId: user.id });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error al quitar jugador';
+      console.error(`[tournamentResolver.removeTournamentTeamMember] Failed for userId=${user.id}:`, error);
       return { success: false, teamId: null, message, tournament: null };
     }
   },

--- a/apps/backend/src/graphql/schema/tournament.graphql
+++ b/apps/backend/src/graphql/schema/tournament.graphql
@@ -116,12 +116,28 @@ input RegisterTournamentTeamInput {
   name: String!
 }
 
+input JoinTournamentInput {
+  tournamentId: ID!
+  teamName: String!
+  memberIds: [ID!] = []
+}
+
+input TournamentTeamMemberInput {
+  tournamentId: ID!
+  teamId: ID!
+  playerId: ID!
+}
+
 extend type Query {
   tournaments: [Tournament!]!
   tournament(id: ID!): Tournament
+  tournamentEligiblePlayers(tournamentId: ID!, search: String): [TournamentPlayer!]!
 }
 
 extend type Mutation {
   createTournament(input: CreateTournamentInput!): CreateTournamentResult!
   registerTournamentTeam(input: RegisterTournamentTeamInput!): TournamentTeamRegistrationResult!
+  joinTournament(input: JoinTournamentInput!): TournamentTeamRegistrationResult!
+  addTournamentTeamMember(input: TournamentTeamMemberInput!): TournamentTeamRegistrationResult!
+  removeTournamentTeamMember(input: TournamentTeamMemberInput!): TournamentTeamRegistrationResult!
 }

--- a/apps/backend/src/repositories/tournamentRepository.ts
+++ b/apps/backend/src/repositories/tournamentRepository.ts
@@ -187,6 +187,12 @@ export interface RegisterTournamentTeamRpcInput {
   name: string;
 }
 
+export interface JoinTournamentRpcInput {
+  tournamentId: string;
+  teamName: string;
+  memberIds: string[];
+}
+
 export interface MatchSlotReservationRow {
   id: string;
   clubSlotId: string | null;
@@ -222,12 +228,21 @@ export interface TournamentTeamMemberRow {
   player: TournamentPlayerRow | null;
 }
 
+export interface TournamentMemberPlayerRow {
+  playerId: string;
+  tournamentTeams: {
+    tournamentId: string;
+  } | null;
+}
+
 function isMissingTournamentRpcError(message: string): boolean {
   return (
     message.includes('Could not find the function public.create_tournament_with_fixture') ||
     message.includes('Could not find the function public.register_tournament_team') ||
+    message.includes('Could not find the function public.join_tournament') ||
     message.includes('function public.create_tournament_with_fixture') ||
-    message.includes('function public.register_tournament_team')
+    message.includes('function public.register_tournament_team') ||
+    message.includes('function public.join_tournament')
   );
 }
 
@@ -386,6 +401,31 @@ export async function registerTournamentTeamRpc(
   return data;
 }
 
+export async function joinTournamentRpc(
+  input: JoinTournamentRpcInput,
+  client: SupabaseClient,
+): Promise<string> {
+  const { data, error } = await client.rpc('join_tournament', {
+    p_tournament_id: input.tournamentId,
+    p_team_name: input.teamName,
+    p_member_ids: input.memberIds,
+  });
+
+  if (error) {
+    console.error('[tournamentRepository.joinTournamentRpc] Supabase error:', error.message);
+    if (isMissingTournamentRpcError(error.message)) {
+      throw new Error('Falta aplicar la migracion SQL de unirse a torneos en Supabase');
+    }
+    throw new Error(error.message);
+  }
+
+  if (!data || typeof data !== 'string') {
+    throw new Error('No se pudo inscribir el equipo en Supabase');
+  }
+
+  return data;
+}
+
 export async function insertFixtureMatches(
   rows: CreateFixtureMatchInput[],
   client: SupabaseClient = supabase,
@@ -486,6 +526,112 @@ export async function getTournamentTeams(
   return (data as unknown as TournamentTeamRow[]) ?? [];
 }
 
+export async function getTournamentMemberPlayerIds(
+  tournamentId: string,
+  client: SupabaseClient = supabase,
+): Promise<string[]> {
+  const { data, error } = await client
+    .from('tournamentTeamMembers')
+    .select('playerId, tournamentTeams!inner("tournamentId")')
+    .eq('tournamentTeams.tournamentId', tournamentId);
+
+  if (error) {
+    console.error('[tournamentRepository.getTournamentMemberPlayerIds] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return ((data as unknown as TournamentMemberPlayerRow[]) ?? []).map((row) => row.playerId);
+}
+
+export async function getTournamentTeamById(
+  teamId: string,
+  client: SupabaseClient = supabase,
+): Promise<TournamentTeamRow | null> {
+  const { data, error } = await client
+    .from('tournamentTeams')
+    .select('id, "tournamentId", name, "captainId", "createdAt"')
+    .eq('id', teamId)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return null;
+    console.error('[tournamentRepository.getTournamentTeamById] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return data as unknown as TournamentTeamRow;
+}
+
+export async function getTournamentTeamMemberIds(
+  teamId: string,
+  client: SupabaseClient = supabase,
+): Promise<string[]> {
+  const { data, error } = await client
+    .from('tournamentTeamMembers')
+    .select('"playerId"')
+    .eq('teamId', teamId);
+
+  if (error) {
+    console.error('[tournamentRepository.getTournamentTeamMemberIds] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return ((data as Array<{ playerId: string }> | null) ?? []).map((row) => row.playerId);
+}
+
+export async function getPlayerProfilesByIds(
+  playerIds: string[],
+  client: SupabaseClient = supabase,
+): Promise<TournamentPlayerRow[]> {
+  if (playerIds.length === 0) return [];
+
+  const { data, error } = await client
+    .from('profiles')
+    .select(TOURNAMENT_PLAYER_COLUMNS)
+    .eq('role', 'player')
+    .in('id', playerIds);
+
+  if (error) {
+    console.error('[tournamentRepository.getPlayerProfilesByIds] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return (data as unknown as TournamentPlayerRow[]) ?? [];
+}
+
+export async function searchEligiblePlayers(
+  tournamentId: string,
+  search: string | null,
+  limit = 12,
+  client: SupabaseClient = supabase,
+): Promise<TournamentPlayerRow[]> {
+  const usedPlayerIds = await getTournamentMemberPlayerIds(tournamentId, client);
+  let query = client
+    .from('profiles')
+    .select(TOURNAMENT_PLAYER_COLUMNS)
+    .eq('role', 'player')
+    .order('displayName', { ascending: true })
+    .limit(limit);
+
+  if (usedPlayerIds.length > 0) {
+    query = query.not('id', 'in', `(${usedPlayerIds.join(',')})`);
+  }
+
+  const term = search?.trim();
+  if (term) {
+    query = query.ilike('displayName', `%${term}%`);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error('[tournamentRepository.searchEligiblePlayers] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return (data as unknown as TournamentPlayerRow[]) ?? [];
+}
+
 export async function createTournamentTeam(
   tournamentId: string,
   name: string,
@@ -521,6 +667,40 @@ export async function createTournamentTeamMember(
 
   if (error) {
     console.error('[tournamentRepository.createTournamentTeamMember] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+}
+
+export async function createTournamentTeamMembers(
+  teamId: string,
+  playerIds: string[],
+  client: SupabaseClient = supabase,
+): Promise<void> {
+  if (playerIds.length === 0) return;
+
+  const { error } = await client
+    .from('tournamentTeamMembers')
+    .insert(playerIds.map((playerId) => ({ teamId, playerId })));
+
+  if (error) {
+    console.error('[tournamentRepository.createTournamentTeamMembers] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+}
+
+export async function deleteTournamentTeamMember(
+  teamId: string,
+  playerId: string,
+  client: SupabaseClient = supabase,
+): Promise<void> {
+  const { error } = await client
+    .from('tournamentTeamMembers')
+    .delete()
+    .eq('teamId', teamId)
+    .eq('playerId', playerId);
+
+  if (error) {
+    console.error('[tournamentRepository.deleteTournamentTeamMember] Supabase error:', error.message);
     throw new Error(error.message);
   }
 }
@@ -565,12 +745,20 @@ export const tournamentRepository = {
   createTournament,
   createTournamentWithFixtureRpc,
   registerTournamentTeamRpc,
+  joinTournamentRpc,
   insertFixtureMatches,
   getTournamentById,
   getRegistrationTournaments,
   getTournamentTeams,
+  getTournamentMemberPlayerIds,
+  getTournamentTeamById,
+  getTournamentTeamMemberIds,
+  getPlayerProfilesByIds,
+  searchEligiblePlayers,
   createTournamentTeam,
   createTournamentTeamMember,
+  createTournamentTeamMembers,
+  deleteTournamentTeamMember,
   updateFixtureTeams,
   updateTournamentStatus,
 };

--- a/apps/backend/src/services/tournamentService.ts
+++ b/apps/backend/src/services/tournamentService.ts
@@ -18,11 +18,13 @@ import {
   TournamentStatus,
   type CreateTournamentInput,
   type CreateTournamentResult,
+  type JoinTournamentInput,
   type RegisterTournamentTeamInput,
   type Tournament,
   type TournamentFixtureMatch,
   type TournamentPlayer,
   type TournamentTeam,
+  type TournamentTeamMemberInput,
   type TournamentTeamRegistrationResult,
 } from '../graphql/generated/graphql.js';
 import {
@@ -334,6 +336,36 @@ async function invalidateTournamentListCaches(): Promise<void> {
   await cacheDeletePattern(`${CACHE_PREFIX.TOURNAMENTS_LIST}:*`);
 }
 
+function uniqueIds(ids: string[]): string[] {
+  return [...new Set(ids.filter(Boolean))];
+}
+
+async function validateJoinRoster(
+  tournament: TournamentRow,
+  captainId: string,
+  memberIds: string[],
+): Promise<string[]> {
+  const playerIds = uniqueIds([captainId, ...memberIds]);
+  if (playerIds.length > tournament.playersPerTeam) {
+    throw new Error(`El equipo no puede superar ${tournament.playersPerTeam} jugadores`);
+  }
+
+  const players = await tournamentRepository.getPlayerProfilesByIds(playerIds);
+  const foundIds = new Set(players.map((player) => player.id));
+  const missing = playerIds.filter((playerId) => !foundIds.has(playerId));
+  if (missing.length > 0) {
+    throw new Error('Uno o mas jugadores no existen o no tienen rol de jugador');
+  }
+
+  const usedPlayerIds = await tournamentRepository.getTournamentMemberPlayerIds(tournament.id);
+  const alreadyInTournament = playerIds.filter((playerId) => usedPlayerIds.includes(playerId));
+  if (alreadyInTournament.length > 0) {
+    throw new Error('Uno o mas jugadores ya estan anotados en otro equipo de este torneo');
+  }
+
+  return playerIds;
+}
+
 // =====================================================
 // Service Functions
 // =====================================================
@@ -359,6 +391,21 @@ export async function getTournamentById(
   );
 
   return tournament ? toTournament(tournament) : null;
+}
+
+export async function searchTournamentEligiblePlayers(
+  _ctx: ServiceContext,
+  tournamentId: string,
+  search?: string | null,
+): Promise<TournamentPlayer[]> {
+  const tournament = await tournamentRepository.getTournamentById(tournamentId);
+  if (!tournament) throw new Error('Torneo no encontrado');
+  if (tournament.status !== 'registration') return [];
+
+  const players = await tournamentRepository.searchEligiblePlayers(tournamentId, search ?? null);
+  return players
+    .map((player) => toTournamentPlayer(player))
+    .filter((player): player is TournamentPlayer => Boolean(player));
 }
 
 export async function createTournament(
@@ -462,11 +509,23 @@ export async function registerTournamentTeam(
   input: RegisterTournamentTeamInput,
   ctx: ServiceContext,
 ): Promise<TournamentTeamRegistrationResult> {
-  if (!ctx.userId) throw new Error('Authentication required');
-  const db = ctx.supabase;
-  if (!db) throw new Error('User-scoped client required for write operations');
+  return joinTournament(
+    {
+      tournamentId: input.tournamentId,
+      teamName: input.name,
+      memberIds: [],
+    },
+    ctx,
+  );
+}
 
-  const teamName = input.name.trim();
+export async function joinTournament(
+  input: JoinTournamentInput,
+  ctx: ServiceContext,
+): Promise<TournamentTeamRegistrationResult> {
+  if (!ctx.userId) throw new Error('Authentication required');
+
+  const teamName = input.teamName.trim();
   if (teamName.length < 2) throw new Error('El nombre del equipo debe tener al menos 2 caracteres');
   if (teamName.length > 80) throw new Error('El nombre del equipo no puede superar 80 caracteres');
 
@@ -484,13 +543,10 @@ export async function registerTournamentTeam(
     throw new Error('Ya existe un equipo con ese nombre en el torneo');
   }
 
-  const teamId = await tournamentRepository.registerTournamentTeamRpc(
-    {
-      tournamentId: input.tournamentId,
-      name: teamName,
-    },
-    db,
-  );
+  const playerIds = await validateJoinRoster(tournament, ctx.userId, input.memberIds ?? []);
+  const team = await tournamentRepository.createTournamentTeam(input.tournamentId, teamName, ctx.userId, supabase);
+  await tournamentRepository.createTournamentTeamMembers(team.id, playerIds, supabase);
+  await generateFixtureIfRegistrationComplete({ userId: ctx.userId, supabase }, input.tournamentId);
 
   const updatedTournament = await tournamentRepository.getTournamentById(input.tournamentId);
   if (!updatedTournament) throw new Error('No se pudo cargar el torneo actualizado');
@@ -498,16 +554,83 @@ export async function registerTournamentTeam(
 
   return {
     success: true,
-    teamId,
+    teamId: team.id,
     message: null,
     tournament: toTournament(updatedTournament),
   };
 }
 
+export async function addTournamentTeamMember(
+  input: TournamentTeamMemberInput,
+  ctx: ServiceContext,
+): Promise<TournamentTeamRegistrationResult> {
+  if (!ctx.userId) throw new Error('Authentication required');
+
+  const [tournament, team] = await Promise.all([
+    tournamentRepository.getTournamentById(input.tournamentId),
+    tournamentRepository.getTournamentTeamById(input.teamId),
+  ]);
+  if (!tournament) throw new Error('Torneo no encontrado');
+  if (!team || team.tournamentId !== input.tournamentId) throw new Error('Equipo no encontrado');
+  if (team.captainId !== ctx.userId) throw new Error('Solo el capitan puede modificar este equipo');
+  if (tournament.status !== 'registration') throw new Error('La inscripcion de este torneo ya esta cerrada');
+
+  const currentMemberIds = await tournamentRepository.getTournamentTeamMemberIds(input.teamId);
+  if (currentMemberIds.includes(input.playerId)) {
+    throw new Error('Ese jugador ya integra el equipo');
+  }
+  if (currentMemberIds.length >= tournament.playersPerTeam) {
+    throw new Error(`El equipo no puede superar ${tournament.playersPerTeam} jugadores`);
+  }
+
+  const [player] = await tournamentRepository.getPlayerProfilesByIds([input.playerId]);
+  if (!player) throw new Error('Jugador no encontrado');
+
+  const usedPlayerIds = await tournamentRepository.getTournamentMemberPlayerIds(input.tournamentId);
+  if (usedPlayerIds.includes(input.playerId)) {
+    throw new Error('Ese jugador ya esta anotado en otro equipo de este torneo');
+  }
+
+  await tournamentRepository.createTournamentTeamMember(input.teamId, input.playerId, supabase);
+  await invalidateTournamentListCaches();
+  const updatedTournament = await tournamentRepository.getTournamentById(input.tournamentId);
+  if (!updatedTournament) throw new Error('No se pudo cargar el torneo actualizado');
+
+  return { success: true, teamId: input.teamId, message: null, tournament: toTournament(updatedTournament) };
+}
+
+export async function removeTournamentTeamMember(
+  input: TournamentTeamMemberInput,
+  ctx: ServiceContext,
+): Promise<TournamentTeamRegistrationResult> {
+  if (!ctx.userId) throw new Error('Authentication required');
+
+  const [tournament, team] = await Promise.all([
+    tournamentRepository.getTournamentById(input.tournamentId),
+    tournamentRepository.getTournamentTeamById(input.teamId),
+  ]);
+  if (!tournament) throw new Error('Torneo no encontrado');
+  if (!team || team.tournamentId !== input.tournamentId) throw new Error('Equipo no encontrado');
+  if (team.captainId !== ctx.userId) throw new Error('Solo el capitan puede modificar este equipo');
+  if (tournament.status !== 'registration') throw new Error('La inscripcion de este torneo ya esta cerrada');
+  if (input.playerId === team.captainId) throw new Error('El capitan no puede quitarse del equipo');
+
+  await tournamentRepository.deleteTournamentTeamMember(input.teamId, input.playerId, supabase);
+  await invalidateTournamentListCaches();
+  const updatedTournament = await tournamentRepository.getTournamentById(input.tournamentId);
+  if (!updatedTournament) throw new Error('No se pudo cargar el torneo actualizado');
+
+  return { success: true, teamId: input.teamId, message: null, tournament: toTournament(updatedTournament) };
+}
+
 export const tournamentService = {
   listRegistrationTournaments,
   getTournamentById,
+  searchTournamentEligiblePlayers,
   createTournament,
   generateFixtureIfRegistrationComplete,
   registerTournamentTeam,
+  joinTournament,
+  addTournamentTeamMember,
+  removeTournamentTeamMember,
 };

--- a/apps/frontend/src/components/tournaments/TournamentCard.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentCard.tsx
@@ -14,7 +14,7 @@ import { Calendar, Loader2, MapPin, Trophy, Users } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
-  REGISTER_TOURNAMENT_TEAM,
+  JOIN_TOURNAMENT,
   type TournamentListItem,
   type TournamentTeamRegistrationResult,
 } from '@/graphql/operations/tournaments';
@@ -87,13 +87,13 @@ export function TournamentCard({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          query: REGISTER_TOURNAMENT_TEAM,
-          variables: { input: { tournamentId: tournament.id, name } },
+          query: JOIN_TOURNAMENT,
+          variables: { input: { tournamentId: tournament.id, teamName: name, memberIds: [] } },
         }),
       });
 
       const payload = (await response.json()) as {
-        data?: { registerTournamentTeam?: TournamentTeamRegistrationResult };
+        data?: { joinTournament?: TournamentTeamRegistrationResult };
         errors?: Array<{ message: string }>;
       };
 
@@ -103,7 +103,7 @@ export function TournamentCard({
         throw new Error(graphQLError);
       }
 
-      const result = payload.data?.registerTournamentTeam;
+      const result = payload.data?.joinTournament;
       if (!result) throw new Error('Respuesta inesperada del servidor');
       if (!result.success) {
         const message = result.message ?? 'No se pudo inscribir el equipo';

--- a/apps/frontend/src/components/tournaments/TournamentRegistrationForm.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentRegistrationForm.tsx
@@ -1,8 +1,13 @@
-import { type SyntheticEvent, useState } from 'react';
-import { Loader2, LogIn, UserPlus } from 'lucide-react';
+import { type SyntheticEvent, useEffect, useMemo, useState } from 'react';
+import { Loader2, LogIn, Search, UserMinus, UserPlus, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
-  REGISTER_TOURNAMENT_TEAM,
+  ADD_TOURNAMENT_TEAM_MEMBER,
+  GET_TOURNAMENT_ELIGIBLE_PLAYERS,
+  JOIN_TOURNAMENT,
+  REMOVE_TOURNAMENT_TEAM_MEMBER,
+  type TournamentPlayer,
+  type TournamentTeam,
   type TournamentTeamRegistrationResult,
 } from '@/graphql/operations/tournaments';
 
@@ -10,23 +15,126 @@ interface TournamentRegistrationFormProps {
   tournamentId: string;
   isAuthenticated: boolean;
   canRegister: boolean;
+  playersPerTeam: number;
+  currentUserId?: string | null;
+  teams?: TournamentTeam[];
+}
+
+interface EligiblePlayersPayload {
+  tournamentEligiblePlayers: TournamentPlayer[];
 }
 
 function isAuthError(message: string): boolean {
   return message.toLowerCase().includes('authentication required');
 }
 
+function initials(name: string): string {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('');
+}
+
+async function postTournamentMutation(
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<TournamentTeamRegistrationResult> {
+  const response = await fetch('/api/graphql-auth', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const payload = (await response.json()) as {
+    data?: Record<string, TournamentTeamRegistrationResult | undefined>;
+    errors?: Array<{ message: string }>;
+  };
+
+  const graphQLError = payload.errors?.[0]?.message;
+  if (graphQLError) {
+    if (isAuthError(graphQLError)) window.location.href = '/login';
+    throw new Error(graphQLError);
+  }
+
+  const result = Object.values(payload.data ?? {})[0];
+  if (!result) throw new Error('Respuesta inesperada del servidor');
+  if (!result.success) {
+    const message = result.message ?? 'No se pudo actualizar el equipo';
+    if (isAuthError(message)) window.location.href = '/login';
+    throw new Error(message);
+  }
+
+  return result;
+}
+
 export function TournamentRegistrationForm({
   tournamentId,
   isAuthenticated,
   canRegister,
+  playersPerTeam,
+  currentUserId = null,
+  teams = [],
 }: TournamentRegistrationFormProps) {
   const [teamName, setTeamName] = useState('');
+  const [search, setSearch] = useState('');
+  const [eligiblePlayers, setEligiblePlayers] = useState<TournamentPlayer[]>([]);
+  const [selectedPlayers, setSelectedPlayers] = useState<TournamentPlayer[]>([]);
+  const [loadingPlayers, setLoadingPlayers] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleSubmit(event: SyntheticEvent<HTMLFormElement>) {
+  const captainTeam = useMemo(
+    () => teams.find((team) => team.captainId === currentUserId) ?? null,
+    [currentUserId, teams],
+  );
+  const currentRosterSize = captainTeam?.players.length ?? 1;
+  const selectedIds = useMemo(() => new Set(selectedPlayers.map((player) => player.id)), [selectedPlayers]);
+  const selectedRosterSize = 1 + selectedPlayers.length;
+  const canSelectMore = selectedRosterSize < playersPerTeam;
+
+  useEffect(() => {
+    if (!isAuthenticated || (!canRegister && !captainTeam)) return;
+
+    const timeout = window.setTimeout(() => {
+      setLoadingPlayers(true);
+      fetch('/api/graphql-auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: GET_TOURNAMENT_ELIGIBLE_PLAYERS,
+          variables: { tournamentId, search: search.trim() || null },
+        }),
+      })
+        .then((response) => response.json())
+        .then((payload: { data?: EligiblePlayersPayload; errors?: Array<{ message: string }> }) => {
+          const graphQLError = payload.errors?.[0]?.message;
+          if (graphQLError) throw new Error(graphQLError);
+          setEligiblePlayers(payload.data?.tournamentEligiblePlayers ?? []);
+        })
+        .catch((err: unknown) => {
+          setError(err instanceof Error ? err.message : 'Error al buscar jugadores');
+          setEligiblePlayers([]);
+        })
+        .finally(() => setLoadingPlayers(false));
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [captainTeam, canRegister, isAuthenticated, search, tournamentId]);
+
+  function addSelectedPlayer(player: TournamentPlayer) {
+    if (!canSelectMore || selectedIds.has(player.id)) return;
+    setSelectedPlayers((current) => [...current, player]);
+    setSearch('');
+  }
+
+  function removeSelectedPlayer(playerId: string) {
+    setSelectedPlayers((current) => current.filter((player) => player.id !== playerId));
+  }
+
+  async function handleJoin(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!isAuthenticated) {
       window.location.href = '/login';
@@ -35,7 +143,11 @@ export function TournamentRegistrationForm({
 
     const name = teamName.trim();
     if (name.length < 2) {
-      setError('Ingresá al menos 2 caracteres para el equipo.');
+      setError('Ingresa al menos 2 caracteres para el equipo.');
+      return;
+    }
+    if (selectedRosterSize > playersPerTeam) {
+      setError(`El equipo no puede superar ${playersPerTeam} jugadores.`);
       return;
     }
 
@@ -44,34 +156,13 @@ export function TournamentRegistrationForm({
     setError(null);
 
     try {
-      const response = await fetch('/api/graphql-auth', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          query: REGISTER_TOURNAMENT_TEAM,
-          variables: { input: { tournamentId, name } },
-        }),
+      await postTournamentMutation(JOIN_TOURNAMENT, {
+        input: {
+          tournamentId,
+          teamName: name,
+          memberIds: selectedPlayers.map((player) => player.id),
+        },
       });
-
-      const payload = (await response.json()) as {
-        data?: { registerTournamentTeam?: TournamentTeamRegistrationResult };
-        errors?: Array<{ message: string }>;
-      };
-
-      const graphQLError = payload.errors?.[0]?.message;
-      if (graphQLError) {
-        if (isAuthError(graphQLError)) window.location.href = '/login';
-        throw new Error(graphQLError);
-      }
-
-      const result = payload.data?.registerTournamentTeam;
-      if (!result) throw new Error('Respuesta inesperada del servidor');
-      if (!result.success) {
-        const resultMessage = result.message ?? 'No se pudo inscribir el equipo';
-        if (isAuthError(resultMessage)) window.location.href = '/login';
-        throw new Error(resultMessage);
-      }
-
       setMessage('Equipo anotado. Actualizando torneo...');
       window.location.reload();
     } catch (err) {
@@ -81,25 +172,117 @@ export function TournamentRegistrationForm({
     }
   }
 
-  if (!canRegister) {
-    return (
-      <div className="registration-closed" role="status">
-        <span>Inscripción cerrada o cupos completos</span>
-      </div>
-    );
+  async function handleAddMember(player: TournamentPlayer) {
+    if (!captainTeam || currentRosterSize >= playersPerTeam) return;
+    setSubmitting(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      await postTournamentMutation(ADD_TOURNAMENT_TEAM_MEMBER, {
+        input: { tournamentId, teamId: captainTeam.id, playerId: player.id },
+      });
+      setMessage('Jugador agregado. Actualizando torneo...');
+      window.location.reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al agregar jugador');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleRemoveMember(playerId: string) {
+    if (!captainTeam) return;
+    setSubmitting(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      await postTournamentMutation(REMOVE_TOURNAMENT_TEAM_MEMBER, {
+        input: { tournamentId, teamId: captainTeam.id, playerId },
+      });
+      setMessage('Jugador quitado. Actualizando torneo...');
+      window.location.reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al quitar jugador');
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   if (!isAuthenticated) {
     return (
       <a className="detail-login-button" href="/login">
         <LogIn className="h-4 w-4" aria-hidden="true" />
-        Iniciar sesión para anotar equipo
+        Iniciar sesion para anotar equipo
       </a>
     );
   }
 
+  if (captainTeam) {
+    const removablePlayers = captainTeam.players.filter((player) => player.id !== captainTeam.captainId);
+
+    return (
+      <div className="detail-register-form">
+        <div className="captain-panel">
+          <strong>Tu equipo: {captainTeam.name}</strong>
+          <span>{captainTeam.players.length}/{playersPerTeam} jugadores</span>
+        </div>
+
+        {removablePlayers.length > 0 && (
+          <div className="selected-player-list">
+            {removablePlayers.map((player) => (
+              <button
+                key={player.id}
+                type="button"
+                className="selected-player-chip"
+                disabled={submitting}
+                onClick={() => handleRemoveMember(player.id)}
+              >
+                {player.displayName}
+                <UserMinus className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            ))}
+          </div>
+        )}
+
+        {currentRosterSize < playersPerTeam && (
+          <div className="player-search-box">
+            <Search className="h-4 w-4" aria-hidden="true" />
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Buscar jugador para agregar"
+              className="player-search-input"
+            />
+          </div>
+        )}
+
+        {currentRosterSize < playersPerTeam && (
+          <PlayerResults
+            players={eligiblePlayers.filter((player) => player.id !== currentUserId)}
+            loading={loadingPlayers}
+            disabled={submitting}
+            onSelect={handleAddMember}
+          />
+        )}
+
+        {error && <p className="detail-form-error" role="alert">{error}</p>}
+        {message && <p className="detail-form-message" role="status">{message}</p>}
+      </div>
+    );
+  }
+
+  if (!canRegister) {
+    return (
+      <div className="registration-closed" role="status">
+        <span>Inscripcion cerrada o cupos completos</span>
+      </div>
+    );
+  }
+
   return (
-    <form className="detail-register-form" onSubmit={handleSubmit}>
+    <form className="detail-register-form" onSubmit={handleJoin}>
       <label className="sr-only" htmlFor="teamName">Nombre del equipo</label>
       <input
         id="teamName"
@@ -109,6 +292,48 @@ export function TournamentRegistrationForm({
         placeholder="Nombre del equipo"
         className="detail-team-input"
       />
+
+      <div className="team-builder-count">
+        <span>Capitan + miembros</span>
+        <strong>{selectedRosterSize}/{playersPerTeam}</strong>
+      </div>
+
+      {selectedPlayers.length > 0 && (
+        <div className="selected-player-list">
+          {selectedPlayers.map((player) => (
+            <button
+              key={player.id}
+              type="button"
+              className="selected-player-chip"
+              onClick={() => removeSelectedPlayer(player.id)}
+            >
+              {player.displayName}
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {canSelectMore && (
+        <>
+          <div className="player-search-box">
+            <Search className="h-4 w-4" aria-hidden="true" />
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Buscar miembros"
+              className="player-search-input"
+            />
+          </div>
+          <PlayerResults
+            players={eligiblePlayers.filter((player) => player.id !== currentUserId && !selectedIds.has(player.id))}
+            loading={loadingPlayers}
+            disabled={submitting}
+            onSelect={addSelectedPlayer}
+          />
+        </>
+      )}
+
       <Button type="submit" disabled={submitting}>
         {submitting ? (
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
@@ -120,5 +345,43 @@ export function TournamentRegistrationForm({
       {error && <p className="detail-form-error" role="alert">{error}</p>}
       {message && <p className="detail-form-message" role="status">{message}</p>}
     </form>
+  );
+}
+
+function PlayerResults({
+  players,
+  loading,
+  disabled,
+  onSelect,
+}: {
+  players: TournamentPlayer[];
+  loading: boolean;
+  disabled: boolean;
+  onSelect: (player: TournamentPlayer) => void;
+}) {
+  if (loading) {
+    return <div className="player-results-note">Buscando jugadores...</div>;
+  }
+
+  if (players.length === 0) {
+    return <div className="player-results-note">No hay jugadores disponibles</div>;
+  }
+
+  return (
+    <div className="player-results-list">
+      {players.slice(0, 6).map((player) => (
+        <button
+          key={player.id}
+          type="button"
+          className="player-result-item"
+          disabled={disabled}
+          onClick={() => onSelect(player)}
+        >
+          <span className="player-result-avatar">{initials(player.displayName) || 'J'}</span>
+          <span>{player.displayName}</span>
+          <UserPlus className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      ))}
+    </div>
   );
 }

--- a/apps/frontend/src/graphql/operations/tournaments.graphql
+++ b/apps/frontend/src/graphql/operations/tournaments.graphql
@@ -90,6 +90,15 @@ query GetTournamentDetail($id: ID!) {
   }
 }
 
+query GetTournamentEligiblePlayers($tournamentId: ID!, $search: String) {
+  tournamentEligiblePlayers(tournamentId: $tournamentId, search: $search) {
+    id
+    displayName
+    avatarUrl
+    preferredPosition
+  }
+}
+
 mutation CreateTournament($input: CreateTournamentInput!) {
   createTournament(input: $input) {
     success
@@ -187,6 +196,133 @@ mutation RegisterTournamentTeam($input: RegisterTournamentTeamInput!) {
         status
         scoreHome
         scoreAway
+      }
+    }
+  }
+}
+
+mutation JoinTournament($input: JoinTournamentInput!) {
+  joinTournament(input: $input) {
+    success
+    teamId
+    message
+    tournament {
+      id
+      name
+      format
+      teamCount
+      playersPerTeam
+      registeredTeamsCount
+      status
+      description
+      startDate
+      endDate
+      teams {
+        id
+        name
+        captainId
+        captain {
+          id
+          displayName
+          avatarUrl
+          preferredPosition
+        }
+        players {
+          id
+          displayName
+          avatarUrl
+          preferredPosition
+        }
+        createdAt
+      }
+      club {
+        id
+        name
+        zone
+        address
+        imageUrl
+      }
+      fixtureMatches {
+        id
+        tournamentId
+        round
+        homeTeamId
+        awayTeamId
+        homeTeam {
+          id
+          name
+        }
+        awayTeam {
+          id
+          name
+        }
+        courtId
+        scheduledAt
+        status
+        scoreHome
+        scoreAway
+      }
+    }
+  }
+}
+
+mutation AddTournamentTeamMember($input: TournamentTeamMemberInput!) {
+  addTournamentTeamMember(input: $input) {
+    success
+    teamId
+    message
+    tournament {
+      id
+      registeredTeamsCount
+      status
+      teams {
+        id
+        name
+        captainId
+        captain {
+          id
+          displayName
+          avatarUrl
+          preferredPosition
+        }
+        players {
+          id
+          displayName
+          avatarUrl
+          preferredPosition
+        }
+        createdAt
+      }
+    }
+  }
+}
+
+mutation RemoveTournamentTeamMember($input: TournamentTeamMemberInput!) {
+  removeTournamentTeamMember(input: $input) {
+    success
+    teamId
+    message
+    tournament {
+      id
+      registeredTeamsCount
+      status
+      teams {
+        id
+        name
+        captainId
+        captain {
+          id
+          displayName
+          avatarUrl
+          preferredPosition
+        }
+        players {
+          id
+          displayName
+          avatarUrl
+          preferredPosition
+        }
+        createdAt
       }
     }
   }

--- a/apps/frontend/src/graphql/operations/tournaments.ts
+++ b/apps/frontend/src/graphql/operations/tournaments.ts
@@ -121,6 +121,18 @@ export interface RegisterTournamentTeamInput {
   name: string;
 }
 
+export interface JoinTournamentInput {
+  tournamentId: string;
+  teamName: string;
+  memberIds: string[];
+}
+
+export interface TournamentTeamMemberInput {
+  tournamentId: string;
+  teamId: string;
+  playerId: string;
+}
+
 export interface TournamentTeamRegistrationResult {
   success: boolean;
   teamId: string | null;
@@ -218,6 +230,17 @@ export const GET_TOURNAMENT_DETAIL = /* GraphQL */ `
         scoreHome
         scoreAway
       }
+    }
+  }
+`;
+
+export const GET_TOURNAMENT_ELIGIBLE_PLAYERS = /* GraphQL */ `
+  query GetTournamentEligiblePlayers($tournamentId: ID!, $search: String) {
+    tournamentEligiblePlayers(tournamentId: $tournamentId, search: $search) {
+      id
+      displayName
+      avatarUrl
+      preferredPosition
     }
   }
 `;
@@ -322,6 +345,139 @@ export const REGISTER_TOURNAMENT_TEAM = /* GraphQL */ `
           status
           scoreHome
           scoreAway
+        }
+      }
+    }
+  }
+`;
+
+export const JOIN_TOURNAMENT = /* GraphQL */ `
+  mutation JoinTournament($input: JoinTournamentInput!) {
+    joinTournament(input: $input) {
+      success
+      teamId
+      message
+      tournament {
+        id
+        name
+        format
+        teamCount
+        playersPerTeam
+        registeredTeamsCount
+        status
+        description
+        startDate
+        endDate
+        teams {
+          id
+          name
+          captainId
+          captain {
+            id
+            displayName
+            avatarUrl
+            preferredPosition
+          }
+          players {
+            id
+            displayName
+            avatarUrl
+            preferredPosition
+          }
+          createdAt
+        }
+        club {
+          id
+          name
+          zone
+          address
+          imageUrl
+        }
+        fixtureMatches {
+          id
+          tournamentId
+          round
+          homeTeamId
+          awayTeamId
+          homeTeam {
+            id
+            name
+          }
+          awayTeam {
+            id
+            name
+          }
+          courtId
+          scheduledAt
+          status
+          scoreHome
+          scoreAway
+        }
+      }
+    }
+  }
+`;
+
+export const ADD_TOURNAMENT_TEAM_MEMBER = /* GraphQL */ `
+  mutation AddTournamentTeamMember($input: TournamentTeamMemberInput!) {
+    addTournamentTeamMember(input: $input) {
+      success
+      teamId
+      message
+      tournament {
+        id
+        registeredTeamsCount
+        status
+        teams {
+          id
+          name
+          captainId
+          captain {
+            id
+            displayName
+            avatarUrl
+            preferredPosition
+          }
+          players {
+            id
+            displayName
+            avatarUrl
+            preferredPosition
+          }
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export const REMOVE_TOURNAMENT_TEAM_MEMBER = /* GraphQL */ `
+  mutation RemoveTournamentTeamMember($input: TournamentTeamMemberInput!) {
+    removeTournamentTeamMember(input: $input) {
+      success
+      teamId
+      message
+      tournament {
+        id
+        registeredTeamsCount
+        status
+        teams {
+          id
+          name
+          captainId
+          captain {
+            id
+            displayName
+            avatarUrl
+            preferredPosition
+          }
+          players {
+            id
+            displayName
+            avatarUrl
+            preferredPosition
+          }
+          createdAt
         }
       }
     }

--- a/apps/frontend/src/pages/torneos/[id].astro
+++ b/apps/frontend/src/pages/torneos/[id].astro
@@ -201,6 +201,9 @@ for (const match of tournament?.fixtureMatches ?? []) {
                 tournamentId={tournament.id}
                 isAuthenticated={isAuthenticated}
                 canRegister={canRegister}
+                playersPerTeam={tournament.playersPerTeam}
+                currentUserId={user?.id ?? null}
+                teams={tournament.teams}
               />
             </aside>
           </section>
@@ -340,6 +343,18 @@ for (const match of tournament?.fixtureMatches ?? []) {
   :global(.detail-team-input) { min-height: 42px; border: 1px solid rgba(255,255,255,0.12); background: hsl(220 55% 8%); color: white; border-radius: 8px; padding: 0 0.8rem; outline: none; }
   :global(.detail-form-error) { margin: 0; color: hsl(0 72% 70%); font-size: 0.85rem; }
   :global(.detail-form-message) { margin: 0; color: hsl(142 72% 65%); font-size: 0.85rem; }
+  :global(.team-builder-count), :global(.captain-panel) { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; color: hsl(215 20% 70%); font-size: 0.84rem; }
+  :global(.team-builder-count strong), :global(.captain-panel strong) { color: white; }
+  :global(.captain-panel) { align-items: flex-start; flex-direction: column; background: rgba(255,255,255,0.055); border: 1px solid rgba(255,255,255,0.09); border-radius: 8px; padding: 0.75rem; }
+  :global(.captain-panel span) { color: hsl(35 100% 65%); font-weight: 700; }
+  :global(.player-search-box) { min-height: 40px; display: flex; align-items: center; gap: 0.55rem; border: 1px solid rgba(255,255,255,0.12); background: hsl(220 55% 8%); color: hsl(215 20% 55%); border-radius: 8px; padding: 0 0.75rem; }
+  :global(.player-search-input) { width: 100%; min-width: 0; color: white; outline: none; font-size: 0.88rem; }
+  :global(.selected-player-list), :global(.player-results-list) { display: grid; gap: 0.45rem; }
+  :global(.selected-player-chip), :global(.player-result-item) { min-height: 36px; display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; border-radius: 8px; border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.05); color: hsl(210 20% 90%); padding: 0.45rem 0.65rem; font-size: 0.84rem; cursor: pointer; }
+  :global(.selected-player-chip:hover), :global(.player-result-item:hover) { border-color: rgba(246,164,0,0.35); color: white; }
+  :global(.player-result-avatar) { width: 24px; height: 24px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; background: hsl(35 100% 48%); color: hsl(220 72% 7%); font-size: 0.68rem; font-weight: 800; }
+  :global(.player-result-item span:nth-child(2)) { flex: 1; min-width: 0; text-align: left; overflow-wrap: anywhere; }
+  :global(.player-results-note) { color: hsl(215 20% 55%); font-size: 0.82rem; border: 1px dashed rgba(255,255,255,0.12); border-radius: 8px; padding: 0.6rem 0.7rem; }
   :global(.detail-login-button), :global(.registration-closed) { display: inline-flex; align-items: center; justify-content: center; gap: 0.45rem; min-height: 42px; border-radius: 8px; text-decoration: none; font-weight: 700; }
   :global(.detail-login-button) { background: hsl(35 100% 48%); color: hsl(220 72% 7%); }
   :global(.registration-closed) { background: rgba(255,255,255,0.06); color: hsl(215 20% 62%); padding: 0 0.75rem; }


### PR DESCRIPTION
…anagement

- Introduced `JoinTournamentInput` and `TournamentTeamMemberInput` GraphQL inputs.
- Implemented `joinTournament` mutation to allow teams to join tournaments.
- Added `addTournamentTeamMember` and `removeTournamentTeamMember` mutations for managing team members.
- Updated tournament service to validate team rosters and handle member additions/removals.
- Enhanced frontend components to support joining tournaments and managing team members.
- Added GraphQL queries for fetching eligible players for tournaments.
- Updated styles for improved user experience in tournament registration forms.