### PR TITLE
feat(auth): implement change password functionality

### DIFF
--- a/apps/backend/src/controllers/authController.registerPlayer.test.ts
+++ b/apps/backend/src/controllers/authController.registerPlayer.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const authServiceMock = vi.hoisted(() => ({
   registerPlayer: vi.fn(),
+  changePassword: vi.fn(),
 }));
 
 vi.mock('../services/authService.js', () => ({
@@ -13,21 +14,33 @@ import { authController } from './authController.js';
 type MockResponse = {
   status: ReturnType<typeof vi.fn>;
   json: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
 };
 
 function createResponse(): MockResponse {
   const response = {
     status: vi.fn(),
     json: vi.fn(),
+    send: vi.fn(),
   };
   response.status.mockReturnValue(response);
   response.json.mockReturnValue(response);
+  response.send.mockReturnValue(response);
   return response;
 }
 
 async function registerPlayer(body: unknown): Promise<MockResponse> {
   const res = createResponse();
   await authController.registerPlayer({ body } as never, res as never);
+  return res;
+}
+
+async function changePassword(body: unknown, authorization = 'Bearer token-123'): Promise<MockResponse> {
+  const res = createResponse();
+  await authController.changePassword(
+    { body, headers: { authorization } } as never,
+    res as never,
+  );
   return res;
 }
 
@@ -143,5 +156,79 @@ describe('authController.registerPlayer', () => {
     expect(res.json).toHaveBeenCalledWith({
       message: 'Demasiados intentos de registro. Esperá unos minutos y volvé a intentarlo.',
     });
+  });
+});
+
+describe('authController.changePassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authServiceMock.changePassword.mockResolvedValue(undefined);
+  });
+
+  it('validates payload and updates password through the service', async () => {
+    const res = await changePassword({
+      currentPassword: 'Actual123',
+      newPassword: 'Nueva1234',
+      confirmPassword: 'Nueva1234',
+    });
+
+    expect(authServiceMock.changePassword).toHaveBeenCalledWith({
+      accessToken: 'token-123',
+      currentPassword: 'Actual123',
+      newPassword: 'Nueva1234',
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'ContraseÃ±a actualizada correctamente',
+    });
+  });
+
+  it('returns validation errors without calling the service', async () => {
+    const res = await changePassword({
+      currentPassword: '',
+      newPassword: '123',
+      confirmPassword: '',
+    });
+
+    expect(authServiceMock.changePassword).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Datos invÃ¡lidos',
+      errors: {
+        currentPassword: 'IngresÃ¡ tu contraseÃ±a actual',
+        newPassword: 'La nueva contraseÃ±a debe tener al menos 8 caracteres',
+        confirmPassword: 'ConfirmÃ¡ tu nueva contraseÃ±a',
+      },
+    });
+  });
+
+  it('maps current password failures to the currentPassword field', async () => {
+    authServiceMock.changePassword.mockRejectedValueOnce(
+      new Error('Current password is incorrect'),
+    );
+
+    const res = await changePassword({
+      currentPassword: 'Actual123',
+      newPassword: 'Nueva1234',
+      confirmPassword: 'Nueva1234',
+    });
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Datos invÃ¡lidos',
+      errors: { currentPassword: 'La contraseÃ±a actual no es correcta' },
+    });
+  });
+
+  it('requires an auth token', async () => {
+    const res = await changePassword({
+      currentPassword: 'Actual123',
+      newPassword: 'Nueva1234',
+      confirmPassword: 'Nueva1234',
+    }, '');
+
+    expect(authServiceMock.changePassword).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Missing or malformed token.' });
   });
 });

--- a/apps/backend/src/controllers/authController.ts
+++ b/apps/backend/src/controllers/authController.ts
@@ -75,6 +75,21 @@ const RegisterPlayerSchema = z
     path: ['confirmPassword'],
   });
 
