### PR TITLE
test(e2e): cubrir dashboard de club con Playwright

### DIFF
--- a/apps/testing/scripts/seed.ts
+++ b/apps/testing/scripts/seed.ts
@@ -64,6 +64,22 @@ const OPEN_MATCH_FORMAT = '5v5';
 const OPEN_MATCH_DURATION_MIN = 60;
 const OPEN_MATCH_DAYS_AHEAD = 14;
 
+const CLUB_DASHBOARD_FIXTURE = {
+  clubId: 'b2000000-0000-0000-0000-000000000001',
+  courtId: 'c2000000-0000-0000-0000-000000000001',
+  freeSlotId: 'd2000000-0000-0000-0000-000000000001',
+  matchSlotId: 'd2000000-0000-0000-0000-000000000002',
+  blockedSlotId: 'd2000000-0000-0000-0000-000000000003',
+  matchId: 'e2000000-0000-0000-0000-000000000001',
+  clubName: 'Club Dashboard E2E',
+  courtName: 'Cancha Dashboard 1',
+} as const;
+
+const DASHBOARD_SLOT_DAY = 'saturday';
+const DASHBOARD_FREE_TIME = '10:00';
+const DASHBOARD_MATCH_TIME = '11:00';
+const DASHBOARD_BLOCKED_TIME = '12:00';
+
 function requiredEnv(name: string): string {
   const value = process.env[name];
   if (!value || value.trim() === '') {
@@ -80,6 +96,57 @@ function buildAdminClient(): SupabaseClient {
   return createClient(url, serviceKey, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
+}
+
+function buildUserClient(accessToken: string): SupabaseClient {
+  const url = requiredEnv('SUPABASE_URL');
+  const anonKey = requiredEnv('SUPABASE_ANON_KEY');
+  return createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+}
+
+function addDaysUTC(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function currentWeekSaturday(): Date {
+  const now = new Date();
+  const day = now.getUTCDay(); // 0=Sunday
+  const monday = addDaysUTC(now, -((day + 6) % 7));
+  return addDaysUTC(monday, 5);
+}
+
+function scheduledAtForDashboardMatch(): string {
+  const saturday = currentWeekSaturday();
+  return new Date(Date.UTC(
+    saturday.getUTCFullYear(),
+    saturday.getUTCMonth(),
+    saturday.getUTCDate(),
+    14,
+    0,
+    0,
+  )).toISOString();
+}
+
+async function signInTestClubAdmin(): Promise<{ ownerId: string; accessToken: string }> {
+  const email = process.env.TEST_CLUB_EMAIL ?? 'frantestsumateya@gmail.com';
+  const password = process.env.TEST_CLUB_PASSWORD ?? 'aaaa1234';
+  const authClient = createClient(requiredEnv('SUPABASE_URL'), requiredEnv('SUPABASE_ANON_KEY'), {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const { data, error } = await authClient.auth.signInWithPassword({ email, password });
+
+  if (error || !data.user || !data.session) {
+    throw new Error(
+      `[seed] No se pudo autenticar el club_admin de testing (${email}): ${error?.message ?? 'sin usuario/sesion'}`,
+    );
+  }
+
+  return { ownerId: data.user.id, accessToken: data.session.access_token };
 }
 
 async function ensureMatchExists(client: SupabaseClient): Promise<void> {
@@ -298,6 +365,269 @@ async function ensureTestUserNotInOpenMatch(client: SupabaseClient): Promise<voi
     throw new Error(
       `[seed] No se pudo limpiar la inscripcion del usuario de prueba en E2: ${error.message}`,
     );
+  }
+}
+
+async function ensureClubAdminProfile(client: SupabaseClient, ownerId: string): Promise<void> {
+  const { data: profile, error: selectError } = await client
+    .from('profiles')
+    .select('id, role')
+    .eq('id', ownerId)
+    .maybeSingle();
+  if (selectError) {
+    throw new Error(`[seed] Error consultando perfil club_admin: ${selectError.message}`);
+  }
+
+  if (!profile) {
+    const { error: insertError } = await client.from('profiles').insert({
+      id: ownerId,
+      displayName: 'Admin Club E2E',
+      role: 'club_admin',
+      division: 1,
+      matchesPlayed: 0,
+      matchesWon: 0,
+    });
+    if (insertError) {
+      throw new Error(`[seed] No se pudo crear perfil club_admin: ${insertError.message}`);
+    }
+    return;
+  }
+
+  if (profile.role !== 'club_admin') {
+    const { error: updateError } = await client
+      .from('profiles')
+      .update({ role: 'club_admin' })
+      .eq('id', ownerId);
+    if (updateError) {
+      throw new Error(`[seed] No se pudo ajustar rol club_admin: ${updateError.message}`);
+    }
+  }
+}
+
+async function ensureDashboardClub(client: SupabaseClient, ownerId: string): Promise<string> {
+  const { data: existing, error: selectError } = await client
+    .from('clubs')
+    .select('id')
+    .eq('ownerId', ownerId)
+    .order('createdAt', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (selectError) {
+    throw new Error(`[seed] Error consultando club del admin E2E: ${selectError.message}`);
+  }
+
+  const payload = {
+    ownerId,
+    name: CLUB_DASHBOARD_FIXTURE.clubName,
+    address: 'Av. Dashboard 1234',
+    zone: 'E2E',
+    lat: -34.9011,
+    lng: -56.1645,
+    phone: '+598 99 123 456',
+    description: 'Club seed para tests E2E de dashboard.',
+  };
+
+  if (existing) {
+    const { error: updateError } = await client
+      .from('clubs')
+      .update(payload)
+      .eq('id', existing.id);
+    if (updateError) {
+      throw new Error(`[seed] No se pudo ajustar club dashboard: ${updateError.message}`);
+    }
+    return existing.id as string;
+  }
+
+  const { error: insertError } = await client
+    .from('clubs')
+    .insert({ id: CLUB_DASHBOARD_FIXTURE.clubId, ...payload });
+  if (insertError) {
+    throw new Error(`[seed] No se pudo crear club dashboard: ${insertError.message}`);
+  }
+
+  return CLUB_DASHBOARD_FIXTURE.clubId;
+}
+
+async function ensureDashboardCourt(client: SupabaseClient, clubId: string): Promise<string> {
+  const { data: existing, error: selectError } = await client
+    .from('courts')
+    .select('id')
+    .eq('clubId', clubId)
+    .eq('name', CLUB_DASHBOARD_FIXTURE.courtName)
+    .maybeSingle();
+  if (selectError) {
+    throw new Error(`[seed] Error consultando cancha dashboard: ${selectError.message}`);
+  }
+
+  const payload = {
+    clubId,
+    name: CLUB_DASHBOARD_FIXTURE.courtName,
+    surface: 'synthetic',
+    isIndoor: false,
+    maxFormat: '5v5',
+  };
+
+  if (existing) {
+    const { error: updateError } = await client
+      .from('courts')
+      .update(payload)
+      .eq('id', existing.id);
+    if (updateError) {
+      throw new Error(`[seed] No se pudo ajustar cancha dashboard: ${updateError.message}`);
+    }
+    return existing.id as string;
+  }
+
+  // Some shared cloud DBs already provision a court for the club_admin account
+  // but do not allow direct court INSERT through the testing key. Reuse that
+  // court so the dashboard seed can stay idempotent without needing schema
+  // admin privileges.
+  const { data: reusable, error: reusableError } = await client
+    .from('courts')
+    .select('id')
+    .eq('clubId', clubId)
+    .order('createdAt', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (reusableError) {
+    throw new Error(`[seed] Error buscando cancha reutilizable dashboard: ${reusableError.message}`);
+  }
+  if (reusable) {
+    return reusable.id as string;
+  }
+
+  const { error: insertError } = await client
+    .from('courts')
+    .insert({ id: CLUB_DASHBOARD_FIXTURE.courtId, ...payload });
+  if (insertError) {
+    throw new Error(`[seed] No se pudo crear cancha dashboard: ${insertError.message}`);
+  }
+
+  return CLUB_DASHBOARD_FIXTURE.courtId;
+}
+
+async function ensureDashboardSlot(
+  client: SupabaseClient,
+  input: {
+    id: string;
+    clubId: string;
+    courtId: string;
+    startTime: string;
+    isBlocked: boolean;
+    blockReason: string | null;
+    blockType: string | null;
+    priceArs: number;
+  },
+): Promise<string> {
+  const { data: existing, error: selectError } = await client
+    .from('clubSlots')
+    .select('id')
+    .eq('courtId', input.courtId)
+    .eq('dayOfWeek', DASHBOARD_SLOT_DAY)
+    .eq('startTime', input.startTime)
+    .maybeSingle();
+  if (selectError) {
+    throw new Error(`[seed] Error consultando slot dashboard: ${selectError.message}`);
+  }
+
+  const payload = {
+    clubId: input.clubId,
+    courtId: input.courtId,
+    dayOfWeek: DASHBOARD_SLOT_DAY,
+    startTime: input.startTime,
+    endTime: `${String(Number(input.startTime.slice(0, 2)) + 1).padStart(2, '0')}:00`,
+    duration: 60,
+    priceArs: input.priceArs,
+    isBlocked: input.isBlocked,
+    blockReason: input.blockReason,
+    blockType: input.blockType,
+    isActive: true,
+    allowOnlineBooking: true,
+  };
+
+  if (existing) {
+    const { error: updateError } = await client
+      .from('clubSlots')
+      .update(payload)
+      .eq('id', existing.id);
+    if (updateError) {
+      throw new Error(`[seed] No se pudo ajustar slot dashboard: ${updateError.message}`);
+    }
+    return existing.id as string;
+  }
+
+  const { error: insertError } = await client
+    .from('clubSlots')
+    .insert({ id: input.id, ...payload });
+  if (insertError) {
+    throw new Error(`[seed] No se pudo crear slot dashboard: ${insertError.message}`);
+  }
+
+  return input.id;
+}
+
+async function seedClubDashboard(client: SupabaseClient): Promise<void> {
+  const { ownerId, accessToken } = await signInTestClubAdmin();
+  const clubAdminClient = buildUserClient(accessToken);
+  await ensureClubAdminProfile(client, ownerId);
+  const clubId = await ensureDashboardClub(client, ownerId);
+  const courtId = await ensureDashboardCourt(client, clubId);
+
+  await ensureDashboardSlot(client, {
+    id: CLUB_DASHBOARD_FIXTURE.freeSlotId,
+    clubId,
+    courtId,
+    startTime: DASHBOARD_FREE_TIME,
+    isBlocked: false,
+    blockReason: null,
+    blockType: null,
+    priceArs: 24000,
+  });
+
+  const matchSlotId = await ensureDashboardSlot(client, {
+    id: CLUB_DASHBOARD_FIXTURE.matchSlotId,
+    clubId,
+    courtId,
+    startTime: DASHBOARD_MATCH_TIME,
+    isBlocked: false,
+    blockReason: null,
+    blockType: null,
+    priceArs: 30000,
+  });
+
+  await ensureDashboardSlot(client, {
+    id: CLUB_DASHBOARD_FIXTURE.blockedSlotId,
+    clubId,
+    courtId,
+    startTime: DASHBOARD_BLOCKED_TIME,
+    isBlocked: true,
+    blockReason: 'Mantenimiento E2E',
+    blockType: 'maintenance',
+    priceArs: 26000,
+  });
+
+  const { error: matchError } = await clubAdminClient.from('matches').upsert(
+    {
+      id: CLUB_DASHBOARD_FIXTURE.matchId,
+      organizerId: ownerId,
+      clubId,
+      courtId,
+      clubSlotId: matchSlotId,
+      format: '5v5',
+      capacity: 10,
+      scheduledAt: scheduledAtForDashboardMatch(),
+      durationMin: 60,
+      status: 'open',
+      description: 'Partido dashboard E2E',
+      resultStatus: 'pending',
+      winningTeam: null,
+      scoreTeamA: null,
+      scoreTeamB: null,
+    },
+    { onConflict: 'id' },
+  );
+  if (matchError) {
+    throw new Error(`[seed] No se pudo crear/actualizar partido dashboard: ${matchError.message}`);
   }
 }
 
@@ -536,10 +866,11 @@ async function seed(): Promise<void> {
   await ensureMatchFullWithTestUser(client);
   await ensureOpenMatchExists(client);
   await ensureTestUserNotInOpenMatch(client);
+  await seedClubDashboard(client);
   await seedTournaments(client);
   // eslint-disable-next-line no-console
   console.log(
-    '[seed] Fixtures listas: E1 lleno, E2 abierto, T1 torneo abierto, T2 torneo con capitan.',
+    '[seed] Fixtures listas: E1 lleno, E2 abierto, dashboard club, T1 torneo abierto, T2 torneo con capitan.',
   );
 }
 

--- a/apps/testing/tests/club-dashboard.spec.ts
+++ b/apps/testing/tests/club-dashboard.spec.ts
@@ -1,0 +1,175 @@
+import type { Browser, Page, Request } from '@playwright/test';
+import {
+  CLUB_DASHBOARD_URL,
+  expect,
+  FRONTEND_URL,
+  SEED_CLUB_DASHBOARD,
+  test,
+  TEST_USERS,
+} from './support';
+
+/**
+ * Tests E2E del dashboard de club (/panel-club/dashboard).
+ *
+ * Decision Context:
+ * - La historia pedía /club/dashboard, pero la pantalla existente del producto
+ *   vive en /panel-club/dashboard y está protegida por el middleware de rol.
+ * - La primera carga hace fetch SSR contra GraphQL; Playwright no puede mockear
+ *   ese request desde el browser. Por eso usamos el seed idempotente para dejar
+ *   un club, una cancha y tres estados de slot determinísticos.
+ */
+
+function emptyStorageState() {
+  return { cookies: [], origins: [] };
+}
+
+async function openDashboardAs(
+  browser: Browser,
+  storageState: string | ReturnType<typeof emptyStorageState>,
+): Promise<Page> {
+  const context = await browser.newContext({ storageState });
+  const page = await context.newPage();
+  return page;
+}
+
+function isDashboardRefetch(req: Request): boolean {
+  const body = req.postData() ?? '';
+  return req.method() === 'POST'
+    && req.url().includes('/api/graphql')
+    && body.includes('CLUB_DASHBOARD');
+}
+
+test.describe('Dashboard de club (/panel-club/dashboard)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('redirige al login si no hay sesion autenticada', async ({ browser }) => {
+    const page = await openDashboardAs(browser, emptyStorageState());
+    try {
+      await page.goto(CLUB_DASHBOARD_URL);
+      await expect(page).toHaveURL(`${FRONTEND_URL}/login`);
+    } finally {
+      await page.context().close();
+    }
+  });
+
+  test('bloquea el acceso a jugadores y los redirige a /partidos', async ({ browser }) => {
+    const page = await openDashboardAs(browser, TEST_USERS.playerMateo.storageStatePath);
+    try {
+      await page.goto(CLUB_DASHBOARD_URL);
+      await expect(page).toHaveURL(`${FRONTEND_URL}/partidos`);
+    } finally {
+      await page.context().close();
+    }
+  });
+
+  test.describe('como club_admin', () => {
+    test.use({ storageState: TEST_USERS.clubAdmin.storageStatePath });
+
+    test('muestra la vista semanal con slots libres, ocupados y bloqueados', async ({
+      clubDashboardPage,
+      page,
+    }) => {
+      await clubDashboardPage.goto();
+
+      await expect(page.getByRole('heading', { name: SEED_CLUB_DASHBOARD.clubName })).toBeVisible();
+      await expect(page.getByText(/partidos esta semana/i).first()).toBeVisible();
+      await expect(page.getByText(/ocupaci/i).first()).toBeVisible();
+      await expect(page.getByText(/canchas activas/i).first()).toBeVisible();
+
+      await expect(page.getByText('Libre').first()).toBeVisible();
+      await expect(page.getByText('Partido abierto').first()).toBeVisible();
+      await expect(page.getByText('Bloqueado').first()).toBeVisible();
+
+      await expect(
+        clubDashboardPage.slotCell(SEED_CLUB_DASHBOARD.freeSlotTime, 'AVAILABLE'),
+      ).toBeVisible();
+      await expect(
+        clubDashboardPage.slotCell(SEED_CLUB_DASHBOARD.matchSlotTime, 'MATCH_OPEN'),
+      ).toBeVisible();
+      await expect(
+        clubDashboardPage.slotCell(SEED_CLUB_DASHBOARD.blockedSlotTime, 'BLOCKED'),
+      ).toBeVisible();
+    });
+
+    test('permite inspeccionar un slot libre y un slot bloqueado desde el calendario', async ({
+      clubDashboardPage,
+      page,
+    }) => {
+      await clubDashboardPage.goto();
+
+      await clubDashboardPage.slotCell(SEED_CLUB_DASHBOARD.freeSlotTime, 'AVAILABLE').click();
+      await expect(page.getByText(/horario libre/i)).toBeVisible();
+      await expect(page.getByText(/cancha/i).first()).toBeVisible();
+      await expect(page.getByRole('link', { name: /crear partido aqu/i })).toHaveAttribute(
+        'href',
+        /action=create/,
+      );
+      await expect(page.getByRole('link', { name: /bloquear horario/i })).toHaveAttribute(
+        'href',
+        /action=block/,
+      );
+      await page.getByRole('button', { name: /cerrar/i }).click();
+
+      await clubDashboardPage.slotCell(SEED_CLUB_DASHBOARD.blockedSlotTime, 'BLOCKED').click();
+      const blockedPanel = page.locator('.slot-panel');
+      await expect(blockedPanel.getByText(/^bloqueado$/i)).toBeVisible();
+      await expect(blockedPanel.getByText(SEED_CLUB_DASHBOARD.blockedReason)).toBeVisible();
+      await expect(blockedPanel.getByRole('link', { name: /desbloquear en horarios/i })).toHaveAttribute(
+        'href',
+        /action=unblock/,
+      );
+    });
+
+    test('abre el detalle del partido con cancha, formato, cupos y organizador', async ({
+      clubDashboardPage,
+      page,
+    }) => {
+      await clubDashboardPage.goto();
+
+      await clubDashboardPage.slotCell(SEED_CLUB_DASHBOARD.matchSlotTime, 'MATCH_OPEN').click();
+
+      const dialog = page.getByRole('dialog', { name: /detalle del partido/i });
+      await expect(dialog).toBeVisible();
+      await expect(dialog.getByText('5 vs 5')).toBeVisible();
+      await expect(dialog.getByText(/abierto/i)).toBeVisible();
+      await expect(dialog.getByText(/cancha/i).first()).toBeVisible();
+      await expect(dialog.getByText(/\d+ \/ 10 jugadores/i)).toBeVisible();
+      await expect(dialog.getByText(/organizador/i)).toBeVisible();
+      await expect(dialog.getByRole('link', { name: /ver perfil del organizador/i })).toBeVisible();
+    });
+
+    test('muestra la agenda semanal y refetchea GraphQL con filtros de fecha', async ({
+      clubDashboardPage,
+      page,
+    }) => {
+      await clubDashboardPage.goto();
+
+      await clubDashboardPage.agendaViewButton.click();
+      await expect(clubDashboardPage.agendaMatchCell()).toBeVisible();
+      await expect(page.getByText('5 vs 5').first()).toBeVisible();
+      await expect(page.getByText(/\d+\/10/).first()).toBeVisible();
+
+      const requestPromise = page.waitForRequest(isDashboardRefetch);
+      await clubDashboardPage.nextWeekButton.click();
+      const request = await requestPromise;
+      const payload = JSON.parse(request.postData() ?? '{}') as {
+        variables?: {
+          filters?: {
+            startDate?: string;
+            endDate?: string;
+            includeBlocked?: boolean;
+            includeInactive?: boolean;
+          };
+        };
+      };
+
+      expect(payload.variables?.filters).toMatchObject({
+        includeBlocked: true,
+        includeInactive: false,
+      });
+      expect(payload.variables?.filters?.startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(payload.variables?.filters?.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      await clubDashboardPage.waitForRefetchSettled();
+    });
+  });
+});

--- a/apps/testing/tests/support/constants.ts
+++ b/apps/testing/tests/support/constants.ts
@@ -37,6 +37,7 @@ export const GRAPHQL_AUTH_ROUTE = '**/api/graphql-auth**';
 
 export const TORNEOS_URL = `${FRONTEND_URL}/torneos`;
 export const TORNEOS_CREAR_URL = `${FRONTEND_URL}/torneos/crear`;
+export const CLUB_DASHBOARD_URL = `${FRONTEND_URL}/panel-club/dashboard`;
 
 /** Returns the detail URL for a given tournament ID. */
 export function torneoDetailUrl(id: string): string {
@@ -74,4 +75,19 @@ export const SEED_TOURNAMENTS = {
    * was found not to exist in the dev DB (see seed.ts Decision Context).
    */
   withCaptainMateo: 'c0000000-0000-0000-0000-000000000002',
+} as const;
+
+/**
+ * Club dashboard fixtures guaranteed by `apps/testing/scripts/seed.ts`.
+ *
+ * The dashboard is SSR, so these tests use real DB rows instead of Playwright
+ * route mocks for the first load.
+ */
+export const SEED_CLUB_DASHBOARD = {
+  clubName: 'Club Dashboard E2E',
+  courtName: 'Cancha Dashboard 1',
+  freeSlotTime: '10:00',
+  matchSlotTime: '11:00',
+  blockedSlotTime: '12:00',
+  blockedReason: 'Mantenimiento E2E',
 } as const;

--- a/apps/testing/tests/support/fixtures.ts
+++ b/apps/testing/tests/support/fixtures.ts
@@ -1,6 +1,7 @@
 import { test as base } from '@playwright/test';
 import { CreateMatchPage } from './page-objects/CreateMatchPage';
 import { CreateTournamentPage } from './page-objects/CreateTournamentPage';
+import { ClubDashboardPage } from './page-objects/ClubDashboardPage';
 import { HomePage } from './page-objects/HomePage';
 import { LoginPage } from './page-objects/LoginPage';
 import { MatchDetailPage } from './page-objects/MatchDetailPage';
@@ -42,6 +43,7 @@ type Fixtures = {
   matchDetailPage: MatchDetailPage;
   createMatchPage: CreateMatchPage;
   createTournamentPage: CreateTournamentPage;
+  clubDashboardPage: ClubDashboardPage;
   profilePage: ProfilePage;
   settingsPage: SettingsPage;
   /** Open-registration tournament (no teams). For inscription tests (US #39). */
@@ -77,6 +79,9 @@ export const test = base.extend<Fixtures>({
   },
   createTournamentPage: async ({ page }, use) => {
     await use(new CreateTournamentPage(page));
+  },
+  clubDashboardPage: async ({ page }, use) => {
+    await use(new ClubDashboardPage(page));
   },
   profilePage: async ({ page }, use) => {
     await use(new ProfilePage(page));

--- a/apps/testing/tests/support/index.ts
+++ b/apps/testing/tests/support/index.ts
@@ -18,6 +18,7 @@ export * from './builders';
 export * from './divisions';
 export { CreateMatchPage } from './page-objects/CreateMatchPage';
 export { CreateTournamentPage } from './page-objects/CreateTournamentPage';
+export { ClubDashboardPage } from './page-objects/ClubDashboardPage';
 export { HomePage } from './page-objects/HomePage';
 export { LoginPage } from './page-objects/LoginPage';
 export { MatchDetailPage } from './page-objects/MatchDetailPage';

--- a/apps/testing/tests/support/page-objects/ClubDashboardPage.ts
+++ b/apps/testing/tests/support/page-objects/ClubDashboardPage.ts
@@ -1,0 +1,70 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { CLUB_DASHBOARD_URL } from '../constants';
+
+/**
+ * Page Object for /panel-club/dashboard.
+ *
+ * Decision Context:
+ * - The page SSR-prefetches dashboard data, then hydrates a React island for
+ *   week navigation, filters and modals. goto() waits for both the SSR shell
+ *   and the island hydration marker before tests click calendar cells.
+ * - Cell locators use CalendarGrid's accessible aria-labels instead of CSS
+ *   color classes, so the E2E contract remains user-facing: a slot is free,
+ *   occupied by a match, or blocked.
+ */
+export class ClubDashboardPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly root: Locator;
+  readonly calendarViewButton: Locator;
+  readonly agendaViewButton: Locator;
+  readonly previousWeekButton: Locator;
+  readonly nextWeekButton: Locator;
+  readonly loadingBar: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole('heading', { name: /^dashboard$/i });
+    this.root = page.locator('.dash-view');
+    this.calendarViewButton = page.getByRole('button', { name: /vista calendario/i });
+    this.agendaViewButton = page.getByRole('button', { name: /vista agenda/i });
+    this.previousWeekButton = page.getByRole('button', { name: /semana anterior/i });
+    this.nextWeekButton = page.getByRole('button', { name: /semana siguiente/i });
+    this.loadingBar = page.getByLabel(/cargando dashboard/i);
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto(CLUB_DASHBOARD_URL);
+    await expect(this.heading).toBeVisible();
+    await this.waitForIslandsHydrated();
+    await expect(this.root).toBeVisible();
+    await expect(this.calendarViewButton).toBeVisible();
+  }
+
+  /** Astro stamps `client-render-time` on a client island after hydration. */
+  async waitForIslandsHydrated(): Promise<void> {
+    await this.page.waitForFunction(
+      () => {
+        const islands = Array.from(document.querySelectorAll('astro-island[client="load"]'));
+        if (islands.length === 0) return true;
+        return islands.every((island) => island.hasAttribute('client-render-time'));
+      },
+      { timeout: 10_000 },
+    );
+  }
+
+  async waitForRefetchSettled(): Promise<void> {
+    await expect(this.loadingBar).toHaveCount(0);
+  }
+
+  slotCell(time: string, status: string): Locator {
+    const safeStatus = status.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return this.page.getByRole('button', {
+      name: new RegExp(`saturday\\s+${time}.*${safeStatus}`, 'i'),
+    });
+  }
+
+  agendaMatchCell(): Locator {
+    return this.page.getByRole('button', { name: /cancha .*abierto/i });
+  }
+}


### PR DESCRIPTION
Agrega cobertura E2E con Playwright para el dashboard de club en `/panel-club/dashboard`.

Se incorporan tests para validar:
- acceso restringido: usuarios sin sesión son redirigidos a `/login`
- acceso por rol: usuarios jugador no pueden entrar y son redirigidos a `/partidos`
- vista semanal del club admin con slots libres, ocupados y bloqueados
- inspección de slot libre con acciones para crear partido o bloquear horario
- inspección de slot bloqueado con motivo y acción para desbloquear
- apertura del detalle de partido mostrando cancha, formato, cupos y organizador
- vista de agenda semanal
- refetch GraphQL del dashboard con filtros de fecha al cambiar de semana

También se agrega el Page Object `ClubDashboardPage` y se exponen fixtures/constantes compartidas para mantener los specs legibles y reutilizables.

El seed E2E ahora prepara datos determinísticos para el dashboard de club: club de testing, slots de sábado para estados libre/ocupado/bloqueado y un partido asociado al slot ocupado. Esto evita depender del estado manual de la DB y permite correr la suite sin skips.

Validación realizada:
- Comando ejecutado desde `apps/testing`:
  `$env:NODE_PATH='..\..\node_modules\.pnpm\node_modules'; .\node_modules\.bin\playwright.cmd test tests/club-dashboard.spec.ts --project=chrome`
- Se corrió 3 veces seguidas
- Resultado: `9 passed` en las 3 corridas
- Para ver el reporte HTML desde `apps/testing`:
  `.\node_modules\.bin\playwright.cmd show-report`