### PR TITLE
feat(torneos): agregar mapa de torneos disponibles

### DIFF
--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -861,6 +861,8 @@ export type TournamentClub = {
   address?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   imageUrl?: Maybe<Scalars['String']['output']>;
+  lat?: Maybe<Scalars['Float']['output']>;
+  lng?: Maybe<Scalars['Float']['output']>;
   name: Scalars['String']['output'];
   zone?: Maybe<Scalars['String']['output']>;
 };
@@ -1641,6 +1643,8 @@ export type TournamentClubResolvers<ContextType = GraphQLContext, ParentType ext
   address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   imageUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lat?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  lng?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   zone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;

--- a/apps/backend/src/graphql/schema/tournament.graphql
+++ b/apps/backend/src/graphql/schema/tournament.graphql
@@ -29,6 +29,8 @@ type TournamentClub {
   name: String!
   zone: String
   address: String
+  lat: Float
+  lng: Float
   imageUrl: String
 }
 

--- a/apps/backend/src/repositories/tournamentRepository.ts
+++ b/apps/backend/src/repositories/tournamentRepository.ts
@@ -34,6 +34,8 @@ const TOURNAMENT_CLUB_COLUMNS = `
   name,
   zone,
   address,
+  lat,
+  lng,
   "imageUrl"
 `;
 
@@ -88,6 +90,8 @@ export interface TournamentClubRow {
   name: string;
   zone: string | null;
   address: string | null;
+  lat: number | null;
+  lng: number | null;
   imageUrl: string | null;
 }
 

--- a/apps/backend/src/services/tournamentService.ts
+++ b/apps/backend/src/services/tournamentService.ts
@@ -85,8 +85,8 @@ const FORMAT_ORDER: Record<string, number> = {
   '11v11': 4,
 };
 
-const TOURNAMENTS_REGISTRATION_CACHE_KEY = `${CACHE_PREFIX.TOURNAMENTS_LIST}:status:registration`;
-const TOURNAMENT_DETAIL_CACHE_PREFIX = `${CACHE_PREFIX.TOURNAMENTS_LIST}:detail:`;
+const TOURNAMENTS_REGISTRATION_CACHE_KEY = `${CACHE_PREFIX.TOURNAMENTS_LIST}:status:registration:v2`;
+const TOURNAMENT_DETAIL_CACHE_PREFIX = `${CACHE_PREFIX.TOURNAMENTS_LIST}:detail:v2:`;
 
 // =====================================================
 // Helpers
@@ -193,6 +193,8 @@ function toTournament(row: TournamentRow): Tournament {
           name: row.clubs.name,
           zone: row.clubs.zone,
           address: row.clubs.address,
+          lat: row.clubs.lat ?? null,
+          lng: row.clubs.lng ?? null,
           imageUrl: row.clubs.imageUrl,
         }
       : null,

