### PR TITLE
fix(horarios): mover precio del slot para evitar overlap con nombre d…

### DIFF
--- a/apps/frontend/src/components/club/SlotCalendarView.tsx
+++ b/apps/frontend/src/components/club/SlotCalendarView.tsx
@@ -19,6 +19,13 @@
  *     Fix: isPastDay check on the whole date, applied before slot-status classes.
  *   - Today's future hours weren't visible at full color because past-hour opacity was
  *     applied to ALL of today. Fix: only dim hours where isToday && hour < nowHour.
+ *   - `.slot-price` and `.cal-court-label` both lived in the bottom-left corner of the
+ *     cell after the CalendarGrid extraction (the shared label was added without moving
+ *     the existing price), so prices like "$26000" overlapped court names like
+ *     "Cancha 1". Fix: relocate `.slot-price` to the top-left corner with the smaller
+ *     font + green color used by AvailableSlotsPicker's `.pk-price`, and hide it on
+ *     match-status slots (same rule as the Crear Partido picker, since an occupied
+ *     slot isn't bookable so the price has no actionable value there).
  */
 
 import { useState, useMemo } from 'react';
@@ -107,7 +114,7 @@ export function SlotCalendarView({ slots, selectedIds, onToggleSelect, onEdit }:
           onClick={(e) => { e.stopPropagation(); onToggleSelect(primary.id); }}
           onChange={() => {}}
         />
-        {primary.priceArs != null && (
+        {primary.priceArs != null && status !== 'match' && (
           <span className="slot-price">${primary.priceArs}</span>
         )}
         {status === 'blocked' && (
@@ -198,10 +205,16 @@ export function SlotCalendarView({ slots, selectedIds, onToggleSelect, onEdit }:
           position: absolute; top: 3px; right: 3px;
           width: 11px; height: 11px; accent-color: hsl(var(--primary)); cursor: pointer;
         }
+        /* Top-left corner. Previously was bottom-left which overlapped with
+           .cal-court-label (also bottom-left after the shared-grid refactor).
+           Mirrors AvailableSlotsPicker's .pk-price corner + color so both
+           calendars match the epic #110 criterion ("Se ve igual que calendario
+           Crear Partido"). Hidden when status === 'match' (consistent with the
+           Crear Partido picker which hides price for occupied slots). */
         .slot-price {
-          position: absolute; bottom: 2px; left: 4px;
-          font-family: 'Barlow Condensed', sans-serif; font-size: 0.68rem; font-weight: 700;
-          color: hsl(var(--muted-foreground));
+          position: absolute; top: 3px; left: 4px;
+          font-family: 'Barlow Condensed', sans-serif; font-size: 0.62rem; font-weight: 700;
+          color: hsl(142 70% 55%);
         }
         .slot-icon {
           position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%);

--- a/apps/testing/tests/horarios-calendar-overlap.spec.ts
+++ b/apps/testing/tests/horarios-calendar-overlap.spec.ts
@@ -1,0 +1,195 @@
+import {
+  expect,
+  FRONTEND_URL,
+  test,
+  TEST_USERS,
+} from './support';
+
+/**
+ * Regression e2e — fix visual overlap del calendario en /panel-club/horarios.
+ *
+ * Decision Context:
+ * - Por qué SSR-friendly + sin mocks: la query `MY_CLUB_SLOTS_SSR` se ejecuta
+ *   en el frontmatter de `apps/frontend/src/pages/panel-club/horarios.astro`
+ *   (server-side, POST directo al backend `:4000/graphql` con la cookie
+ *   HttpOnly). Ese request nunca pasa por el browser, así que `page.route()`
+ *   NO puede interceptarlo. Por eso este spec se apoya 100% en la seed real
+ *   (`apps/testing/scripts/seed.ts` → `seedClubDashboard`), que crea, para el
+ *   club_admin de testing (`TEST_USERS.clubAdmin`), tres slots los sábados:
+ *     · 10:00 → `available`, priceArs=24000  (precio debe verse, no solapar)
+ *     · 11:00 → `match`,     priceArs=30000  (precio NO debe renderizarse)
+ *     · 12:00 → `blocked`,   priceArs=26000  (precio debe verse)
+ * - Por qué selectores crudos (`.slot-price`, `.cal-court-label`,
+ *   `.cal-cell--match-open`): el bug VIVE en esas clases concretas (posición
+ *   absoluta dentro de la celda) y el contrato del fix se expresa
+ *   exactamente sobre ellas. Un Page Object dedicado a 2-3 aserciones de
+ *   layout sería over-engineering. La regla #2 del e2e-testing rulebook
+ *   (POs dueños de selectores) no aplica acá porque no hay un PO existente
+ *   para SlotManager / SlotCalendarView, y el spec entero son 3 casos cortos
+ *   sobre clases CSS que son las que el fix protege.
+ * - Por qué buscamos cell-por-cell en vez de hardcodear `getByRole('button',
+ *   { name: /saturday 10:00/i })`: si el día actual ya pasó el sábado, la
+ *   primera semana renderizada por SlotCalendarView usa el lunes-de-hoy como
+ *   inicio y el sábado de la semana corriente puede ser un "past day"
+ *   (que la lógica de `renderCell` pinta con clase `cal-cell--past-day-*`
+ *   y NO renderiza el contenido normal con `.slot-price` / `.cal-court-label`).
+ *   Iterar las celdas visibles del calendario es robusto frente a esa
+ *   variación: si la seed no produjo una celda elegible en la semana actual,
+ *   skipeamos con un mensaje claro en vez de fallar falsamente.
+ *
+ * - Bug previo que este test protege contra regresiones:
+ *     `.slot-price` (bottom:2px;left:4px) y `.cal-court-label`
+ *     (bottom:4px;left:5px) compartían la esquina inferior-izquierda de la
+ *     celda, así que el precio (ej. "$26000") se solapaba con el nombre de
+ *     la cancha (ej. "Cancha Dashboard 1"). El fix mueve `.slot-price` a la
+ *     esquina superior-izquierda (top:3px;left:4px) con la tipografía/color
+ *     verde de `AvailableSlotsPicker .pk-price`, y oculta el precio cuando
+ *     `status === 'match'` (mismo criterio que el picker de "Crear Partido").
+ *     Cualquier regresión que vuelva a poner el precio en la mitad inferior
+ *     de la celda, o que lo muestre en slots ocupados, hará fallar este spec.
+ */
+
+test.use({ storageState: TEST_USERS.clubAdmin.storageStatePath });
+
+const HORARIOS_URL = `${FRONTEND_URL}/panel-club/horarios`;
+
+/**
+ * Espera a que los islands `client="load"` terminen de hidratar.
+ * SlotManager hidrata con `client:load`, así que cuando este marker se
+ * estampa en el `<astro-island>` ya tenemos el calendario interactivo.
+ * (Patrón reutilizado de ClubDashboardPage.waitForIslandsHydrated.)
+ */
+async function waitForIslandsHydrated(page: import('@playwright/test').Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const islands = Array.from(document.querySelectorAll('astro-island[client="load"]'));
+      if (islands.length === 0) return true;
+      return islands.every((island) => island.hasAttribute('client-render-time'));
+    },
+    { timeout: 10_000 },
+  );
+}
+
+type Box = { x: number; y: number; width: number; height: number };
+
+function isOverlap(a: Box, b: Box): boolean {
+  // Dos cajas axis-aligned NO se solapan si una está completamente a un lado
+  // de la otra en cualquier eje. Negamos para detectar solapamiento real.
+  const aRight = a.x + a.width;
+  const aBottom = a.y + a.height;
+  const bRight = b.x + b.width;
+  const bBottom = b.y + b.height;
+  return !(aRight <= b.x || bRight <= a.x || aBottom <= b.y || bBottom <= a.y);
+}
+
+test.describe('Calendario /panel-club/horarios — fix visual overlap precio/cancha', () => {
+  test('precio y nombre de cancha no se solapan en celdas con ambos visibles', async ({ page }) => {
+    await page.goto(HORARIOS_URL);
+    await waitForIslandsHydrated(page);
+    await expect(page.getByRole('heading', { name: /^horarios$/i })).toBeVisible();
+
+    // Aseguramos vista calendario (default, pero hacemos el click idempotente
+    // por si una corrida anterior dejó "Lista" activo via state cacheado).
+    const calendarBtn = page.getByRole('button', { name: /vista calendario|calendario/i }).first();
+    if (await calendarBtn.isVisible().catch(() => false)) {
+      await calendarBtn.click().catch(() => {});
+    }
+
+    // Limitamos la búsqueda al cuerpo del calendario (no afecta el header).
+    const calendarBody = page.locator('.cal-wrap .cal-body');
+    await expect(calendarBody).toBeVisible();
+
+    const cells = calendarBody.locator('.cal-cell');
+    const totalCells = await cells.count();
+    expect.soft(totalCells, 'el grid del calendario debería tener celdas renderizadas').toBeGreaterThan(0);
+
+    // Buscamos la primera celda que tenga AMBOS `.slot-price` y
+    // `.cal-court-label` visibles. La seed garantiza un slot disponible los
+    // sábados a las 10:00 con priceArs=24000 (que post-fix renderiza precio
+    // porque status !== 'match'). Si por past-day esa celda no es elegible
+    // en la semana actual, también sirve el slot bloqueado de las 12:00
+    // sábado (priceArs=26000), que también renderiza precio.
+    let matchedCellHandle: import('@playwright/test').ElementHandle<Element> | null = null;
+    let priceBox: Box | null = null;
+    let labelBox: Box | null = null;
+    let cellBox: Box | null = null;
+
+    for (let i = 0; i < totalCells; i += 1) {
+      const cell = cells.nth(i);
+      const price = cell.locator('.slot-price');
+      const label = cell.locator('.cal-court-label');
+      const priceCount = await price.count();
+      const labelCount = await label.count();
+      if (priceCount === 0 || labelCount === 0) continue;
+
+      const pBox = await price.boundingBox();
+      const lBox = await label.boundingBox();
+      const cBox = await cell.boundingBox();
+      if (!pBox || !lBox || !cBox) continue;
+
+      matchedCellHandle = await cell.elementHandle();
+      priceBox = pBox;
+      labelBox = lBox;
+      cellBox = cBox;
+      break;
+    }
+
+    test.skip(
+      matchedCellHandle === null,
+      'No se encontró ninguna celda con `.slot-price` + `.cal-court-label` visibles en la semana actual. ' +
+        'La seed (`seedClubDashboard`) crea slots los sábados, pero si la semana corriente ya pasó el sábado ' +
+        'no son elegibles (past-day). Reportar al director para decidir si conviene un fixture adicional.',
+    );
+
+    // Garantizado por el `test.skip` de arriba — los `!` son para el typechecker.
+    const p = priceBox!;
+    const l = labelBox!;
+    const c = cellBox!;
+
+    expect(isOverlap(p, l), `slot-price (${JSON.stringify(p)}) y cal-court-label (${JSON.stringify(l)}) se solapan dentro de la celda (${JSON.stringify(c)})`).toBe(false);
+
+    // Aserto adicional barato: el precio queda en la mitad superior de la
+    // celda. Captura la intención del fix (top-left, no bottom-left) sin
+    // acoplarse a pixeles exactos.
+    const cellMidY = c.y + c.height / 2;
+    expect(
+      p.y,
+      `slot-price.top (${p.y}) debe estar por encima del centro vertical de la celda (${cellMidY})`,
+    ).toBeLessThan(cellMidY);
+  });
+
+  test('en celdas con status `match` el precio no se renderiza', async ({ page }) => {
+    await page.goto(HORARIOS_URL);
+    await waitForIslandsHydrated(page);
+    await expect(page.getByRole('heading', { name: /^horarios$/i })).toBeVisible();
+
+    const calendarBody = page.locator('.cal-wrap .cal-body');
+    await expect(calendarBody).toBeVisible();
+
+    // `.cal-cell--match-open` lo aplica SlotCalendarView.renderCell cuando
+    // `getSlotStatus(primary) === 'match'`. La seed crea el partido sábado
+    // 11:00 con status='open', lo que dispara `hasScheduledMatch=true` para
+    // ese slot vía la query GraphQL de horarios.
+    const matchCells = calendarBody.locator('.cal-cell.cal-cell--match-open');
+    const matchCellCount = await matchCells.count();
+
+    test.skip(
+      matchCellCount === 0,
+      'No se encontró ninguna celda con `cal-cell--match-open` en la semana actual. ' +
+        'La seed crea un match el sábado 11:00, pero si la semana corriente ya pasó el sábado ' +
+        'la celda se renderiza con `cal-cell--past-day-busy` y el caso no es ejercitable. ' +
+        'Reportar al director para decidir si conviene un fixture adicional.',
+    );
+
+    // Verificamos en TODAS las celdas con match: ninguna debe tener
+    // `.slot-price`. Si la seed crea 1, validamos 1; si por evolución de
+    // la seed hay más, validamos todas — el fix aplica al render condicional
+    // `primary.priceArs != null && status !== 'match'`.
+    for (let i = 0; i < matchCellCount; i += 1) {
+      const cell = matchCells.nth(i);
+      const price = cell.locator('.slot-price');
+      const priceCount = await price.count();
+      expect(priceCount, `celda match #${i} no debe renderizar .slot-price (esconde el precio en slots ocupados)`).toBe(0);
+    }
+  });
+});

--- a/docs/prompts/k7m9x2p4-prompt-log.md
+++ b/docs/prompts/k7m9x2p4-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-05-29 18:50:00
+- Task ID: k7m9x2p4
+
+## User Prompt
+
+> Agregá un test e2e Playwright que valide el fix de un bug visual en el calendario de `/panel-club/horarios`. Branch actual: `fix/horarios-calendar-overlap`. Leé `.claude/rules/e2e-testing.md` antes de tocar nada bajo `apps/testing/tests/**`. El bug: `.slot-price` y `.cal-court-label` vivían en la misma esquina bottom-left de cada celda y se solapaban (ej. "$26000" sobre "Cancha 1"). Fix ya aplicado en esta branch: `.slot-price` movido a top-left, y escondido cuando status === 'match'. SSR fetch de slots → no se puede mockear con `page.route()`. Hay que usar seed real (clubAdmin de testing). Casos: (1) no-overlap real entre `.slot-price` y `.cal-court-label`; (2) precio escondido en celdas con match; (3) opcional: precio en cuadrante superior de la celda. Skipear si la seed no provee datos. NO tocar producción.
+
+## Agent Main Actions
+
+- Creé `apps/testing/tests/horarios-calendar-overlap.spec.ts` con dos casos (no-overlap + precio escondido en celdas con match), reutilizando `TEST_USERS.clubAdmin.storageStatePath` y la seed existente; selectores crudos `.slot-price` / `.cal-court-label` / `.cal-cell--match-open` documentados en el bloque Decision Context.
+- Corrí `turbo typecheck --force` (3/3 tareas OK) y la spec en Playwright: 1 caso pasa, 1 caso skipea con mensaje claro porque `clubSlotManagementService.getManagedSlots` devuelve `hasScheduledMatch: false` cableado (gap backend separado al fix visual).
+- Reporté hallazgo al director: la celda con partido no se pinta como `cal-cell--match-open` porque el resolver `myClubSlots` no enriquece `hasScheduledMatch`; la spec correctamente skipea en vez de fallar falsamente.

--- a/docs/prompts/x9k4n7tm-prompt-log.md
+++ b/docs/prompts/x9k4n7tm-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-05-19 17:00:00
+- Task ID: x9k4n7tm
+
+## User Prompt
+
+> [Tras detectar visualmente en /panel-club/horarios que precio y nombre de cancha se superponen en cada celda] quiero que en una nueva branch resuelvas el bug y ademas agreges testing
+
+## Agent Main Actions
+
+- Creé la branch `fix/horarios-calendar-overlap` desde main actualizado y arreglé el bug en `apps/frontend/src/components/club/SlotCalendarView.tsx`: moví `.slot-price` del `bottom-left` (donde colisionaba con el `.cal-court-label` agregado por el refactor de CalendarGrid) al `top-left`, bajé el font-size a 0.62rem y le puse color verde `hsl(142 70% 55%)` para alinear con `.pk-price` del calendario de "Crear Partido" (AvailableSlotsPicker), y agregué la condición `status !== 'match'` al render para que un slot ocupado no muestre precio. Actualicé el bloque "Previously fixed bugs" del Decision Context del componente.
+- Vía el agente `tester` agregué `apps/testing/tests/horarios-calendar-overlap.spec.ts` con 2 casos contra seed real (la página es SSR, no se puede mockear con `page.route`): (1) buscar una celda con `.slot-price` + `.cal-court-label` visibles y asertar AABB-no-intersection + precio en la mitad superior; (2) verificar que celdas con status match no renderizan precio. Sin Page Object nuevo — selectores crudos justificados en el Decision Context por el tamaño pequeño del spec.
+- Verificado por mí: typecheck verde (3/3 tasks); spec `horarios-calendar-overlap.spec.ts` con 4 passed + 1 skipped (el caso 2 quedó skipped porque el backend `myClubSlots` hardcodea `hasScheduledMatch: false` en `clubSlotManagementService.ts:137` y nunca lo enriquece — gap previo, no introducido por este fix; el render condicional queda como defensive code listo para cuando se cierre ese gap del backend).


### PR DESCRIPTION
…e cancha

El .slot-price quedaba en la misma esquina inferior izquierda que el .cal-court-label compartido (agregado durante el refactor a CalendarGrid), causando que '$26000' se viera pisado sobre 'Cancha 1' en cada celda del calendario semanal. Se mueve el precio al top-left con la misma tipografia y color verde que usa .pk-price en AvailableSlotsPicker, alineando con el criterio de done del epic #110. Tambien se esconde el precio en slots ocupados (status === 'match'), mismo comportamiento que el calendario de Crear Partido.

Test: nuevo spec Playwright horarios-calendar-overlap.spec.ts que valida AABB-no-intersection entre .slot-price y .cal-court-label sobre seed real, mas posicionamiento del precio en la mitad superior de la celda. Un segundo caso queda skipped por un gap previo del backend (myClubSlots no enriquece hasScheduledMatch en clubSlotManagementService:137), reportado para fix aparte.
<img width="700" height="566" alt="image" src="https://github.com/user-attachments/assets/dce8ce1c-7cf2-48bf-b92c-96792a1cf667" />
