### PR TITLE
feat: add division management and recalculation for player profiles

### DIFF
--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -822,6 +822,7 @@ export type TeamMember = {
   __typename?: 'TeamMember';
   avatarUrl?: Maybe<Scalars['String']['output']>;
   displayName: Scalars['String']['output'];
+  division?: Maybe<Scalars['Int']['output']>;
   id: Scalars['ID']['output'];
   preferredPosition?: Maybe<Scalars['String']['output']>;
 };
@@ -1612,6 +1613,7 @@ export type SlotImpactPreviewResolvers<ContextType = GraphQLContext, ParentType 
 export type TeamMemberResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TeamMember'] = ResolversParentTypes['TeamMember']> = ResolversObject<{
   avatarUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  division?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   preferredPosition?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;

--- a/apps/backend/src/graphql/schema/match.graphql
+++ b/apps/backend/src/graphql/schema/match.graphql
@@ -40,6 +40,7 @@ type TeamMember {
   displayName: String!
   avatarUrl: String
   preferredPosition: String
+  division: Int
 }
 
 # Participants split by team with counts and available spots

--- a/apps/backend/src/repositories/matchRepository.ts
+++ b/apps/backend/src/repositories/matchRepository.ts
@@ -438,7 +438,7 @@ const PARTICIPANT_COLUMNS = `
   id,
   team,
   "joinedAt",
-  profiles(id, "displayName", "avatarUrl", "preferredPosition")
+  profiles(id, "displayName", "avatarUrl", "preferredPosition", division)
 `;
 
 export interface ParticipantProfileRow {
@@ -446,6 +446,7 @@ export interface ParticipantProfileRow {
   displayName: string;
   avatarUrl: string | null;
   preferredPosition: string | null;
+  division: number;
 }
 
 export interface ParticipantRow {

--- a/apps/backend/src/repositories/matchResultVoteRepository.ts
+++ b/apps/backend/src/repositories/matchResultVoteRepository.ts
@@ -378,6 +378,24 @@ export async function updateMatchWithResult(
 }
 
 /**
+ * Recalculate matchesPlayed, matchesWon, and division for every participant in a match.
+ * The SQL function derives stats from confirmed matches, so retries never double-count.
+ */
+export async function refreshCompetitiveStatsForMatch(matchId: string): Promise<void> {
+  const { error } = await supabase.rpc('refresh_profile_competitive_stats_for_match', {
+    p_match_id: matchId,
+  });
+
+  if (error) {
+    console.error(
+      `[matchResultVoteRepository.refreshCompetitiveStatsForMatch] Supabase error matchId=${matchId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+}
+
+/**
  * Get all participant userIds for a match.
  * Used for cache invalidation after result confirmation.
  */
@@ -410,5 +428,6 @@ export const matchResultVoteRepository = {
   confirmSubmission,
   rejectOtherSubmissions,
   updateMatchWithResult,
+  refreshCompetitiveStatsForMatch,
   getParticipantIds,
 };

--- a/apps/backend/src/services/matchResultVoteService.test.ts
+++ b/apps/backend/src/services/matchResultVoteService.test.ts
@@ -39,6 +39,7 @@ const repoMock = vi.hoisted(() => ({
   confirmSubmission: vi.fn(),
   rejectOtherSubmissions: vi.fn(),
   updateMatchWithResult: vi.fn(),
+  refreshCompetitiveStatsForMatch: vi.fn(),
   getParticipantIds: vi.fn(),
 }));
 
@@ -65,6 +66,7 @@ vi.mock('../config/redis.js', () => ({
     MATCH_DETAIL: 'match:',
     MATCHES_OPEN: 'matches:open',
     MATCHES_LIST: 'matches:list',
+    PROFILE_ME: 'profile:me:',
     USER_MATCHES: 'user:matches:',
   },
   CACHE_TTL: {
@@ -132,6 +134,7 @@ beforeEach(() => {
   repoMock.confirmSubmission.mockResolvedValue(undefined);
   repoMock.rejectOtherSubmissions.mockResolvedValue(undefined);
   repoMock.updateMatchWithResult.mockResolvedValue(undefined);
+  repoMock.refreshCompetitiveStatsForMatch.mockResolvedValue(undefined);
   repoMock.getParticipantIds.mockResolvedValue([USER_ID, OTHER_USER_ID]);
   repoMock.getSubmissionsByMatch.mockResolvedValue([]);
   repoMock.getSubmissionById.mockResolvedValue(buildSubmissionRow());
@@ -373,6 +376,7 @@ describe('matchResultVoteService.voteMatchResult', () => {
     expect(repoMock.confirmSubmission).toHaveBeenCalledWith(SUBMISSION_ID);
     expect(repoMock.rejectOtherSubmissions).toHaveBeenCalledWith(MATCH_ID, SUBMISSION_ID);
     expect(repoMock.updateMatchWithResult).toHaveBeenCalledWith(MATCH_ID, 3, 1, 'a');
+    expect(repoMock.refreshCompetitiveStatsForMatch).toHaveBeenCalledWith(MATCH_ID);
     expect(result.statusChanged).toBe(true);
     expect(result.submission.status).toBe(SubmissionStatus.Confirmed);
 
@@ -385,6 +389,10 @@ describe('matchResultVoteService.voteMatchResult', () => {
     // Per-participant history caches cleared
     expect(cacheMock.cacheDeletePattern).toHaveBeenCalledWith(`user:matches:${USER_ID}*`);
     expect(cacheMock.cacheDeletePattern).toHaveBeenCalledWith(`user:matches:${OTHER_USER_ID}*`);
+    expect(cacheMock.cacheDelete).toHaveBeenCalledWith(`profile:me:${USER_ID}`);
+    expect(cacheMock.cacheDelete).toHaveBeenCalledWith(`profile:me:${OTHER_USER_ID}`);
+    expect(cacheMock.cacheDelete).toHaveBeenCalledWith(`profile:public:${USER_ID}`);
+    expect(cacheMock.cacheDelete).toHaveBeenCalledWith(`profile:public:${OTHER_USER_ID}`);
 
     // Submission list cache cleared
     expect(cacheMock.cacheDelete).toHaveBeenCalledWith(`match:submissions:${MATCH_ID}`);

--- a/apps/backend/src/services/matchResultVoteService.ts
+++ b/apps/backend/src/services/matchResultVoteService.ts
@@ -308,6 +308,7 @@ export async function voteMatchResult(
       submission.scoreTeamB,
       submission.winningTeam,
     );
+    await matchResultVoteRepository.refreshCompetitiveStatsForMatch(submission.matchId);
 
     console.info(
       `[matchResultVoteService.voteMatchResult] submissionId=${parsed.submissionId} confirmed — match ${submission.matchId} completed`,
@@ -322,9 +323,11 @@ export async function voteMatchResult(
     // Invalidate history cache for all participants
     const participantIds = await matchResultVoteRepository.getParticipantIds(submission.matchId);
     await Promise.all(
-      participantIds.map((uid) =>
+      participantIds.flatMap((uid) => [
         cacheDeletePattern(`${CACHE_PREFIX.USER_MATCHES}${uid}*`),
-      ),
+        cacheDelete(`${CACHE_PREFIX.PROFILE_ME}${uid}`),
+        cacheDelete(`profile:public:${uid}`),
+      ]),
     );
   }
 

--- a/apps/backend/src/services/matchService.ts
+++ b/apps/backend/src/services/matchService.ts
@@ -382,6 +382,7 @@ function toMatchDetail(row: MatchDetailRow, userId?: string): Match {
       displayName: p.profiles.displayName,
       avatarUrl: p.profiles.avatarUrl ?? null,
       preferredPosition: p.profiles.preferredPosition ?? null,
+      division: p.profiles.division,
     }));
 
   const teamB = row.matchParticipants
@@ -391,6 +392,7 @@ function toMatchDetail(row: MatchDetailRow, userId?: string): Match {
       displayName: p.profiles.displayName,
       avatarUrl: p.profiles.avatarUrl ?? null,
       preferredPosition: p.profiles.preferredPosition ?? null,
+      division: p.profiles.division,
     }));
 
   const spotsPerTeam = Math.floor(row.capacity / 2);

--- a/apps/backend/supabase/migrations/20260518000000_profile_division_recalculation.sql
+++ b/apps/backend/supabase/migrations/20260518000000_profile_division_recalculation.sql
@@ -1,0 +1,88 @@
+-- ============================================================
+-- Profile divisions and ranking stats recalculation
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.calculate_profile_division(
+  p_matches_played int,
+  p_matches_won int
+)
+RETURNS smallint
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN p_matches_played < 5 THEN 1
+    WHEN (p_matches_won::numeric / NULLIF(p_matches_played, 0)) >= 0.75 THEN 4
+    WHEN (p_matches_won::numeric / NULLIF(p_matches_played, 0)) >= 0.60 THEN 3
+    WHEN (p_matches_won::numeric / NULLIF(p_matches_played, 0)) >= 0.45 THEN 2
+    ELSE 1
+  END::smallint;
+$$;
+
+CREATE OR REPLACE FUNCTION public.refresh_profile_competitive_stats_for_match(
+  p_match_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  WITH affected_players AS (
+    SELECT DISTINCT mp."playerId"
+    FROM public."matchParticipants" mp
+    WHERE mp."matchId" = p_match_id
+  ),
+  stats AS (
+    SELECT
+      ap."playerId",
+      COUNT(m.id)::int AS matches_played,
+      COUNT(m.id) FILTER (WHERE m."winningTeam" = mp.team)::int AS matches_won
+    FROM affected_players ap
+    LEFT JOIN public."matchParticipants" mp
+      ON mp."playerId" = ap."playerId"
+    LEFT JOIN public.matches m
+      ON m.id = mp."matchId"
+      AND m.status = 'completed'
+      AND m."resultStatus" = 'confirmed'
+      AND m."winningTeam" IS NOT NULL
+    GROUP BY ap."playerId"
+  )
+  UPDATE public.profiles p
+  SET
+    "matchesPlayed" = stats.matches_played,
+    "matchesWon" = stats.matches_won,
+    division = public.calculate_profile_division(stats.matches_played, stats.matches_won)
+  FROM stats
+  WHERE p.id = stats."playerId";
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.refresh_profile_competitive_stats_for_match(uuid)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.refresh_profile_competitive_stats_for_match(uuid)
+TO service_role;
+
+WITH stats AS (
+  SELECT
+    p.id AS "playerId",
+    COUNT(m.id)::int AS matches_played,
+    COUNT(m.id) FILTER (WHERE m."winningTeam" = mp.team)::int AS matches_won
+  FROM public.profiles p
+  LEFT JOIN public."matchParticipants" mp
+    ON mp."playerId" = p.id
+  LEFT JOIN public.matches m
+    ON m.id = mp."matchId"
+    AND m.status = 'completed'
+    AND m."resultStatus" = 'confirmed'
+    AND m."winningTeam" IS NOT NULL
+  WHERE p.role = 'player'
+  GROUP BY p.id
+)
+UPDATE public.profiles p
+SET
+  "matchesPlayed" = stats.matches_played,
+  "matchesWon" = stats.matches_won,
+  division = public.calculate_profile_division(stats.matches_played, stats.matches_won)
+FROM stats
+WHERE p.id = stats."playerId";

--- a/apps/frontend/src/components/matches/PlayerCard.astro
+++ b/apps/frontend/src/components/matches/PlayerCard.astro
@@ -20,6 +20,7 @@
  * - Previously fixed bugs: none relevant.
  */
 import { Hand, Shield, Zap, Target } from 'lucide-react';
+import DivisionBadge from '../shared/DivisionBadge.astro';
 
 const POSITION_ICON_COMPONENT: Record<string, typeof Hand> = {
   goalkeeper: Hand, GOALKEEPER: Hand,
@@ -33,6 +34,7 @@ export interface PlayerCardPlayer {
   displayName: string;
   avatarUrl: string | null;
   preferredPosition: string | null;
+  division?: number | null;
 }
 
 interface Props {
@@ -75,6 +77,7 @@ function initial(name: string) {
   <div class="player-info">
     <div class="player-name-row">
       <span class="player-name">{player.displayName}</span>
+      <DivisionBadge division={player.division} compact />
       {isOrganizer && <span class="badge-organizer">Organizador</span>}
     </div>
     {posLabel && (
@@ -125,6 +128,7 @@ function initial(name: string) {
     display: flex;
     flex-direction: column;
     gap: 0.15rem;
+    flex: 1;
     min-width: 0;
   }
 
@@ -132,6 +136,11 @@ function initial(name: string) {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    min-width: 0;
+  }
+
+  .player-name-row :global(.division-badge) {
+    flex-shrink: 0;
   }
 
   .player-name {

--- a/apps/frontend/src/components/profile/ProfileCard.astro
+++ b/apps/frontend/src/components/profile/ProfileCard.astro
@@ -16,6 +16,7 @@
  */
 
 import type { Profile } from '../../graphql/operations/profile';
+import DivisionBadge from '../shared/DivisionBadge.astro';
 
 interface Props {
   profile: Profile;
@@ -50,7 +51,7 @@ const avatarSrc = profile.avatarUrl ?? null;
 <article class="profile-card">
   <!-- Header stripe -->
   <div class="card-header">
-    <span class="division-badge">DIV {profile.division}</span>
+    <DivisionBadge division={profile.division} />
     <span class="role-badge">{roleLabel}</span>
   </div>
 
@@ -125,17 +126,6 @@ const avatarSrc = profile.avatarUrl ?? null;
     align-items: center;
     justify-content: space-between;
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-  }
-
-  .division-badge {
-    font-family: 'Bebas Neue', sans-serif;
-    font-size: 0.9rem;
-    letter-spacing: 0.12em;
-    color: hsl(35 100% 65%);
-    background: rgba(246, 164, 0, 0.12);
-    border: 1px solid rgba(246, 164, 0, 0.25);
-    padding: 0.15rem 0.6rem;
-    border-radius: 4px;
   }
 
   .role-badge {

--- a/apps/frontend/src/components/settings/ProfilePreviewModal.tsx
+++ b/apps/frontend/src/components/settings/ProfilePreviewModal.tsx
@@ -14,6 +14,7 @@
 
 import { X, User } from 'lucide-react';
 import type { PrivacySettings, Profile } from '../../graphql/operations/profile';
+import { getDivisionMeta } from '../../lib/division';
 
 interface Props {
   isOpen: boolean;
@@ -42,12 +43,15 @@ function PreviewCard({ profile, settings }: { profile: Profile; settings: Privac
     showStats && profile.matchesPlayed && profile.matchesPlayed > 0
       ? ((profile.matchesWon ?? 0) / profile.matchesPlayed) * 100
       : null;
+  const division = getDivisionMeta(profile.division);
 
   return (
     <article className="preview-card">
       <div className="preview-card-header">
         {showDivision && (
-          <span className="preview-div-badge">DIV {profile.division}</span>
+          <span className={`preview-div-badge ${division.className}`}>
+            D{division.level} {division.name}
+          </span>
         )}
         <span className="preview-role-badge">Jugador</span>
       </div>
@@ -124,14 +128,37 @@ function PreviewCard({ profile, settings }: { profile: Profile; settings: Privac
           border-bottom: 1px solid rgba(255,255,255,0.06);
         }
         .preview-div-badge {
+          --division-accent: hsl(35 100% 65%);
+          --division-bg: rgba(246,164,0,0.12);
+          --division-border: rgba(246,164,0,0.25);
           font-family: 'Bebas Neue', sans-serif;
           font-size: 0.85rem;
           letter-spacing: 0.1em;
-          color: hsl(35 100% 65%);
-          background: rgba(246,164,0,0.12);
-          border: 1px solid rgba(246,164,0,0.25);
+          color: var(--division-accent);
+          background: var(--division-bg);
+          border: 1px solid var(--division-border);
           padding: 0.1rem 0.5rem;
           border-radius: 4px;
+        }
+        .preview-div-badge.division-bronze {
+          --division-accent: hsl(24 78% 64%);
+          --division-bg: hsl(24 78% 45% / 0.13);
+          --division-border: hsl(24 78% 52% / 0.34);
+        }
+        .preview-div-badge.division-silver {
+          --division-accent: hsl(205 18% 82%);
+          --division-bg: hsl(205 18% 64% / 0.12);
+          --division-border: hsl(205 18% 76% / 0.34);
+        }
+        .preview-div-badge.division-gold {
+          --division-accent: hsl(44 100% 62%);
+          --division-bg: hsl(44 100% 50% / 0.13);
+          --division-border: hsl(44 100% 54% / 0.36);
+        }
+        .preview-div-badge.division-diamond {
+          --division-accent: hsl(184 86% 66%);
+          --division-bg: hsl(184 86% 46% / 0.13);
+          --division-border: hsl(184 86% 58% / 0.38);
         }
         .preview-role-badge {
           font-family: 'Barlow Condensed', sans-serif;

--- a/apps/frontend/src/components/shared/DivisionBadge.astro
+++ b/apps/frontend/src/components/shared/DivisionBadge.astro
@@ -1,0 +1,92 @@
+---
+import { getDivisionMeta } from '../../lib/division';
+
+interface Props {
+  division: number | null | undefined;
+  compact?: boolean;
+}
+
+const { division, compact = false } = Astro.props;
+const meta = getDivisionMeta(division);
+const label = compact ? meta.shortName : meta.name;
+---
+
+<span
+  class:list={['division-badge', meta.className, { 'division-badge--compact': compact }]}
+  title={`División ${meta.name}`}
+>
+  <span class="division-mark">D{meta.level}</span>
+  <span class="division-name">{label}</span>
+</span>
+
+<style>
+  .division-badge {
+    --division-accent: hsl(35 100% 55%);
+    --division-bg: hsl(35 100% 48% / 0.12);
+    --division-border: hsl(35 100% 48% / 0.32);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    width: fit-content;
+    max-width: 100%;
+    border-radius: 5px;
+    border: 1px solid var(--division-border);
+    background: var(--division-bg);
+    color: var(--division-accent);
+    padding: 0.16rem 0.5rem;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    line-height: 1;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .division-mark {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 0.9rem;
+    font-weight: 400;
+    letter-spacing: 0.04em;
+  }
+
+  .division-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .division-badge--compact {
+    gap: 0.25rem;
+    padding-inline: 0.38rem;
+  }
+
+  .division-bronze {
+    --division-accent: hsl(24 78% 64%);
+    --division-bg: hsl(24 78% 45% / 0.13);
+    --division-border: hsl(24 78% 52% / 0.34);
+  }
+
+  .division-silver {
+    --division-accent: hsl(205 18% 82%);
+    --division-bg: hsl(205 18% 64% / 0.12);
+    --division-border: hsl(205 18% 76% / 0.34);
+  }
+
+  .division-gold {
+    --division-accent: hsl(44 100% 62%);
+    --division-bg: hsl(44 100% 50% / 0.13);
+    --division-border: hsl(44 100% 54% / 0.36);
+  }
+
+  .division-diamond {
+    --division-accent: hsl(184 86% 66%);
+    --division-bg: hsl(184 86% 46% / 0.13);
+    --division-border: hsl(184 86% 58% / 0.38);
+  }
+
+  .division-elite {
+    --division-accent: hsl(320 80% 72%);
+    --division-bg: hsl(320 80% 48% / 0.13);
+    --division-border: hsl(320 80% 62% / 0.36);
+  }
+</style>

--- a/apps/frontend/src/graphql/operations/matches.graphql
+++ b/apps/frontend/src/graphql/operations/matches.graphql
@@ -85,12 +85,14 @@ query GetMatchDetail($id: ID!) {
         displayName
         avatarUrl
         preferredPosition
+        division
       }
       teamB {
         id
         displayName
         avatarUrl
         preferredPosition
+        division
       }
       teamACount
       teamBCount

--- a/apps/frontend/src/graphql/operations/matches.ts
+++ b/apps/frontend/src/graphql/operations/matches.ts
@@ -91,6 +91,7 @@ export interface TeamMember {
   displayName: string;
   avatarUrl: string | null;
   preferredPosition: string | null;
+  division: number | null;
 }
 
 export interface MatchParticipantsData {
@@ -300,8 +301,8 @@ export const GET_MATCH_DETAIL = /* GraphQL */ `
         imageUrl
       }
       participants {
-        teamA { id displayName avatarUrl preferredPosition }
-        teamB { id displayName avatarUrl preferredPosition }
+        teamA { id displayName avatarUrl preferredPosition division }
+        teamB { id displayName avatarUrl preferredPosition division }
         teamACount
         teamBCount
         totalCount

--- a/apps/frontend/src/lib/division.ts
+++ b/apps/frontend/src/lib/division.ts
@@ -1,0 +1,23 @@
+export interface DivisionMeta {
+  level: number;
+  name: string;
+  shortName: string;
+  className: string;
+}
+
+const DIVISIONS: Record<number, DivisionMeta> = {
+  1: { level: 1, name: 'Bronce', shortName: 'BR', className: 'division-bronze' },
+  2: { level: 2, name: 'Plata', shortName: 'PL', className: 'division-silver' },
+  3: { level: 3, name: 'Oro', shortName: 'OR', className: 'division-gold' },
+  4: { level: 4, name: 'Diamante', shortName: 'DI', className: 'division-diamond' },
+};
+
+export function getDivisionMeta(division: number | null | undefined): DivisionMeta {
+  const level = Math.max(1, Math.floor(division ?? 1));
+  return DIVISIONS[level] ?? {
+    level,
+    name: `Elite ${level}`,
+    shortName: `E${level}`,
+    className: 'division-elite',
+  };
+}

--- a/apps/frontend/src/pages/perfil/[id].astro
+++ b/apps/frontend/src/pages/perfil/[id].astro
@@ -21,6 +21,7 @@ export const prerender = false;
 
 import { Volleyball, Lock, ArrowLeft, BarChart3 } from 'lucide-react';
 import Layout from '../../layouts/Layout.astro';
+import DivisionBadge from '../../components/shared/DivisionBadge.astro';
 import { ACCESS_TOKEN_COOKIE } from '../../lib/auth';
 import {
   GET_PROFILE,
@@ -137,7 +138,7 @@ const winrateDisplay =
             <!-- Card header -->
             <div class="card-header">
               {profile.division != null && (
-                <span class="division-badge">DIV {profile.division}</span>
+                <DivisionBadge division={profile.division} />
               )}
               <span class="role-badge">Jugador</span>
             </div>
@@ -364,16 +365,6 @@ const winrateDisplay =
     align-items: center;
     justify-content: space-between;
     border-bottom: 1px solid rgba(255,255,255,0.06);
-  }
-  .division-badge {
-    font-family: 'Bebas Neue', sans-serif;
-    font-size: 0.9rem;
-    letter-spacing: 0.12em;
-    color: hsl(35 100% 65%);
-    background: rgba(246,164,0,0.12);
-    border: 1px solid rgba(246,164,0,0.25);
-    padding: 0.15rem 0.6rem;
-    border-radius: 4px;
   }
   .role-badge {
     font-family: 'Barlow Condensed', sans-serif;


### PR DESCRIPTION
Agrega funcionalidad de División y Ranking para jugadores.

- Define divisiones Bronce, Plata, Oro y Diamante según winrate y partidos jugados.
- Recalcula automáticamente `matchesPlayed`, `matchesWon` y `division` al confirmar resultados.
- Expone la división en perfiles y participantes de partidos.
- Agrega `DivisionBadge` reutilizable con estilos por nivel.
- Incluye migración SQL con recálculo idempotente desde partidos confirmados.
- Verificado con typecheck, tests backend y builds de frontend/backend.