--- a/apps/frontend/src/components/tournaments/TournamentMap.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentMap.tsx
@@ -1,0 +1,270 @@
+/**
+ * TournamentMap - Leaflet map view of registration tournaments.
+ *
+ * Decision Context:
+ * - Mirrors MatchMap so tournaments use the same OpenStreetMap/Leaflet integration.
+ * - Leaflet touches browser globals, so this component is only imported lazily from
+ *   TournamentsView after hydration.
+ * - Tournament pins come from the associated club coordinates: clubs.lat / clubs.lng.
+ *   Clubs without coordinates are omitted from the marker layer without breaking the list.
+ */
+
+import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+import { MapContainer, Marker, Popup, TileLayer, useMap } from 'react-leaflet';
+import { LocateFixed } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import {
+  GET_TOURNAMENTS,
+  type TournamentListItem,
+} from '@/graphql/operations/tournaments';
+import type { MatchFormat } from '@/graphql/operations/matches';
+
+delete (L.Icon.Default.prototype as unknown as { _getIconUrl?: unknown })._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+  iconRetinaUrl:
+    'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+});
+
+const MONTEVIDEO: [number, number] = [-34.9011, -56.1645];
+const DEFAULT_CENTER = MONTEVIDEO;
+const DEFAULT_ZOOM = 12;
+const MAP_HEIGHT_DESKTOP = '600px';
+const MAP_HEIGHT_MOBILE_BREAKPOINT = 640;
+
+const FORMAT_LABELS: Record<MatchFormat, string> = {
+  FIVE_VS_FIVE: '5v5',
+  SEVEN_VS_SEVEN: '7v7',
+  TEN_VS_TEN: '10v10',
+  ELEVEN_VS_ELEVEN: '11v11',
+};
+
+interface GetTournamentsPayload {
+  tournaments: TournamentListItem[];
+}
+
+function keepRegistrationOnly(tournaments: TournamentListItem[]): TournamentListItem[] {
+  return tournaments.filter((tournament) => tournament.status === 'REGISTRATION');
+}
+
+function LocationButton() {
+  const map = useMap();
+  const [tooltip, setTooltip] = useState<string | null>(null);
+  const [geoSupported, setGeoSupported] = useState(false);
+
+  useEffect(() => {
+    setGeoSupported('geolocation' in navigator);
+  }, []);
+
+  const centerOnUser = useCallback(() => {
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        map.setView([pos.coords.latitude, pos.coords.longitude], 14);
+      },
+      () => {
+        setTooltip('No se pudo obtener tu ubicacion, mostrando la ubicacion por defecto');
+        setTimeout(() => setTooltip(null), 4000);
+      },
+    );
+  }, [map]);
+
+  if (!geoSupported) return null;
+
+  return (
+    <div className="leaflet-top leaflet-right" style={{ pointerEvents: 'auto', zIndex: 1000 }}>
+      <div className="leaflet-control leaflet-bar" style={{ margin: 10 }}>
+        <button
+          type="button"
+          onClick={centerOnUser}
+          title="Centrar en mi ubicacion"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 30,
+            height: 30,
+            background: 'hsl(220 55% 11%)',
+            border: 'none',
+            color: 'hsl(35 100% 55%)',
+            cursor: 'pointer',
+          }}
+          aria-label="Centrar en mi ubicacion"
+        >
+          <LocateFixed size={16} strokeWidth={2.25} aria-hidden="true" />
+        </button>
+      </div>
+      {tooltip && (
+        <div
+          style={{
+            margin: '0 10px',
+            padding: '6px 10px',
+            background: 'hsl(220 55% 11%)',
+            color: 'hsl(215 20% 65%)',
+            borderRadius: 6,
+            fontSize: '0.75rem',
+            maxWidth: 200,
+            border: '1px solid rgba(255,255,255,0.1)',
+          }}
+        >
+          {tooltip}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TournamentPopup({ tournament }: { tournament: TournamentListItem }) {
+  const registeredTeams = Math.min(tournament.registeredTeamsCount, tournament.teamCount);
+
+  return (
+    <div style={{ minWidth: 180 }}>
+      <strong style={{ display: 'block', marginBottom: 4 }}>{tournament.name}</strong>
+      {tournament.club && (
+        <span style={{ display: 'block', fontSize: '0.75rem', color: '#666', marginBottom: 4 }}>
+          {tournament.club.name}
+          {tournament.club.zone ? ` - ${tournament.club.zone}` : ''}
+        </span>
+      )}
+      <span style={{ display: 'block', marginBottom: 2 }}>
+        {FORMAT_LABELS[tournament.format] ?? tournament.format}
+      </span>
+      <span style={{ display: 'block', marginBottom: 8 }}>
+        {registeredTeams}/{tournament.teamCount} equipos
+      </span>
+      <a
+        href={`/torneos/${tournament.id}`}
+        style={{ color: 'hsl(216 85% 45%)', fontWeight: 600, textDecoration: 'none' }}
+      >
+        Ver detalle -&gt;
+      </a>
+    </div>
+  );
+}
+
+function EmptyMap({ message, mapStyle }: { message: string; mapStyle: CSSProperties }) {
+  return (
+    <div className="tournament-map-wrap">
+      <MapContainer
+        center={DEFAULT_CENTER}
+        zoom={DEFAULT_ZOOM}
+        style={mapStyle}
+        scrollWheelZoom={false}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+      </MapContainer>
+      <p className="tournament-map-empty-msg">{message}</p>
+    </div>
+  );
+}
+
+export function TournamentMap() {
+  const [tournaments, setTournaments] = useState<TournamentListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const mapHeight = useMemo(
+    () => (window.innerWidth <= MAP_HEIGHT_MOBILE_BREAKPOINT ? '400px' : MAP_HEIGHT_DESKTOP),
+    [],
+  );
+  const mapStyle = useMemo(() => ({ height: mapHeight, width: '100%' }), [mapHeight]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetch('/api/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: GET_TOURNAMENTS }),
+    })
+      .then((response) => response.json())
+      .then((payload: { data?: GetTournamentsPayload; errors?: Array<{ message: string }> }) => {
+        if (cancelled) return;
+        const graphQLError = payload.errors?.[0]?.message;
+        if (graphQLError) throw new Error(graphQLError);
+        setTournaments(keepRegistrationOnly(payload.data?.tournaments ?? []));
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Error al cargar el mapa');
+          setTournaments([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const geoTournaments = tournaments.filter((tournament) => {
+    if (tournament.club?.lat == null || tournament.club?.lng == null) {
+      if (tournament.club) {
+        console.warn(
+          `[TournamentMap] Club sin coordenadas, omitido del mapa: tournamentId=${tournament.id}`,
+        );
+      }
+      return false;
+    }
+    return true;
+  });
+
+  if (loading) {
+    return (
+      <div className="tournament-map-loading">
+        <div className="tournament-map-loading-inner">Cargando mapa...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="tournament-map-loading">
+        <p style={{ color: 'hsl(0 72% 51%)' }}>{error}</p>
+      </div>
+    );
+  }
+
+  if (tournaments.length === 0) {
+    return <EmptyMap message="No hay torneos en inscripcion" mapStyle={mapStyle} />;
+  }
+
+  if (geoTournaments.length === 0) {
+    return <EmptyMap message="No hay torneos con ubicacion disponible" mapStyle={mapStyle} />;
+  }
+
+  return (
+    <div className="tournament-map-wrap">
+      <MapContainer
+        center={DEFAULT_CENTER}
+        zoom={DEFAULT_ZOOM}
+        style={mapStyle}
+        scrollWheelZoom={true}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <LocationButton />
+        {geoTournaments.map((tournament) => (
+          <Marker
+            key={tournament.id}
+            position={[tournament.club!.lat as number, tournament.club!.lng as number]}
+          >
+            <Popup>
+              <TournamentPopup tournament={tournament} />
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/tournaments/TournamentsView.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentsView.tsx
@@ -1,0 +1,176 @@
+/**
+ * TournamentsView - toggle wrapper between tournament list and map views.
+ *
+ * Decision Context:
+ * - MatchesView already established the interaction: keep the selected view client-side
+ *   and lazy-load Leaflet only when the user opens the map.
+ * - TournamentList and TournamentMap fetch independently, matching the existing matches
+ *   architecture and keeping registration updates scoped to the list card flow.
+ */
+
+import { lazy, Suspense, useState } from 'react';
+import { List, Map as MapIcon } from 'lucide-react';
+import { TournamentList } from './TournamentList';
+
+const TournamentMap = lazy(() =>
+  import('./TournamentMap').then((module) => ({ default: module.TournamentMap })),
+);
+
+type View = 'list' | 'map';
+
+interface TournamentsViewProps {
+  isAuthenticated?: boolean;
+}
+
+export function TournamentsView({ isAuthenticated = false }: TournamentsViewProps) {
+  const [view, setView] = useState<View>('list');
+
+  return (
+    <div>
+      <div className="tournament-view-toggle" role="group" aria-label="Seleccionar vista de torneos">
+        <button
+          type="button"
+          className={`tournament-view-toggle-btn${view === 'list' ? ' active' : ''}`}
+          onClick={() => setView('list')}
+          aria-pressed={view === 'list'}
+        >
+          <span className="tournament-view-toggle-icon">
+            <List size={16} strokeWidth={2.25} aria-hidden="true" />
+          </span>
+          Lista
+        </button>
+        <button
+          type="button"
+          className={`tournament-view-toggle-btn${view === 'map' ? ' active' : ''}`}
+          onClick={() => setView('map')}
+          aria-pressed={view === 'map'}
+        >
+          <span className="tournament-view-toggle-icon">
+            <MapIcon size={16} strokeWidth={2.25} aria-hidden="true" />
+          </span>
+          Mapa
+        </button>
+      </div>
+
+      {view === 'list' ? (
+        <TournamentList isAuthenticated={isAuthenticated} />
+      ) : (
+        <Suspense
+          fallback={
+            <div className="tournament-map-loading">
+              <div className="tournament-map-loading-inner">Cargando mapa...</div>
+            </div>
+          }
+        >
+          <TournamentMap />
+        </Suspense>
+      )}
+
+      <style>{`
+        .tournament-view-toggle {
+          display: inline-flex;
+          gap: 0;
+          border-radius: 8px;
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          overflow: hidden;
+          margin-bottom: 1.5rem;
+          background: hsl(220 55% 11%);
+        }
+
+        .tournament-view-toggle-btn {
+          display: flex;
+          align-items: center;
+          gap: 0.4rem;
+          padding: 0.4rem 1rem;
+          min-height: 44px;
+          background: transparent;
+          border: none;
+          color: hsl(215 20% 55%);
+          font-family: 'Barlow Condensed', sans-serif;
+          font-size: 0.875rem;
+          font-weight: 700;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          cursor: pointer;
+          transition: background 0.15s, color 0.15s;
+        }
+
+        .tournament-view-toggle-btn + .tournament-view-toggle-btn {
+          border-left: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .tournament-view-toggle-btn:hover {
+          background: rgba(255, 255, 255, 0.06);
+          color: hsl(210 20% 85%);
+        }
+
+        .tournament-view-toggle-btn.active {
+          background: hsl(35 100% 48%);
+          color: hsl(220 72% 7%);
+        }
+
+        .tournament-view-toggle-icon {
+          font-size: 0.9rem;
+          line-height: 1;
+        }
+
+        .tournament-map-wrap {
+          position: relative;
+          border-radius: 12px;
+          overflow: hidden;
+          box-shadow: 0 4px 32px rgba(0, 0, 0, 0.4);
+        }
+
+        .tournament-map-empty-msg {
+          position: absolute;
+          bottom: 1.25rem;
+          left: 50%;
+          transform: translateX(-50%);
+          background: rgba(7, 15, 31, 0.85);
+          color: hsl(215 20% 65%);
+          padding: 0.5rem 1.25rem;
+          border-radius: 20px;
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.875rem;
+          white-space: nowrap;
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          backdrop-filter: blur(8px);
+        }
+
+        .tournament-map-loading {
+          height: 400px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border-radius: 12px;
+          background: hsl(220 55% 11%);
+          border: 1px solid rgba(255, 255, 255, 0.06);
+        }
+
+        .tournament-map-loading-inner {
+          color: hsl(215 20% 55%);
+          font-family: 'Barlow', sans-serif;
+          font-size: 0.9rem;
+        }
+
+        @media (max-width: 420px) {
+          .tournament-view-toggle {
+            display: flex;
+            width: 100%;
+          }
+
+          .tournament-view-toggle-btn {
+            flex: 1;
+            justify-content: center;
+          }
+
+          .tournament-map-empty-msg {
+            max-width: calc(100% - 2rem);
+            white-space: normal;
+            text-align: center;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/frontend/src/graphql/operations/tournaments.graphql
+++ b/apps/frontend/src/graphql/operations/tournaments.graphql
@@ -17,6 +17,8 @@ query GetTournaments {
       name
       zone
       address
+      lat
+      lng
       imageUrl
     }
   }
@@ -47,6 +49,8 @@ query GetTournamentDetail($id: ID!) {
       name
       zone
       address
+      lat
+      lng
       imageUrl
     }
     teams {
@@ -128,6 +132,8 @@ mutation CreateTournament($input: CreateTournamentInput!) {
         name
         zone
         address
+        lat
+        lng
         imageUrl
       }
       fixtureMatches {
@@ -175,6 +181,8 @@ mutation RegisterTournamentTeam($input: RegisterTournamentTeamInput!) {
         name
         zone
         address
+        lat
+        lng
         imageUrl
       }
       fixtureMatches {
@@ -240,6 +248,8 @@ mutation JoinTournament($input: JoinTournamentInput!) {
         name
         zone
         address
+        lat
+        lng
         imageUrl
       }
       fixtureMatches {

--- a/apps/frontend/src/graphql/operations/tournaments.ts
+++ b/apps/frontend/src/graphql/operations/tournaments.ts
@@ -83,6 +83,8 @@ export interface TournamentData {
     name: string;
     zone: string | null;
     address: string | null;
+    lat: number | null;
+    lng: number | null;
     imageUrl: string | null;
   } | null;
   teams: TournamentTeam[];
@@ -105,6 +107,8 @@ export interface TournamentListItem {
     name: string;
     zone: string | null;
     address: string | null;
+    lat: number | null;
+    lng: number | null;
     imageUrl: string | null;
   } | null;
 }
@@ -158,6 +162,8 @@ export const GET_TOURNAMENTS = /* GraphQL */ `
         name
         zone
         address
+        lat
+        lng
         imageUrl
       }
     }
@@ -190,6 +196,8 @@ export const GET_TOURNAMENT_DETAIL = /* GraphQL */ `
         name
         zone
         address
+        lat
+        lng
         imageUrl
       }
       teams {
@@ -275,6 +283,8 @@ export const CREATE_TOURNAMENT = /* GraphQL */ `
           name
           zone
           address
+          lat
+          lng
           imageUrl
         }
         fixtureMatches {
@@ -324,6 +334,8 @@ export const REGISTER_TOURNAMENT_TEAM = /* GraphQL */ `
           name
           zone
           address
+          lat
+          lng
           imageUrl
         }
         fixtureMatches {
@@ -391,6 +403,8 @@ export const JOIN_TOURNAMENT = /* GraphQL */ `
           name
           zone
           address
+          lat
+          lng
           imageUrl
         }
         fixtureMatches {

--- a/apps/frontend/src/pages/torneos/index.astro
+++ b/apps/frontend/src/pages/torneos/index.astro
@@ -12,7 +12,7 @@ export const prerender = false;
 
 import { Trophy, Volleyball } from 'lucide-react';
 import Layout from '../../layouts/Layout.astro';
-import { TournamentList } from '../../components/tournaments/TournamentList';
+import { TournamentsView } from '../../components/tournaments/TournamentsView';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
 
 const user = Astro.locals.user;
@@ -73,7 +73,7 @@ const nombre = user?.displayName || user?.email;
       </header>
 
       <section class="tournaments-section">
-        <TournamentList client:visible isAuthenticated={isAuthenticated} />
+        <TournamentsView client:visible isAuthenticated={isAuthenticated} />
       </section>
     </main>
   </div>


### PR DESCRIPTION
Se agregó una vista de mapa en la página de torneos para que los jugadores puedan encontrar torneos cercanos más fácilmente.

También se incorporó el toggle para cambiar entre lista y mapa, se muestran los torneos como marcadores usando la ubicación del club asociado, y cada popup incluye el nombre del torneo, formato, equipos inscriptos y acceso al detalle.

Además, se extendió el contrato GraphQL de torneos para devolver las coordenadas del club.