+const ChangePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, 'IngresÃ¡ tu contraseÃ±a actual'),
+    newPassword: z.string().min(8, 'La nueva contraseÃ±a debe tener al menos 8 caracteres'),
+    confirmPassword: z.string().min(1, 'ConfirmÃ¡ tu nueva contraseÃ±a'),
+  })
+  .refine((d) => d.newPassword === d.confirmPassword, {
+    message: 'Las contraseÃ±as no coinciden',
+    path: ['confirmPassword'],
+  })
+  .refine((d) => d.currentPassword !== d.newPassword, {
+    message: 'La nueva contraseÃ±a debe ser distinta a la actual',
+    path: ['newPassword'],
+  });
+
 export const authController = {
   async login(req: Request, res: Response): Promise<void> {
     const email = typeof req.body?.email === 'string' ? req.body.email.trim() : '';
@@ -164,6 +179,63 @@ export const authController = {
     }
 
     res.status(204).send();
+  },
+
+  async changePassword(req: Request, res: Response): Promise<void> {
+    const authHeader = req.headers.authorization;
+    const accessToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
+
+    if (!accessToken) {
+      res.status(401).json({ message: 'Missing or malformed token.' });
+      return;
+    }
+
+    const parsed = ChangePasswordSchema.safeParse(req.body);
+    if (!parsed.success) {
+      const errors: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        const field = issue.path[0];
+        if (typeof field === 'string' && !errors[field]) {
+          errors[field] = issue.message;
+        }
+      }
+      res.status(400).json({ message: 'Datos invÃ¡lidos', errors });
+      return;
+    }
+
+    try {
+      await authService.changePassword({
+        accessToken,
+        currentPassword: parsed.data.currentPassword,
+        newPassword: parsed.data.newPassword,
+      });
+      res.status(200).json({ message: 'ContraseÃ±a actualizada correctamente' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Password update failed';
+
+      if (message === 'Invalid or expired token') {
+        res.status(401).json({ message: 'SesiÃ³n invÃ¡lida. IniciÃ¡ sesiÃ³n nuevamente.' });
+        return;
+      }
+
+      if (message === 'Current password is incorrect') {
+        res.status(400).json({
+          message: 'Datos invÃ¡lidos',
+          errors: { currentPassword: 'La contraseÃ±a actual no es correcta' },
+        });
+        return;
+      }
+
+      if (message.toLowerCase().includes('password')) {
+        res.status(400).json({
+          message: 'Datos invÃ¡lidos',
+          errors: { newPassword: 'La nueva contraseÃ±a no cumple los requisitos mÃ­nimos' },
+        });
+        return;
+      }
+
+      res.status(400).json({ message: 'No pudimos actualizar la contraseÃ±a. IntentÃ¡ de nuevo.' });
+    }
   },
 
   async register(req: Request, res: Response): Promise<void> {

--- a/apps/backend/src/routes/authRoutes.ts
+++ b/apps/backend/src/routes/authRoutes.ts
@@ -18,6 +18,7 @@ router.post('/login', authController.login);
 router.get('/session', authController.session);
 router.post('/refresh', authController.refresh);
 router.post('/logout', authController.logout);
+router.post('/change-password', authController.changePassword);
 router.post('/register-club', authController.register);
 router.post('/register-player', authController.registerPlayer);
 

--- a/apps/backend/src/services/authService.registerPlayer.test.ts
+++ b/apps/backend/src/services/authService.registerPlayer.test.ts
@@ -1,15 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const supabaseMock = vi.hoisted(() => ({
+  createAnonClient: vi.fn(),
+  createUserClient: vi.fn(),
   createUser: vi.fn(),
   deleteUser: vi.fn(),
+  signInWithPassword: vi.fn(),
+  getUser: vi.fn(),
+  updateUser: vi.fn(),
   from: vi.fn(),
   insert: vi.fn(),
 }));
 
 vi.mock('../config/supabase.js', () => ({
-  createAnonClient: vi.fn(),
-  createUserClient: vi.fn(),
+  createAnonClient: supabaseMock.createAnonClient,
+  createUserClient: supabaseMock.createUserClient,
   supabase: {
     auth: {
       admin: {
@@ -38,6 +43,21 @@ describe('authService.registerPlayer', () => {
       error: null,
     });
     supabaseMock.deleteUser.mockResolvedValue({ error: null });
+    supabaseMock.signInWithPassword.mockResolvedValue({ data: {}, error: null });
+    supabaseMock.getUser.mockResolvedValue({
+      data: { user: { id: 'user-123', email: 'mateo@example.com' } },
+      error: null,
+    });
+    supabaseMock.updateUser.mockResolvedValue({ data: {}, error: null });
+    supabaseMock.createAnonClient.mockReturnValue({
+      auth: { signInWithPassword: supabaseMock.signInWithPassword },
+    });
+    supabaseMock.createUserClient.mockReturnValue({
+      auth: {
+        getUser: supabaseMock.getUser,
+        updateUser: supabaseMock.updateUser,
+      },
+    });
     supabaseMock.insert.mockResolvedValue({ error: null });
     supabaseMock.from.mockReturnValue({ insert: supabaseMock.insert });
   });
@@ -133,5 +153,76 @@ describe('authService.registerPlayer', () => {
     ).rejects.toThrow('No se pudo crear el usuario. Intentá de nuevo.');
 
     expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+});
+
+describe('authService.changePassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    supabaseMock.signInWithPassword.mockResolvedValue({ data: {}, error: null });
+    supabaseMock.getUser.mockResolvedValue({
+      data: { user: { id: 'user-123', email: 'mateo@example.com' } },
+      error: null,
+    });
+    supabaseMock.updateUser.mockResolvedValue({ data: {}, error: null });
+    supabaseMock.createAnonClient.mockReturnValue({
+      auth: { signInWithPassword: supabaseMock.signInWithPassword },
+    });
+    supabaseMock.createUserClient.mockReturnValue({
+      auth: {
+        getUser: supabaseMock.getUser,
+        updateUser: supabaseMock.updateUser,
+      },
+    });
+  });
+
+  it('verifies the current password and updates the Supabase Auth password', async () => {
+    await authService.changePassword({
+      accessToken: 'token-123',
+      currentPassword: 'Actual123',
+      newPassword: 'Nueva1234',
+    });
+
+    expect(supabaseMock.createUserClient).toHaveBeenCalledWith('token-123');
+    expect(supabaseMock.signInWithPassword).toHaveBeenCalledWith({
+      email: 'mateo@example.com',
+      password: 'Actual123',
+    });
+    expect(supabaseMock.updateUser).toHaveBeenCalledWith({ password: 'Nueva1234' });
+  });
+
+  it('does not update when the current password is invalid', async () => {
+    supabaseMock.signInWithPassword.mockResolvedValueOnce({
+      data: {},
+      error: { message: 'Invalid login credentials' },
+    });
+
+    await expect(
+      authService.changePassword({
+        accessToken: 'token-123',
+        currentPassword: 'Mal12345',
+        newPassword: 'Nueva1234',
+      }),
+    ).rejects.toThrow('Current password is incorrect');
+
+    expect(supabaseMock.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('fails when the access token is invalid', async () => {
+    supabaseMock.getUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: 'JWT expired' },
+    });
+
+    await expect(
+      authService.changePassword({
+        accessToken: 'expired',
+        currentPassword: 'Actual123',
+        newPassword: 'Nueva1234',
+      }),
+    ).rejects.toThrow('Invalid or expired token');
+
+    expect(supabaseMock.signInWithPassword).not.toHaveBeenCalled();
+    expect(supabaseMock.updateUser).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/services/authService.ts
+++ b/apps/backend/src/services/authService.ts
@@ -81,6 +81,12 @@ export interface RegisterPlayerInput {
   password: string;
 }
 
+export interface ChangePasswordInput {
+  accessToken: string;
+  currentPassword: string;
+  newPassword: string;
+}
+
 interface UserProfile {
   role: AuthUserRole;
   displayName: string;
@@ -198,6 +204,46 @@ export const authService = {
 
     if (error) {
       console.warn('[authService.logout] signOut error:', error.message);
+    }
+  },
+
+  /**
+   * Change the authenticated user's password.
+   *
+   * Decision Context:
+   * - Supabase Auth owns password storage; profiles is never touched.
+   * - updateUser({ password }) only needs a valid session, but the product flow asks for
+   *   current password. We verify it with signInWithPassword before updating.
+   * - Uses the existing access token for getUser/updateUser so the mutation is scoped to
+   *   the caller's session.
+   */
+  async changePassword(input: ChangePasswordInput): Promise<void> {
+    const userClient = createUserClient(input.accessToken);
+    const {
+      data: { user },
+      error: userError,
+    } = await userClient.auth.getUser();
+
+    if (userError || !user?.email) {
+      throw new Error('Invalid or expired token');
+    }
+
+    const anonClient = createAnonClient();
+    const { error: verifyError } = await anonClient.auth.signInWithPassword({
+      email: user.email,
+      password: input.currentPassword,
+    });
+
+    if (verifyError) {
+      throw new Error('Current password is incorrect');
+    }
+
+    const { error: updateError } = await userClient.auth.updateUser({
+      password: input.newPassword,
+    });
+
+    if (updateError) {
+      throw new Error(updateError.message || 'Password update failed');
     }
   },
 

--- a/apps/frontend/src/components/settings/ChangePasswordForm.tsx
+++ b/apps/frontend/src/components/settings/ChangePasswordForm.tsx
@@ -1,0 +1,345 @@
+/**
+ * ChangePasswordForm — account security form for /ajustes.
+ *
+ * Decision Context:
+ * - Why React island: password fields need immediate client-side validation, loading
+ *   state, and success/error feedback without a full-page reload.
+ * - The backend verifies currentPassword and calls Supabase Auth updateUser. The frontend
+ *   never stores or logs password values.
+ */
+
+import { Check, KeyRound, Loader2, LockKeyhole, Save, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+interface Props {
+  accessToken: string;
+  backendUrl: string;
+}
+
+interface FieldErrors {
+  currentPassword?: string;
+  newPassword?: string;
+  confirmPassword?: string;
+}
+
+interface ToastState {
+  type: 'success' | 'error';
+  message: string;
+}
+
+const INITIAL_VALUES = {
+  currentPassword: '',
+  newPassword: '',
+  confirmPassword: '',
+};
+
+export default function ChangePasswordForm({ accessToken, backendUrl }: Props) {
+  const [values, setValues] = useState(INITIAL_VALUES);
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const passwordStrength = useMemo(() => {
+    const password = values.newPassword;
+    if (password.length === 0) return { label: 'Sin ingresar', score: 0 };
+    let score = password.length >= 8 ? 1 : 0;
+    if (/[A-Z]/.test(password)) score += 1;
+    if (/[0-9]/.test(password)) score += 1;
+    if (/[^A-Za-z0-9]/.test(password)) score += 1;
+    if (score >= 4) return { label: 'Fuerte', score: 4 };
+    if (score >= 2) return { label: 'Media', score };
+    return { label: 'Básica', score };
+  }, [values.newPassword]);
+
+  function showToast(type: ToastState['type'], message: string) {
+    setToast({ type, message });
+    setTimeout(() => setToast(null), 3500);
+  }
+
+  function updateValue(field: keyof typeof values, value: string) {
+    setValues((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => ({ ...prev, [field]: undefined }));
+  }
+
+  function validate(): FieldErrors {
+    const nextErrors: FieldErrors = {};
+    if (!values.currentPassword) {
+      nextErrors.currentPassword = 'Ingresá tu contraseña actual';
+    }
+    if (values.newPassword.length < 8) {
+      nextErrors.newPassword = 'La nueva contraseña debe tener al menos 8 caracteres';
+    }
+    if (values.currentPassword && values.currentPassword === values.newPassword) {
+      nextErrors.newPassword = 'La nueva contraseña debe ser distinta a la actual';
+    }
+    if (!values.confirmPassword) {
+      nextErrors.confirmPassword = 'Confirmá tu nueva contraseña';
+    } else if (values.newPassword !== values.confirmPassword) {
+      nextErrors.confirmPassword = 'Las contraseñas no coinciden';
+    }
+    return nextErrors;
+  }
+
+  async function handleSubmit(event: { preventDefault: () => void }) {
+    event.preventDefault();
+    const nextErrors = validate();
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+
+    setSaving(true);
+    try {
+      const response = await fetch(`${backendUrl}/api/auth/change-password`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify(values),
+      });
+
+      const payload = (await response.json().catch(() => null)) as
+        | { message?: string; errors?: FieldErrors }
+        | null;
+
+      if (!response.ok) {
+        if (payload?.errors) setErrors(payload.errors);
+        showToast('error', payload?.message ?? 'No pudimos actualizar la contraseña');
+        return;
+      }
+
+      setValues(INITIAL_VALUES);
+      setErrors({});
+      showToast('success', payload?.message ?? 'Contraseña actualizada correctamente');
+    } catch {
+      showToast('error', 'Error de red. Intentá de nuevo.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form className="password-form" onSubmit={handleSubmit} noValidate>
+      {toast && (
+        <div className={`toast toast--${toast.type}`} role="alert" aria-live="polite">
+          {toast.type === 'success'
+            ? <Check size={16} strokeWidth={2.5} aria-hidden="true" />
+            : <X size={16} strokeWidth={2.5} aria-hidden="true" />}
+          <span>{toast.message}</span>
+        </div>
+      )}
+
+      <div className="password-grid">
+        <label className="field">
+          <span className="field-label">Contraseña actual</span>
+          <span className="field-control">
+            <LockKeyhole size={16} strokeWidth={2} aria-hidden="true" />
+            <input
+              type="password"
+              value={values.currentPassword}
+              autoComplete="current-password"
+              onChange={(event) => updateValue('currentPassword', event.target.value)}
+              aria-invalid={!!errors.currentPassword}
+              aria-describedby={errors.currentPassword ? 'current-password-error' : undefined}
+            />
+          </span>
+          {errors.currentPassword && (
+            <span id="current-password-error" className="field-error">{errors.currentPassword}</span>
+          )}
+        </label>
+
+        <label className="field">
+          <span className="field-label">Nueva contraseña</span>
+          <span className="field-control">
+            <KeyRound size={16} strokeWidth={2} aria-hidden="true" />
+            <input
+              type="password"
+              value={values.newPassword}
+              autoComplete="new-password"
+              minLength={8}
+              onChange={(event) => updateValue('newPassword', event.target.value)}
+              aria-invalid={!!errors.newPassword}
+              aria-describedby={errors.newPassword ? 'new-password-error' : 'password-strength'}
+            />
+          </span>
+          <span id="password-strength" className={`strength strength--${passwordStrength.score}`}>
+            Fortaleza: {passwordStrength.label}
+          </span>
+          {errors.newPassword && (
+            <span id="new-password-error" className="field-error">{errors.newPassword}</span>
+          )}
+        </label>
+
+        <label className="field">
+          <span className="field-label">Confirmar nueva contraseña</span>
+          <span className="field-control">
+            <KeyRound size={16} strokeWidth={2} aria-hidden="true" />
+            <input
+              type="password"
+              value={values.confirmPassword}
+              autoComplete="new-password"
+              onChange={(event) => updateValue('confirmPassword', event.target.value)}
+              aria-invalid={!!errors.confirmPassword}
+              aria-describedby={errors.confirmPassword ? 'confirm-password-error' : undefined}
+            />
+          </span>
+          {errors.confirmPassword && (
+            <span id="confirm-password-error" className="field-error">{errors.confirmPassword}</span>
+          )}
+        </label>
+      </div>
+
+      <div className="security-actions">
+        <button type="submit" className="btn-save" disabled={saving} aria-busy={saving}>
+          {saving
+            ? <Loader2 size={16} strokeWidth={2} aria-hidden="true" className="spin" />
+            : <Save size={16} strokeWidth={2} aria-hidden="true" />}
+          {saving ? 'Actualizando...' : 'Actualizar contraseña'}
+        </button>
+      </div>
+
+      <style>{`
+        .password-form {
+          display: flex;
+          flex-direction: column;
+          gap: 1.25rem;
+          background: hsl(220 55% 11%);
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          border-radius: 0.75rem;
+          padding: 1.25rem;
+        }
+
+        .toast {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          padding: 0.75rem 1rem;
+          border-radius: 8px;
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.875rem;
+          font-weight: 500;
+        }
+        .toast--success {
+          background: rgba(34, 197, 94, 0.12);
+          border: 1px solid rgba(34, 197, 94, 0.3);
+          color: hsl(142 71% 65%);
+        }
+        .toast--error {
+          background: rgba(239, 68, 68, 0.12);
+          border: 1px solid rgba(239, 68, 68, 0.3);
+          color: hsl(0 72% 70%);
+        }
+
+        .password-grid {
+          display: grid;
+          gap: 1rem;
+        }
+
+        .field {
+          display: flex;
+          flex-direction: column;
+          gap: 0.4rem;
+        }
+
+        .field-label {
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.78rem;
+          font-weight: 700;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          color: hsl(215 20% 68%);
+        }
+
+        .field-control {
+          min-height: 46px;
+          display: flex;
+          align-items: center;
+          gap: 0.6rem;
+          border-radius: 8px;
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          background: hsl(220 42% 8%);
+          color: hsl(216 85% 68%);
+          padding: 0 0.85rem;
+          transition: border-color 0.15s, background 0.15s;
+        }
+
+        .field-control:focus-within {
+          border-color: hsl(35 100% 48% / 0.65);
+          background: hsl(220 44% 10%);
+        }
+
+        .field-control input {
+          width: 100%;
+          min-width: 0;
+          border: 0;
+          outline: 0;
+          background: transparent;
+          color: hsl(210 20% 92%);
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.95rem;
+        }
+
+        .field-error {
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.8rem;
+          color: hsl(0 72% 70%);
+        }
+
+        .strength {
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.8rem;
+          color: hsl(215 20% 48%);
+        }
+        .strength--2, .strength--3 { color: hsl(44 100% 62%); }
+        .strength--4 { color: hsl(142 71% 65%); }
+
+        .security-actions {
+          display: flex;
+          justify-content: flex-end;
+        }
+
+        .btn-save {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          gap: 0.5rem;
+          min-height: 44px;
+          border: none;
+          border-radius: 8px;
+          background: hsl(35 100% 48%);
+          color: hsl(220 72% 7%);
+          cursor: pointer;
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.875rem;
+          font-weight: 700;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          padding: 0.65rem 1.25rem;
+          transition: background 0.15s, opacity 0.15s;
+        }
+
+        .btn-save:hover:not(:disabled) {
+          background: hsl(35 100% 55%);
+        }
+
+        .btn-save:disabled {
+          cursor: not-allowed;
+          opacity: 0.7;
+        }
+
+        .spin {
+          animation: spin 1s linear infinite;
+        }
+        @keyframes spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+
+        @media (max-width: 480px) {
+          .password-form { padding: 1rem; }
+          .security-actions { display: block; }
+          .btn-save { width: 100%; }
+        }
+      `}</style>
+    </form>
+  );
+}

--- a/apps/frontend/src/pages/ajustes.astro
+++ b/apps/frontend/src/pages/ajustes.astro
@@ -10,15 +10,15 @@
  * - Graceful degradation: if either fetch fails we render the form with safe defaults
  *   (all public) and show an inline notice. The user can still interact with the form.
  * - Nav reuses the same topbar pattern from /perfil for visual consistency.
- * - Currently only the Privacidad section is implemented. Cuenta and Notificaciones
- *   are placeholder tabs — marked TODO for future sprints.
+ * - Privacidad and Seguridad are implemented. Notificaciones remains a placeholder tab.
  * - Previously fixed bugs: none relevant.
  */
 export const prerender = false;
 
-import { Volleyball, Lock, User, Bell } from 'lucide-react';
+import { Volleyball, Lock, ShieldCheck, Bell } from 'lucide-react';
 import Layout from '../layouts/Layout.astro';
 import PrivacySettingsContainer from '@/components/settings/PrivacySettingsContainer';
+import ChangePasswordForm from '@/components/settings/ChangePasswordForm';
 import { ACCESS_TOKEN_COOKIE } from '../lib/auth';
 import {
   GET_MY_SETTINGS,
@@ -143,11 +143,10 @@ if (accessToken) {
             <Lock size={16} strokeWidth={2} aria-hidden="true" />
             Privacidad
           </a>
-          <span class="settings-nav-item settings-nav-item--disabled" aria-disabled="true">
-            <User size={16} strokeWidth={2} aria-hidden="true" />
-            Cuenta
-            <span class="coming-soon">Próximamente</span>
-          </span>
+          <a href="#seguridad" class="settings-nav-item">
+            <ShieldCheck size={16} strokeWidth={2} aria-hidden="true" />
+            Seguridad
+          </a>
           <span class="settings-nav-item settings-nav-item--disabled" aria-disabled="true">
             <Bell size={16} strokeWidth={2} aria-hidden="true" />
             Notificaciones
@@ -172,6 +171,24 @@ if (accessToken) {
               client:load
               initialSettings={settings}
               profile={profile}
+              accessToken={accessToken}
+              backendUrl={backendUrl}
+            />
+          </section>
+
+          <section id="seguridad" class="settings-section">
+            <div class="settings-section-header">
+              <ShieldCheck size={18} strokeWidth={2} aria-hidden="true" className="settings-section-icon" />
+              <div>
+                <h2 class="settings-section-title">Seguridad</h2>
+                <p class="settings-section-sub">
+                  Actualizá tu contraseña usando tu sesión activa
+                </p>
+              </div>
+            </div>
+
+            <ChangePasswordForm
+              client:load
               accessToken={accessToken}
               backendUrl={backendUrl}
             />
@@ -395,6 +412,12 @@ if (accessToken) {
   }
 
   /* ---- Section ---- */
+  .settings-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
   .settings-section-header {
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
Agrega funcionalidad de cambio de contraseña desde Ajustes.

- Suma sección Seguridad en `/ajustes`.
- Agrega formulario con contraseña actual, nueva contraseña y confirmación.
- Valida mínimo 8 caracteres, coincidencia y que la nueva contraseña sea distinta.
- Crea endpoint autenticado `POST /api/auth/change-password`.
- Verifica la contraseña actual con Supabase Auth antes de actualizar.
- Actualiza la contraseña con `supabase.auth.updateUser({ password })`.
- No almacena ni modifica contraseñas en `profiles`.
- Agrega feedback de éxito/error y tests de controller/service.
- Verificado con tests, typecheck y build de backend/frontend.