### PR TITLE
feat(torneos): implementar abandono de torneo (issue #47)

### DIFF
--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -345,6 +345,20 @@ export type LeaveMatchResult = {
   matchDeleted: Scalars['Boolean']['output'];
 };
 
+export type LeaveTournamentInput = {
+  reason?: InputMaybe<Scalars['String']['input']>;
+  teamId: Scalars['ID']['input'];
+  tournamentId: Scalars['ID']['input'];
+};
+
+export type LeaveTournamentResult = {
+  __typename?: 'LeaveTournamentResult';
+  message: Scalars['String']['output'];
+  remainingTeams?: Maybe<Scalars['Int']['output']>;
+  success: Scalars['Boolean']['output'];
+  tournamentStatus?: Maybe<Scalars['String']['output']>;
+};
+
 export type ManagedClubSlot = {
   __typename?: 'ManagedClubSlot';
   allowOnlineBooking: Scalars['Boolean']['output'];
@@ -494,6 +508,7 @@ export type Mutation = {
   joinMatch: JoinMatchResult;
   joinTournament: TournamentTeamRegistrationResult;
   leaveMatch: LeaveMatchResult;
+  leaveTournament: LeaveTournamentResult;
   proposeMatchResult: MatchResultSubmission;
   registerTournamentTeam: TournamentTeamRegistrationResult;
   removeTournamentTeamMember: TournamentTeamRegistrationResult;
@@ -557,6 +572,11 @@ export type MutationJoinTournamentArgs = {
 
 export type MutationLeaveMatchArgs = {
   input: LeaveMatchInput;
+};
+
+
+export type MutationLeaveTournamentArgs = {
+  input: LeaveTournamentInput;
 };
 
 
@@ -1096,6 +1116,8 @@ export type ResolversTypes = ResolversObject<{
   JoinTournamentInput: JoinTournamentInput;
   LeaveMatchInput: LeaveMatchInput;
   LeaveMatchResult: ResolverTypeWrapper<LeaveMatchResult>;
+  LeaveTournamentInput: LeaveTournamentInput;
+  LeaveTournamentResult: ResolverTypeWrapper<LeaveTournamentResult>;
   ManagedClubSlot: ResolverTypeWrapper<ManagedClubSlot>;
   Match: ResolverTypeWrapper<Match>;
   MatchFilters: MatchFilters;
@@ -1184,6 +1206,8 @@ export type ResolversParentTypes = ResolversObject<{
   JoinTournamentInput: JoinTournamentInput;
   LeaveMatchInput: LeaveMatchInput;
   LeaveMatchResult: LeaveMatchResult;
+  LeaveTournamentInput: LeaveTournamentInput;
+  LeaveTournamentResult: LeaveTournamentResult;
   ManagedClubSlot: ManagedClubSlot;
   Match: Match;
   MatchFilters: MatchFilters;
@@ -1412,6 +1436,13 @@ export type LeaveMatchResultResolvers<ContextType = GraphQLContext, ParentType e
   matchDeleted?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
 }>;
 
+export type LeaveTournamentResultResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['LeaveTournamentResult'] = ResolversParentTypes['LeaveTournamentResult']> = ResolversObject<{
+  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  remainingTeams?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  tournamentStatus?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
 export type ManagedClubSlotResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['ManagedClubSlot'] = ResolversParentTypes['ManagedClubSlot']> = ResolversObject<{
   allowOnlineBooking?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   blockReason?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1516,6 +1547,7 @@ export type MutationResolvers<ContextType = GraphQLContext, ParentType extends R
   joinMatch?: Resolver<ResolversTypes['JoinMatchResult'], ParentType, ContextType, RequireFields<MutationJoinMatchArgs, 'input'>>;
   joinTournament?: Resolver<ResolversTypes['TournamentTeamRegistrationResult'], ParentType, ContextType, RequireFields<MutationJoinTournamentArgs, 'input'>>;
   leaveMatch?: Resolver<ResolversTypes['LeaveMatchResult'], ParentType, ContextType, RequireFields<MutationLeaveMatchArgs, 'input'>>;
+  leaveTournament?: Resolver<ResolversTypes['LeaveTournamentResult'], ParentType, ContextType, RequireFields<MutationLeaveTournamentArgs, 'input'>>;
   proposeMatchResult?: Resolver<ResolversTypes['MatchResultSubmission'], ParentType, ContextType, RequireFields<MutationProposeMatchResultArgs, 'input'>>;
   registerTournamentTeam?: Resolver<ResolversTypes['TournamentTeamRegistrationResult'], ParentType, ContextType, RequireFields<MutationRegisterTournamentTeamArgs, 'input'>>;
   removeTournamentTeamMember?: Resolver<ResolversTypes['TournamentTeamRegistrationResult'], ParentType, ContextType, RequireFields<MutationRemoveTournamentTeamMemberArgs, 'input'>>;
@@ -1715,6 +1747,7 @@ export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   DashboardMatch?: DashboardMatchResolvers<ContextType>;
   JoinMatchResult?: JoinMatchResultResolvers<ContextType>;
   LeaveMatchResult?: LeaveMatchResultResolvers<ContextType>;
+  LeaveTournamentResult?: LeaveTournamentResultResolvers<ContextType>;
   ManagedClubSlot?: ManagedClubSlotResolvers<ContextType>;
   Match?: MatchResolvers<ContextType>;
   MatchHistoryConnection?: MatchHistoryConnectionResolvers<ContextType>;

--- a/apps/backend/src/graphql/resolvers/domains/tournament.ts
+++ b/apps/backend/src/graphql/resolvers/domains/tournament.ts
@@ -1,5 +1,11 @@
 /**
  * Tournament Resolver - GraphQL queries and mutations for tournament flows.
+ *
+ * Decision Context:
+ * - leaveTournament: el resolver valida el input con Zod antes de pasar al service.
+ *   El service aplica las 8 validaciones de negocio en orden estricto.
+ *   El user-scoped client se pasa al service para que las escrituras respeten RLS.
+ * Previously fixed bugs: none relevant.
  */
 
 import { z } from 'zod';
@@ -52,8 +58,18 @@ const TournamentTeamMemberSchema = z.object({
   playerId: z.string().regex(UUID_REGEX, 'playerId invalido'),
 });
 
+const LeaveTournamentSchema = z.object({
+  tournamentId: z.string().regex(UUID_REGEX, 'tournamentId invalido'),
+  teamId: z.string().regex(UUID_REGEX, 'teamId invalido'),
+  reason: z.string().trim().max(500, 'El motivo no puede superar 500 caracteres').optional().nullable(),
+});
+
 function invalidTeamResult(message: string) {
   return { success: false, teamId: null, message: `Datos invalidos: ${message}`, tournament: null };
+}
+
+function invalidLeaveResult(message: string) {
+  return { success: false, message: `Datos invalidos: ${message}`, tournamentStatus: null, remainingTeams: null };
 }
 
 const Query: QueryResolvers = {
@@ -170,6 +186,32 @@ const Mutation: MutationResolvers = {
       const message = error instanceof Error ? error.message : 'Error al quitar jugador';
       console.error(`[tournamentResolver.removeTournamentTeamMember] Failed for userId=${user.id}:`, error);
       return { success: false, teamId: null, message, tournament: null };
+    }
+  },
+
+  leaveTournament: async (_parent, args, ctx) => {
+    const user = requireAuth(ctx);
+    const userClient = ctx.accessToken ? createUserClient(ctx.accessToken) : undefined;
+
+    const parsed = LeaveTournamentSchema.safeParse(args.input);
+    if (!parsed.success) {
+      const message = parsed.error.issues.map((issue) => issue.message).join('; ');
+      return invalidLeaveResult(message);
+    }
+
+    try {
+      return await tournamentService.leaveTournament(
+        {
+          tournamentId: parsed.data.tournamentId,
+          teamId: parsed.data.teamId,
+          reason: parsed.data.reason ?? null,
+        },
+        { userId: user.id, supabase: userClient },
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error al retirar el equipo del torneo';
+      console.error(`[tournamentResolver.leaveTournament] Failed for userId=${user.id}:`, error);
+      return { success: false, message, tournamentStatus: null, remainingTeams: null };
     }
   },
 };

--- a/apps/backend/src/graphql/schema/tournament.graphql
+++ b/apps/backend/src/graphql/schema/tournament.graphql
@@ -136,10 +136,24 @@ extend type Query {
   tournamentEligiblePlayers(tournamentId: ID!, search: String): [TournamentPlayer!]!
 }
 
+input LeaveTournamentInput {
+  tournamentId: ID!
+  teamId: ID!
+  reason: String
+}
+
+type LeaveTournamentResult {
+  success: Boolean!
+  message: String!
+  tournamentStatus: String
+  remainingTeams: Int
+}
+
 extend type Mutation {
   createTournament(input: CreateTournamentInput!): CreateTournamentResult!
   registerTournamentTeam(input: RegisterTournamentTeamInput!): TournamentTeamRegistrationResult!
   joinTournament(input: JoinTournamentInput!): TournamentTeamRegistrationResult!
   addTournamentTeamMember(input: TournamentTeamMemberInput!): TournamentTeamRegistrationResult!
   removeTournamentTeamMember(input: TournamentTeamMemberInput!): TournamentTeamRegistrationResult!
+  leaveTournament(input: LeaveTournamentInput!): LeaveTournamentResult!
 }

--- a/apps/backend/src/repositories/tournamentRepository.ts
+++ b/apps/backend/src/repositories/tournamentRepository.ts
@@ -6,6 +6,9 @@
  * - Writes accept an optional user-scoped client so RLS can enforce organizer ownership.
  * - Availability checks read from both matches and fixtureMatches because tournament
  *   creation reserves club/court time before the participating teams are known.
+ * - tournamentTeams soft-delete: status column ('active'|'withdrawn') added via migration.
+ *   All queries that list teams should filter by status='active' at the service layer.
+ *   REQUIRES MIGRATION: ALTER TABLE "tournamentTeams" ADD COLUMN status, withdrawnAt, withdrawalReason.
  */
 
 import { supabase, type SupabaseClient } from '../config/supabase.js';
@@ -65,6 +68,9 @@ const TOURNAMENT_TEAM_COLUMNS = `
   "tournamentId",
   name,
   "captainId",
+  status,
+  "withdrawnAt",
+  "withdrawalReason",
   "createdAt"
 `;
 
@@ -214,6 +220,10 @@ export interface TournamentTeamRow {
   tournamentId?: string;
   name: string;
   captainId: string;
+  /** Added by migration: 'active' | 'withdrawn'. Absent on rows from queries without status column. */
+  status?: string;
+  withdrawnAt?: string | null;
+  withdrawalReason?: string | null;
   captain?: TournamentPlayerRow | null;
   members?: TournamentTeamMemberRow[];
   createdAt: string;
@@ -518,7 +528,7 @@ export async function getTournamentTeams(
 ): Promise<TournamentTeamRow[]> {
   const { data, error } = await client
     .from('tournamentTeams')
-    .select('id, "tournamentId", name, "captainId", "createdAt"')
+    .select(TOURNAMENT_TEAM_COLUMNS)
     .eq('tournamentId', tournamentId)
     .order('createdAt', { ascending: true });
 
@@ -553,7 +563,7 @@ export async function getTournamentTeamById(
 ): Promise<TournamentTeamRow | null> {
   const { data, error } = await client
     .from('tournamentTeams')
-    .select('id, "tournamentId", name, "captainId", "createdAt"')
+    .select(TOURNAMENT_TEAM_COLUMNS)
     .eq('id', teamId)
     .single();
 
@@ -649,7 +659,7 @@ export async function createTournamentTeam(
       name,
       captainId,
     })
-    .select('id, "tournamentId", name, "captainId", "createdAt"')
+    .select(TOURNAMENT_TEAM_COLUMNS)
     .single();
 
   if (error) {
@@ -742,6 +752,124 @@ export async function updateTournamentStatus(
   }
 }
 
+// =====================================================
+// Withdrawal / Leave Tournament Functions
+// =====================================================
+
+/**
+ * Soft-delete a team by setting status='withdrawn'.
+ * Uses .eq('status', 'active') guard to handle race conditions gracefully —
+ * if two requests fire simultaneously, the second will update 0 rows.
+ * REQUIRES MIGRATION: tournamentTeams must have status, withdrawnAt, withdrawalReason columns.
+ */
+export async function withdrawTeamById(
+  teamId: string,
+  reason: string | null | undefined,
+  client: SupabaseClient = supabase,
+): Promise<void> {
+  const { error } = await client
+    .from('tournamentTeams')
+    .update({
+      status: 'withdrawn',
+      withdrawnAt: new Date().toISOString(),
+      withdrawalReason: reason ?? null,
+    })
+    .eq('id', teamId)
+    .eq('status', 'active');
+
+  if (error) {
+    console.error('[tournamentRepository.withdrawTeamById] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+}
+
+/** Hard-delete all members of a team from tournamentTeamMembers. */
+export async function deleteTeamMembersById(
+  teamId: string,
+  client: SupabaseClient = supabase,
+): Promise<void> {
+  const { error } = await client
+    .from('tournamentTeamMembers')
+    .delete()
+    .eq('teamId', teamId);
+
+  if (error) {
+    console.error('[tournamentRepository.deleteTeamMembersById] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+}
+
+const FIXTURE_TEAM_CHECK_COLUMNS = `id, "tournamentId", round, "homeTeamId", "awayTeamId", status`;
+
+/** Get all fixture matches where this team is home or away (for defense-in-depth checks). */
+export async function getFixtureMatchesByTeam(
+  teamId: string,
+  client: SupabaseClient = supabase,
+): Promise<Pick<FixtureMatchRow, 'id' | 'tournamentId' | 'round' | 'homeTeamId' | 'awayTeamId' | 'status'>[]> {
+  const { data, error } = await client
+    .from('fixtureMatches')
+    .select(FIXTURE_TEAM_CHECK_COLUMNS)
+    .or(`homeTeamId.eq.${teamId},awayTeamId.eq.${teamId}`);
+
+  if (error) {
+    console.error('[tournamentRepository.getFixtureMatchesByTeam] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return (data as unknown as Pick<FixtureMatchRow, 'id' | 'tournamentId' | 'round' | 'homeTeamId' | 'awayTeamId' | 'status'>[]) ?? [];
+}
+
+/**
+ * Null-out team references in fixture matches for non-completed/in-progress fixtures.
+ * Edge case: fixture was generated (registration was briefly complete) before the team withdrew.
+ * Previously fixed bugs: none relevant.
+ */
+export async function clearTeamFromFixtureMatches(
+  teamId: string,
+  client: SupabaseClient = supabase,
+): Promise<void> {
+  const [{ error: homeError }, { error: awayError }] = await Promise.all([
+    client
+      .from('fixtureMatches')
+      .update({ homeTeamId: null })
+      .eq('homeTeamId', teamId)
+      .not('status', 'in', '(completed,in_progress)'),
+    client
+      .from('fixtureMatches')
+      .update({ awayTeamId: null })
+      .eq('awayTeamId', teamId)
+      .not('status', 'in', '(completed,in_progress)'),
+  ]);
+
+  if (homeError) {
+    console.error('[tournamentRepository.clearTeamFromFixtureMatches] homeTeamId error:', homeError.message);
+    throw new Error(homeError.message);
+  }
+  if (awayError) {
+    console.error('[tournamentRepository.clearTeamFromFixtureMatches] awayTeamId error:', awayError.message);
+    throw new Error(awayError.message);
+  }
+}
+
+/** Count teams with status='active' for a tournament. */
+export async function countActiveTeams(
+  tournamentId: string,
+  client: SupabaseClient = supabase,
+): Promise<number> {
+  const { count, error } = await client
+    .from('tournamentTeams')
+    .select('id', { count: 'exact', head: true })
+    .eq('tournamentId', tournamentId)
+    .eq('status', 'active');
+
+  if (error) {
+    console.error('[tournamentRepository.countActiveTeams] Supabase error:', error.message);
+    throw new Error(error.message);
+  }
+
+  return count ?? 0;
+}
+
 export const tournamentRepository = {
   getSlotsByIds,
   getMatchesForSlotDates,
@@ -765,4 +893,9 @@ export const tournamentRepository = {
   deleteTournamentTeamMember,
   updateFixtureTeams,
   updateTournamentStatus,
+  withdrawTeamById,
+  deleteTeamMembersById,
+  getFixtureMatchesByTeam,
+  clearTeamFromFixtureMatches,
+  countActiveTeams,
 };

--- a/apps/backend/src/services/tournamentService.ts
+++ b/apps/backend/src/services/tournamentService.ts
@@ -19,6 +19,8 @@ import {
   type CreateTournamentInput,
   type CreateTournamentResult,
   type JoinTournamentInput,
+  type LeaveTournamentInput,
+  type LeaveTournamentResult,
   type RegisterTournamentTeamInput,
   type Tournament,
   type TournamentFixtureMatch,
@@ -171,7 +173,15 @@ function toTournament(row: TournamentRow): Tournament {
     if (a.round !== b.round) return a.round - b.round;
     return (a.scheduledAt ?? '').localeCompare(b.scheduledAt ?? '');
   });
-  const registeredTeamsCount = row.registeredTeams?.[0]?.count ?? row.tournamentTeams?.length ?? 0;
+
+  // Filter withdrawn teams. When tournamentTeams rows are loaded (detail queries),
+  // derive count from active rows only. Fall back to DB aggregate (list queries).
+  const allTeamRows = row.tournamentTeams ?? [];
+  const activeTeamRows = allTeamRows.filter((t) => !t.status || t.status === 'active');
+  const registeredTeamsCount =
+    allTeamRows.length > 0
+      ? activeTeamRows.length
+      : (row.registeredTeams?.[0]?.count ?? 0);
 
   return {
     id: row.id,
@@ -198,7 +208,7 @@ function toTournament(row: TournamentRow): Tournament {
           imageUrl: row.clubs.imageUrl,
         }
       : null,
-    teams: (row.tournamentTeams ?? []).map(toTournamentTeam),
+    teams: activeTeamRows.map(toTournamentTeam),
     fixtureMatches: fixtureMatches.map(toFixtureMatch),
   };
 }
@@ -625,6 +635,135 @@ export async function removeTournamentTeamMember(
   return { success: true, teamId: input.teamId, message: null, tournament: toTournament(updatedTournament) };
 }
 
+/**
+ * leaveTournament — retirar un equipo de un torneo en inscripción.
+ *
+ * Decision Context:
+ * - Soft delete (status='withdrawn') para preservar historial del equipo en el torneo.
+ * - Los miembros se eliminan (hard delete) porque su inscripción deja de ser válida.
+ * - Si quedan 0 equipos activos, el torneo se cancela automáticamente.
+ * - Si queda 1 equipo, se retorna warning sin cancelar (el organizador decide).
+ * - Las 8 validaciones se aplican en orden estricto para fail-fast con mensajes claros.
+ * - La validación de captainId es la única que autoriza el retiro: ni el organizer del
+ *   torneo ni un miembro del equipo pueden retirar equipos ajenos a su capitanía.
+ * - Validación 8 (fixtures jugados) es defense-in-depth: si el torneo está en
+ *   registration no debería haber fixtures completados, pero se verifica igual.
+ * - Race condition: withdrawTeamById usa .eq('status','active') para que la segunda
+ *   llamada concurrente actualice 0 filas y el service lo detecte via Validación 7.
+ * Previously fixed bugs: none relevant.
+ */
+export async function leaveTournament(
+  input: LeaveTournamentInput,
+  ctx: ServiceContext,
+): Promise<LeaveTournamentResult> {
+  // VALIDACIÓN 1 — Autenticación (requireAuth en resolver, pero se verifica acá también)
+  if (!ctx.userId) throw new Error('Authentication required');
+
+  // VALIDACIÓN 2 — El torneo existe
+  const tournament = await tournamentRepository.getTournamentById(input.tournamentId);
+  if (!tournament) throw new Error('El torneo no existe');
+
+  // VALIDACIÓN 3 — El equipo existe
+  const team = await tournamentRepository.getTournamentTeamById(input.teamId);
+  if (!team) throw new Error('El equipo no existe');
+
+  // VALIDACIÓN 4 — El equipo pertenece a este torneo
+  if (team.tournamentId !== input.tournamentId) {
+    throw new Error('Este equipo no pertenece a este torneo');
+  }
+
+  // VALIDACIÓN 5 — El usuario es el capitán (administrador) del equipo
+  // Ningún otro usuario puede retirar: ni miembro, ni organizer del torneo, ni club_admin
+  if (team.captainId !== ctx.userId) {
+    throw new Error('Solo el capitán (administrador) del equipo puede retirarlo del torneo');
+  }
+
+  // VALIDACIÓN 6 — Estado del torneo permite retiro
+  const statusBlockMessages: Record<string, string> = {
+    in_progress: 'No se puede abandonar un torneo en curso. El torneo ya comenzó y los partidos están programados',
+    completed: 'El torneo ya finalizó',
+    cancelled: 'El torneo fue cancelado',
+  };
+  if (tournament.status !== 'registration') {
+    const msg = statusBlockMessages[tournament.status];
+    throw new Error(msg ?? 'El torneo no está en estado de inscripción');
+  }
+
+  // VALIDACIÓN 7 — El equipo no fue ya retirado (previene race condition + doble retiro)
+  if (team.status === 'withdrawn') {
+    throw new Error('Este equipo ya fue retirado del torneo');
+  }
+
+  // VALIDACIÓN 8 — Defense-in-depth: no hay fixtures jugados del equipo
+  const teamFixtures = await tournamentRepository.getFixtureMatchesByTeam(input.teamId);
+  const hasPlayedFixture = teamFixtures.some(
+    (match) => match.status === 'completed' || match.status === 'in_progress',
+  );
+  if (hasPlayedFixture) {
+    throw new Error('No se puede retirar porque el equipo ya jugó partidos del fixture');
+  }
+
+  // ACCIÓN — Ejecutar retiro (escribir con user-scoped client para respetar RLS)
+  const writeClient = ctx.supabase ?? supabase;
+
+  // 1. Soft delete del equipo (status → withdrawn, guarda timestamp y motivo)
+  await tournamentRepository.withdrawTeamById(input.teamId, input.reason ?? null, writeClient);
+
+  // 2. Hard delete de los miembros (su inscripción queda invalidada)
+  await tournamentRepository.deleteTeamMembersById(input.teamId, writeClient);
+
+  // 3. Limpiar referencias del equipo en fixtures (edge case: fixture fue generado durante registration)
+  if (teamFixtures.length > 0) {
+    await tournamentRepository.clearTeamFromFixtureMatches(input.teamId, supabase);
+  }
+
+  // 4. Calcular equipos activos restantes con service-role client (no user-scoped necesario para lectura)
+  const remainingTeams = await tournamentRepository.countActiveTeams(input.tournamentId, supabase);
+
+  // 5. Invalidar todos los caches del torneo y del listado
+  await invalidateTournamentListCaches();
+
+  console.info(
+    `[tournamentService.leaveTournament] teamId=${input.teamId} retirado de tournamentId=${input.tournamentId} por userId=${ctx.userId}. remainingTeams=${remainingTeams}`,
+  );
+
+  // POST-ACCIÓN — Consecuencias según cantidad de equipos restantes
+
+  // Caso C: 0 equipos → torneo se cancela automáticamente
+  if (remainingTeams === 0) {
+    await tournamentRepository.updateTournamentStatus(input.tournamentId, 'cancelled', supabase);
+    await invalidateTournamentListCaches();
+    console.info(
+      `[tournamentService.leaveTournament] tournamentId=${input.tournamentId} cancelado automáticamente (0 equipos restantes)`,
+    );
+    return {
+      success: true,
+      message: 'El torneo fue cancelado porque no quedan equipos inscriptos',
+      tournamentStatus: 'CANCELLED',
+      remainingTeams: 0,
+    };
+  }
+
+  // Caso B: 1 equipo → warning (el torneo no se cancela pero está en riesgo)
+  if (remainingTeams === 1) {
+    return {
+      success: true,
+      message:
+        'Atención: el torneo tiene solo 1 equipo inscripto. Si no se inscriben más equipos antes de la fecha límite, el torneo podría cancelarse',
+      tournamentStatus: 'REGISTRATION',
+      remainingTeams: 1,
+    };
+  }
+
+  // Caso A: 2+ equipos → torneo sigue normal
+  return {
+    success: true,
+    message: 'Tu equipo fue retirado del torneo exitosamente',
+    tournamentStatus: 'REGISTRATION',
+    remainingTeams,
+  };
+}
+
 export const tournamentService = {
   listRegistrationTournaments,
   getTournamentById,
@@ -635,4 +774,5 @@ export const tournamentService = {
   joinTournament,
   addTournamentTeamMember,
   removeTournamentTeamMember,
+  leaveTournament,
 };

--- a/apps/frontend/src/components/tournaments/LeaveTournamentButton.tsx
+++ b/apps/frontend/src/components/tournaments/LeaveTournamentButton.tsx
@@ -1,0 +1,118 @@
+/**
+ * LeaveTournamentButton — botón secundario destructivo para retirar un equipo de un torneo.
+ *
+ * Decision Context:
+ * - Visible SOLO si: usuario es capitán del equipo Y torneo está en REGISTRATION.
+ * - Las condiciones de visibilidad se comprueban externamente (en TournamentRegistrationForm)
+ *   por lo que este componente asume que ya fue verificado y renderiza siempre.
+ * - Es una acción secundaria de bajo perfil (no un CTA prominente) para evitar retiros
+ *   accidentales — el ícono LogOut de lucide-react comunica la acción sin alarmar.
+ * - El dialog de confirmación real vive en LeaveTournamentDialog.
+ * Previously fixed bugs: none relevant.
+ */
+
+import { useState } from 'react';
+import { LogOut } from 'lucide-react';
+import { LeaveTournamentDialog } from './LeaveTournamentDialog';
+import type { LeaveTournamentResult } from '@/graphql/operations/tournaments';
+
+interface LeaveTournamentButtonProps {
+  tournamentId: string;
+  teamId: string;
+  teamName: string;
+  tournamentName: string;
+  /** True when only 2 active teams remain — used to show extra cancellation warning. */
+  hasOnlyTwoTeams: boolean;
+}
+
+export function LeaveTournamentButton({
+  tournamentId,
+  teamId,
+  teamName,
+  tournamentName,
+  hasOnlyTwoTeams,
+}: LeaveTournamentButtonProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [extraMessage, setExtraMessage] = useState<string | null>(null);
+
+  function handleSuccess(result: LeaveTournamentResult) {
+    setDialogOpen(false);
+    setSuccessMessage(result.message);
+    if (result.tournamentStatus === 'CANCELLED') {
+      setExtraMessage('El torneo fue cancelado. Serás redirigido a la lista de torneos.');
+      setTimeout(() => {
+        window.location.href = '/torneos';
+      }, 2500);
+    } else {
+      setTimeout(() => {
+        window.location.reload();
+      }, 1500);
+    }
+  }
+
+  if (successMessage) {
+    return (
+      <div className="leave-success-state">
+        <p className="leave-success-msg" role="status">{successMessage}</p>
+        {extraMessage && <p className="leave-extra-msg" role="status">{extraMessage}</p>}
+        <style>{`
+          .leave-success-state { display: flex; flex-direction: column; gap: 0.4rem; }
+          .leave-success-msg { margin: 0; color: hsl(142 72% 65%); font-size: 0.84rem; }
+          .leave-extra-msg { margin: 0; color: hsl(45 96% 70%); font-size: 0.82rem; }
+        `}</style>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className="leave-tournament-btn"
+        onClick={() => setDialogOpen(true)}
+        aria-label={`Retirar equipo ${teamName} del torneo`}
+      >
+        <LogOut size={15} aria-hidden="true" />
+        Retirar equipo
+      </button>
+
+      {dialogOpen && (
+        <LeaveTournamentDialog
+          tournamentId={tournamentId}
+          teamId={teamId}
+          teamName={teamName}
+          tournamentName={tournamentName}
+          hasOnlyTwoTeams={hasOnlyTwoTeams}
+          onClose={() => setDialogOpen(false)}
+          onSuccess={handleSuccess}
+        />
+      )}
+
+      <style>{`
+        .leave-tournament-btn {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.45rem;
+          background: transparent;
+          border: 1px solid rgba(239, 68, 68, 0.3);
+          border-radius: 8px;
+          color: hsl(0 72% 68%);
+          padding: 0.5rem 0.875rem;
+          font-size: 0.84rem;
+          font-weight: 600;
+          cursor: pointer;
+          width: 100%;
+          justify-content: center;
+          min-height: 44px;
+          transition: border-color 0.15s, background 0.15s, color 0.15s;
+        }
+        .leave-tournament-btn:hover {
+          border-color: rgba(239, 68, 68, 0.6);
+          background: rgba(239, 68, 68, 0.08);
+          color: hsl(0 72% 78%);
+        }
+      `}</style>
+    </>
+  );
+}

--- a/apps/frontend/src/components/tournaments/LeaveTournamentDialog.tsx
+++ b/apps/frontend/src/components/tournaments/LeaveTournamentDialog.tsx
@@ -1,0 +1,362 @@
+/**
+ * LeaveTournamentDialog — modal de confirmación para retirar un equipo de un torneo.
+ *
+ * Decision Context:
+ * - Acción destructiva irreversible: se requiere checkbox de confirmación obligatorio
+ *   antes de habilitar el botón de retiro. Esto previene retiros accidentales.
+ * - Si el torneo tiene exactamente 2 equipos, se muestra un warning rojo adicional
+ *   porque el retiro dejaría 1 equipo y podría cancelar el torneo.
+ * - El motivo es opcional (textarea, max 500 chars) para registrar contexto histórico.
+ * - Las llamadas se hacen a /api/graphql-auth (proxy autenticado con cookie HttpOnly).
+ * - Post-acción exitosa: toast informativo + window.location.reload() para refrescar
+ *   el estado del torneo. Si el torneo fue cancelado, se muestra mensaje adicional.
+ * Previously fixed bugs: none relevant.
+ */
+
+import { useState } from 'react';
+import { AlertTriangle, Loader2, LogOut, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { LEAVE_TOURNAMENT, type LeaveTournamentResult } from '@/graphql/operations/tournaments';
+
+interface LeaveTournamentDialogProps {
+  tournamentId: string;
+  teamId: string;
+  teamName: string;
+  tournamentName: string;
+  /** True when only 2 teams remain — retiring would leave 1 and risk tournament cancellation. */
+  hasOnlyTwoTeams: boolean;
+  onClose: () => void;
+  onSuccess: (result: LeaveTournamentResult) => void;
+}
+
+export function LeaveTournamentDialog({
+  tournamentId,
+  teamId,
+  teamName,
+  tournamentName,
+  hasOnlyTwoTeams,
+  onClose,
+  onSuccess,
+}: LeaveTournamentDialogProps) {
+  const [reason, setReason] = useState('');
+  const [confirmed, setConfirmed] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleLeave() {
+    if (!confirmed || submitting) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/graphql-auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: LEAVE_TOURNAMENT,
+          variables: {
+            input: {
+              tournamentId,
+              teamId,
+              reason: reason.trim() || null,
+            },
+          },
+        }),
+      });
+
+      const payload = (await response.json()) as {
+        data?: { leaveTournament?: LeaveTournamentResult };
+        errors?: Array<{ message: string }>;
+      };
+
+      const graphQLError = payload.errors?.[0]?.message;
+      if (graphQLError) {
+        if (graphQLError.toLowerCase().includes('authentication required')) {
+          window.location.href = '/login';
+          return;
+        }
+        throw new Error(graphQLError);
+      }
+
+      const result = payload.data?.leaveTournament;
+      if (!result) throw new Error('Respuesta inesperada del servidor');
+      if (!result.success) throw new Error(result.message ?? 'No se pudo retirar el equipo');
+
+      onSuccess(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al retirar el equipo');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const confirmLabel = `Confirmo que quiero retirar al equipo "${teamName}" del torneo "${tournamentName}"`;
+
+  return (
+    <div className="leave-dialog-overlay" role="dialog" aria-modal="true" aria-labelledby="leave-dialog-title">
+      <div className="leave-dialog">
+        <div className="leave-dialog-header">
+          <h2 id="leave-dialog-title" className="leave-dialog-title">
+            Retirar equipo del torneo
+          </h2>
+          <button
+            type="button"
+            className="leave-dialog-close"
+            onClick={onClose}
+            aria-label="Cerrar"
+            disabled={submitting}
+          >
+            <X size={18} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="leave-dialog-body">
+          <div className="leave-warning" role="alert">
+            <AlertTriangle size={18} aria-hidden="true" />
+            <p>
+              Esta acción no se puede deshacer. Tu equipo será eliminado del torneo y todos los
+              miembros perderán su inscripción.
+            </p>
+          </div>
+
+          {hasOnlyTwoTeams && (
+            <div className="leave-warning leave-warning--critical" role="alert">
+              <AlertTriangle size={18} aria-hidden="true" />
+              <p>
+                Si retirás tu equipo, el torneo podría cancelarse porque quedaría solo 1 equipo
+                inscripto.
+              </p>
+            </div>
+          )}
+
+          <div className="leave-reason-group">
+            <label className="leave-label" htmlFor="leave-reason">
+              Motivo del retiro (opcional)
+            </label>
+            <textarea
+              id="leave-reason"
+              className="leave-reason-input"
+              placeholder="Ej: No podemos participar por conflictos de agenda"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              maxLength={500}
+              rows={3}
+              disabled={submitting}
+            />
+            <span className="leave-char-count">{reason.length}/500</span>
+          </div>
+
+          <label className="leave-confirm-label">
+            <input
+              type="checkbox"
+              className="leave-confirm-checkbox"
+              checked={confirmed}
+              onChange={(e) => setConfirmed(e.target.checked)}
+              disabled={submitting}
+            />
+            <span>{confirmLabel}</span>
+          </label>
+
+          {error && (
+            <p className="leave-error" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div className="leave-dialog-footer">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={submitting}
+            className="leave-btn-cancel"
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={handleLeave}
+            disabled={!confirmed || submitting}
+            className="leave-btn-confirm"
+          >
+            {submitting ? (
+              <Loader2 size={16} className="animate-spin" aria-hidden="true" />
+            ) : (
+              <LogOut size={16} aria-hidden="true" />
+            )}
+            Retirar equipo
+          </Button>
+        </div>
+      </div>
+
+      <style>{`
+        .leave-dialog-overlay {
+          position: fixed;
+          inset: 0;
+          background: rgba(7, 15, 31, 0.82);
+          backdrop-filter: blur(6px);
+          z-index: 200;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 1rem;
+        }
+        .leave-dialog {
+          background: hsl(220 55% 11%);
+          border: 1px solid rgba(255,255,255,0.1);
+          border-radius: 14px;
+          width: 100%;
+          max-width: 480px;
+          display: flex;
+          flex-direction: column;
+          gap: 0;
+          box-shadow: 0 24px 64px rgba(0,0,0,0.6);
+        }
+        .leave-dialog-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 1.25rem 1.5rem 1rem;
+          border-bottom: 1px solid rgba(255,255,255,0.08);
+        }
+        .leave-dialog-title {
+          margin: 0;
+          font-family: 'Bebas Neue', sans-serif;
+          font-size: 1.6rem;
+          letter-spacing: 0.04em;
+          color: white;
+        }
+        .leave-dialog-close {
+          background: transparent;
+          border: none;
+          color: hsl(215 20% 55%);
+          cursor: pointer;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          padding: 0.4rem;
+          border-radius: 6px;
+          min-width: 44px;
+          min-height: 44px;
+        }
+        .leave-dialog-close:hover { color: white; background: rgba(255,255,255,0.08); }
+        .leave-dialog-body {
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+          padding: 1.25rem 1.5rem;
+        }
+        .leave-warning {
+          display: flex;
+          gap: 0.6rem;
+          align-items: flex-start;
+          background: rgba(234, 179, 8, 0.1);
+          border: 1px solid rgba(234, 179, 8, 0.3);
+          border-radius: 8px;
+          padding: 0.85rem;
+          color: hsl(45 96% 70%);
+          font-size: 0.875rem;
+          line-height: 1.5;
+        }
+        .leave-warning p { margin: 0; }
+        .leave-warning--critical {
+          background: rgba(239, 68, 68, 0.1);
+          border-color: rgba(239, 68, 68, 0.35);
+          color: hsl(0 86% 78%);
+        }
+        .leave-reason-group {
+          display: flex;
+          flex-direction: column;
+          gap: 0.4rem;
+        }
+        .leave-label {
+          font-size: 0.84rem;
+          color: hsl(215 20% 65%);
+          font-weight: 600;
+        }
+        .leave-reason-input {
+          background: hsl(220 55% 8%);
+          border: 1px solid rgba(255,255,255,0.12);
+          border-radius: 8px;
+          color: white;
+          font-size: 0.875rem;
+          line-height: 1.5;
+          padding: 0.65rem 0.8rem;
+          resize: vertical;
+          min-height: 80px;
+          outline: none;
+          font-family: inherit;
+        }
+        .leave-reason-input:focus { border-color: rgba(246,164,0,0.4); }
+        .leave-reason-input:disabled { opacity: 0.6; }
+        .leave-char-count { font-size: 0.78rem; color: hsl(215 20% 45%); text-align: right; }
+        .leave-confirm-label {
+          display: flex;
+          align-items: flex-start;
+          gap: 0.65rem;
+          cursor: pointer;
+          color: hsl(215 20% 78%);
+          font-size: 0.875rem;
+          line-height: 1.5;
+        }
+        .leave-confirm-checkbox {
+          flex-shrink: 0;
+          margin-top: 0.15rem;
+          width: 18px;
+          height: 18px;
+          accent-color: hsl(35 100% 48%);
+          cursor: pointer;
+        }
+        .leave-error {
+          margin: 0;
+          color: hsl(0 72% 70%);
+          font-size: 0.85rem;
+          border: 1px solid rgba(239,68,68,0.2);
+          background: rgba(239,68,68,0.08);
+          border-radius: 6px;
+          padding: 0.6rem 0.75rem;
+        }
+        .leave-dialog-footer {
+          display: flex;
+          align-items: center;
+          justify-content: flex-end;
+          gap: 0.75rem;
+          padding: 1rem 1.5rem 1.25rem;
+          border-top: 1px solid rgba(255,255,255,0.08);
+        }
+        .leave-btn-cancel {
+          min-height: 44px;
+          font-family: 'Barlow Condensed', sans-serif;
+          font-weight: 700;
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+        }
+        .leave-btn-confirm {
+          min-height: 44px;
+          background: hsl(0 72% 51%);
+          color: white;
+          font-family: 'Barlow Condensed', sans-serif;
+          font-weight: 700;
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+          display: inline-flex;
+          align-items: center;
+          gap: 0.45rem;
+        }
+        .leave-btn-confirm:hover:not(:disabled) { background: hsl(0 72% 45%); }
+        .leave-btn-confirm:disabled { opacity: 0.45; cursor: not-allowed; }
+        @media (max-width: 480px) {
+          .leave-dialog { border-radius: 10px; }
+          .leave-dialog-header,
+          .leave-dialog-body,
+          .leave-dialog-footer { padding-left: 1rem; padding-right: 1rem; }
+          .leave-dialog-footer { flex-direction: column-reverse; }
+          .leave-btn-cancel,
+          .leave-btn-confirm { width: 100%; justify-content: center; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/tournaments/TournamentRegistrationForm.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentRegistrationForm.tsx
@@ -9,10 +9,14 @@ import {
   type TournamentPlayer,
   type TournamentTeam,
   type TournamentTeamRegistrationResult,
+  type TournamentStatus,
 } from '@/graphql/operations/tournaments';
+import { LeaveTournamentButton } from './LeaveTournamentButton';
 
 interface TournamentRegistrationFormProps {
   tournamentId: string;
+  tournamentName: string;
+  tournamentStatus: TournamentStatus;
   isAuthenticated: boolean;
   canRegister: boolean;
   playersPerTeam: number;
@@ -71,6 +75,8 @@ async function postTournamentMutation(
 
 export function TournamentRegistrationForm({
   tournamentId,
+  tournamentName,
+  tournamentStatus,
   isAuthenticated,
   canRegister,
   playersPerTeam,
@@ -221,6 +227,7 @@ export function TournamentRegistrationForm({
 
   if (captainTeam) {
     const removablePlayers = captainTeam.players.filter((player) => player.id !== captainTeam.captainId);
+    const canLeave = tournamentStatus === 'REGISTRATION';
 
     return (
       <div className="detail-register-form">
@@ -269,6 +276,16 @@ export function TournamentRegistrationForm({
 
         {error && <p className="detail-form-error" role="alert">{error}</p>}
         {message && <p className="detail-form-message" role="status">{message}</p>}
+
+        {canLeave && (
+          <LeaveTournamentButton
+            tournamentId={tournamentId}
+            teamId={captainTeam.id}
+            teamName={captainTeam.name}
+            tournamentName={tournamentName}
+            hasOnlyTwoTeams={teams.length === 2}
+          />
+        )}
       </div>
     );
   }

--- a/apps/frontend/src/graphql/operations/tournaments.graphql
+++ b/apps/frontend/src/graphql/operations/tournaments.graphql
@@ -337,3 +337,12 @@ mutation RemoveTournamentTeamMember($input: TournamentTeamMemberInput!) {
     }
   }
 }
+
+mutation LeaveTournament($input: LeaveTournamentInput!) {
+  leaveTournament(input: $input) {
+    success
+    message
+    tournamentStatus
+    remainingTeams
+  }
+}

--- a/apps/frontend/src/graphql/operations/tournaments.ts
+++ b/apps/frontend/src/graphql/operations/tournaments.ts
@@ -497,3 +497,27 @@ export const REMOVE_TOURNAMENT_TEAM_MEMBER = /* GraphQL */ `
     }
   }
 `;
+
+export interface LeaveTournamentInput {
+  tournamentId: string;
+  teamId: string;
+  reason?: string | null;
+}
+
+export interface LeaveTournamentResult {
+  success: boolean;
+  message: string;
+  tournamentStatus: string | null;
+  remainingTeams: number | null;
+}
+
+export const LEAVE_TOURNAMENT = /* GraphQL */ `
+  mutation LeaveTournament($input: LeaveTournamentInput!) {
+    leaveTournament(input: $input) {
+      success
+      message
+      tournamentStatus
+      remainingTeams
+    }
+  }
+`;

--- a/apps/frontend/src/pages/torneos/[id].astro
+++ b/apps/frontend/src/pages/torneos/[id].astro
@@ -199,6 +199,8 @@ for (const match of tournament?.fixtureMatches ?? []) {
               <TournamentRegistrationForm
                 client:load
                 tournamentId={tournament.id}
+                tournamentName={tournament.name}
+                tournamentStatus={tournament.status}
                 isAuthenticated={isAuthenticated}
                 canRegister={canRegister}
                 playersPerTeam={tournament.playersPerTeam}

--- a/docs/TESTING-abandonar-torneo.md
+++ b/docs/TESTING-abandonar-torneo.md
@@ -1,0 +1,218 @@
+# TESTING — Abandonar Torneo (US #47)
+
+> Rama: `abandonar-torneo`
+> Última actualización: 2026-05-30
+
+## Pre-condición
+
+- **La migración DB debe estar aplicada** (ver sección al final).
+- Se necesitan al menos dos cuentas de jugador (ej. `playerMateo`, `playerRicardo`).
+- Se necesita al menos un torneo en estado `REGISTRATION` con equipos inscritos.
+
+---
+
+## Casos de Validación (backend)
+
+### 1 — Retiro exitoso (caso base)
+**Setup**: Torneo en REGISTRATION con 3+ equipos. Usuario autenticado es capitán de un equipo.
+**Acción**: `leaveTournament({ tournamentId, teamId })`
+**Resultado esperado**: `{ success: true, message: "Tu equipo fue retirado del torneo exitosamente", tournamentStatus: "REGISTRATION", remainingTeams: N-1 }`
+**Verificar DB**: `tournamentTeams.status = 'withdrawn'`, `withdrawnAt` con timestamp, miembros eliminados de `tournamentTeamMembers`.
+
+### 2 — Miembro no-capitán intenta retirar
+**Setup**: Usuario autenticado es miembro del equipo pero NO capitán.
+**Acción**: `leaveTournament({ tournamentId, teamId })`
+**Resultado esperado**: Error → `"Solo el capitán (administrador) del equipo puede retirarlo del torneo"`
+
+### 3 — Usuario sin equipo en el torneo
+**Setup**: Usuario autenticado no tiene ningún equipo inscripto en el torneo.
+**Acción**: `leaveTournament({ tournamentId, teamId: uuidDeOtroEquipo })`
+**Resultado esperado**: Error → `"Solo el capitán (administrador) del equipo puede retirarlo del torneo"`
+
+### 4 — Torneo en estado `in_progress`
+**Setup**: Torneo en estado `IN_PROGRESS`.
+**Acción**: `leaveTournament({ tournamentId, teamId })`
+**Resultado esperado**: Error → `"No se puede abandonar un torneo en curso. El torneo ya comenzó y los partidos están programados"`
+
+### 5 — Torneo `completed`
+**Setup**: Torneo en estado `COMPLETED`.
+**Acción**: `leaveTournament({ tournamentId, teamId })`
+**Resultado esperado**: Error → `"El torneo ya finalizó"`
+
+### 6 — Torneo `cancelled`
+**Setup**: Torneo en estado `CANCELLED`.
+**Acción**: `leaveTournament({ tournamentId, teamId })`
+**Resultado esperado**: Error → `"El torneo fue cancelado"`
+
+### 7 — Equipo ya fue retirado
+**Setup**: Equipo con `status = 'withdrawn'` (ya retirado previamente).
+**Acción**: `leaveTournament({ tournamentId, teamId })`
+**Resultado esperado**: Error → `"Este equipo ya fue retirado del torneo"`
+
+### 8 — `tournamentId` inexistente
+**Setup**: UUID válido que no corresponde a ningún torneo.
+**Acción**: `leaveTournament({ tournamentId: "uuid-inexistente", teamId })`
+**Resultado esperado**: Error → `"El torneo no existe"`
+
+### 9 — `teamId` inexistente
+**Setup**: UUID válido que no corresponde a ningún equipo.
+**Acción**: `leaveTournament({ tournamentId, teamId: "uuid-inexistente" })`
+**Resultado esperado**: Error → `"El equipo no existe"`
+
+### 10 — `teamId` de otro torneo
+**Setup**: `teamId` válido pero pertenece a un torneo diferente al `tournamentId`.
+**Acción**: `leaveTournament({ tournamentId: torneo1.id, teamId: equipoTorneo2.id })`
+**Resultado esperado**: Error → `"Este equipo no pertenece a este torneo"`
+
+---
+
+## Casos de Consecuencias (post-retiro)
+
+### 11 — Retiro con 4 equipos → torneo sigue normal
+**Setup**: Torneo con 4 equipos activos. Capitán retira su equipo.
+**Resultado esperado**: `{ success: true, remainingTeams: 3, tournamentStatus: "REGISTRATION" }`
+**Verificar**: Torneo sigue en REGISTRATION, conteo muestra 3 equipos.
+
+### 12 — Retiro con 2 equipos → warning (1 queda)
+**Setup**: Torneo con exactamente 2 equipos activos. Capitán retira su equipo.
+**Resultado esperado**: 
+```json
+{
+  "success": true,
+  "remainingTeams": 1,
+  "tournamentStatus": "REGISTRATION",
+  "message": "Atención: el torneo tiene solo 1 equipo inscripto..."
+}
+```
+**Verificar**: Torneo NO se cancela, sigue en REGISTRATION.
+
+### 13 — Retiro del último equipo → torneo se cancela automáticamente
+**Setup**: Torneo con 1 equipo activo (o los demás ya están withdrawn). Capitán retira su equipo.
+**Resultado esperado**: `{ success: true, remainingTeams: 0, tournamentStatus: "CANCELLED", message: "El torneo fue cancelado porque no quedan equipos inscriptos" }`
+**Verificar DB**: `tournaments.status = 'cancelled'`.
+
+### 14 — Miembros del equipo eliminados de tournamentTeamMembers
+**Setup**: Equipo con 3 miembros + capitán.
+**Acción**: Capitán retira el equipo.
+**Verificar DB**: `tournamentTeamMembers` no tiene filas con `teamId` del equipo retirado.
+
+---
+
+## Casos de UI
+
+### 15 — Botón visible para capitán en torneo REGISTRATION
+**Setup**: Usuario logueado es capitán de un equipo inscripto. Torneo en REGISTRATION.
+**Acción**: Abrir `/torneos/{id}`.
+**Resultado esperado**: Botón "Retirar equipo" visible en el panel lateral del capitán.
+
+### 16 — Botón NO visible para miembro no-capitán
+**Setup**: Usuario logueado es miembro (no capitán) de un equipo inscripto.
+**Acción**: Abrir `/torneos/{id}`.
+**Resultado esperado**: Botón "Retirar equipo" NO aparece (ni en el panel del capitán, porque el usuario no es capitán).
+
+### 17 — Botón NO visible si torneo en IN_PROGRESS o COMPLETED
+**Setup**: Usuario es capitán de un equipo en un torneo con status `IN_PROGRESS`.
+**Acción**: Abrir `/torneos/{id}`.
+**Resultado esperado**: Botón "Retirar equipo" NO aparece (`canLeave = tournamentStatus === 'REGISTRATION'`).
+
+### 18 — Modal de confirmación con checkbox obligatorio
+**Setup**: Capitán hace clic en "Retirar equipo".
+**Resultado esperado**: 
+- Modal abre con título "Retirar equipo del torneo".
+- Warning en amarillo sobre acción irreversible.
+- Checkbox de confirmación desmarcado.
+- Botón "Retirar equipo" deshabilitado hasta tildar checkbox.
+- Botón "Cancelar" siempre habilitado.
+
+### 19 — Warning rojo extra si quedan 2 equipos
+**Setup**: Torneo con exactamente 2 equipos activos. Capitán abre modal.
+**Resultado esperado**: Warning rojo adicional: "Si retirás tu equipo, el torneo podría cancelarse porque quedaría solo 1 equipo inscripto."
+
+### 20 — Toast de confirmación después de retiro exitoso
+**Setup**: Capitán completa el retiro (tilda checkbox, hace clic en "Retirar equipo").
+**Resultado esperado**: Mensaje de éxito en verde. Página recarga automáticamente (~1.5s).
+
+### 21 — Equipo desaparece del listado después del retiro
+**Setup**: Después de retiro exitoso y recarga.
+**Resultado esperado**: El equipo retirado ya no aparece en la sección "Equipos inscriptos" del detalle del torneo.
+
+### 22 — Conteo de equipos se actualiza
+**Setup**: Después del retiro exitoso.
+**Resultado esperado**: El contador "X/Y equipos inscriptos" refleja el nuevo conteo (N-1).
+
+---
+
+## Casos de Seguridad
+
+### 23 — Mutation sin auth → 401
+**Setup**: Request sin cookie de sesión / sin Authorization header.
+**Acción**: POST a `/api/graphql-auth` con mutation `leaveTournament`.
+**Resultado esperado**: HTTP 401 o GraphQL error `"Authentication required"`.
+
+### 24 — RLS: capitán de otro equipo no puede retirar este equipo
+**Setup**: Usuario autenticado (UserA) es capitán del equipoA. Intenta retirar equipoB cuyo capitán es UserB.
+**Acción**: `leaveTournament({ tournamentId, teamId: equipoB.id })`
+**Resultado esperado**: Error → `"Solo el capitán (administrador) del equipo puede retirarlo del torneo"`
+**Verificar**: La RLS policy de UPDATE en `tournamentTeams` deniega el acceso. El service lo captura antes con la validación 5 de todas formas.
+
+### 25 — Input malformado (UUID inválido) → error de validación
+**Acción**: `leaveTournament({ tournamentId: "not-a-uuid", teamId: "also-not" })`
+**Resultado esperado**: `{ success: false, message: "Datos invalidos: tournamentId invalido; teamId invalido" }`
+
+---
+
+## Casos Responsive (mobile)
+
+### 26 — Modal funciona en viewport 375px
+**Setup**: DevTools → 375px width. Abrir modal de confirmación.
+**Resultado esperado**: Modal muestra sin overflow horizontal. Botones apilados verticalmente y ocupan ancho completo (`flex-direction: column-reverse`).
+
+### 27 — Touch targets >= 44px
+**Setup**: Inspeccionar elementos en DevTools.
+**Resultado esperado**: Botón "Retirar equipo" tiene `min-height: 44px`. Botones del modal también (`min-height: 44px`).
+
+### 28 — Sin scroll horizontal en toda la página
+**Setup**: 375px viewport.
+**Resultado esperado**: No hay scroll horizontal en ninguna parte del detalle del torneo.
+
+---
+
+## Migración DB Requerida
+
+**BLOQUEANTE**: Esta feature NO funciona hasta que se aplique la siguiente migración en Supabase.
+
+### Pasos (via Supabase MCP):
+1. Autenticar Supabase MCP con token de acceso personal.
+2. Aplicar `mcp__supabase__apply_migration` con el siguiente SQL:
+
+```sql
+-- Agrega soft-delete a tournamentTeams
+ALTER TABLE "tournamentTeams"
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'active'
+    CONSTRAINT "tournamentTeams_status_check"
+    CHECK (status IN ('active', 'withdrawn')),
+  ADD COLUMN IF NOT EXISTS "withdrawnAt" timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS "withdrawalReason" text NULL;
+
+-- Índice para consultas eficientes de equipos activos por torneo
+CREATE INDEX IF NOT EXISTS "idx_tournamentTeams_tournamentId_status_active"
+  ON "tournamentTeams" ("tournamentId", status)
+  WHERE status = 'active';
+```
+
+3. Verificar RLS en `tournamentTeams`:
+   - `SELECT`: public read (o autenticado según política existente)
+   - `UPDATE WHERE captainId = auth.uid()`: permite soft-delete al capitán
+   - `DELETE WHERE captainId = auth.uid()`: no necesario (usamos soft delete)
+
+4. Verificar RLS en `tournamentTeamMembers`:
+   - `DELETE WHERE teamId IN (SELECT id FROM tournamentTeams WHERE captainId = auth.uid())`: permite al capitán borrar miembros de su equipo
+
+---
+
+## Notas
+
+- El retiro es un **soft delete**: el registro `tournamentTeams` queda con `status='withdrawn'` y se registra `withdrawnAt` + `withdrawalReason`.
+- Los `tournamentTeamMembers` se borran (hard delete) ya que la inscripción queda invalidada.
+- La UI filtra equipos retirados del listado (solo muestra `status='active'` via `toTournament()` en el service).
+- Si todos los equipos se retiran, el torneo cambia automáticamente a `CANCELLED`.

--- a/docs/prompts/k7p2n4qx-prompt-log.md
+++ b/docs/prompts/k7p2n4qx-prompt-log.md
@@ -1,0 +1,16 @@
+# Prompt Log
+
+- Timestamp: 2026-05-30 10:35:00
+- Task ID: k7p2n4qx
+
+## User Prompt
+
+> Sos un desarrollador senior fullstack especializado en Astro 6, GraphQL y Supabase. Necesito que implementes la User Story #47 "Abandonar torneo" en el proyecto sumate-ya con lógica extremadamente estricta en validaciones y permisos.
+>
+> [Se incluyen subtareas completas: mutation leaveTournament, validaciones de capitán, estados del torneo, soft delete, cancelación automática, UI con dialog de confirmación, 20+ casos de testing, typecheck limpio. Restricciones: rama abandonar-torneo, RLS estricto, egress prevention, lucide-react, español en UI.]
+
+## Agent Main Actions
+
+- Implementó la mutation `leaveTournament` completa en backend (schema GraphQL, repository con soft delete, service con 8 validaciones estrictas en orden, resolver con Zod) y corrió codegen para generar tipos TypeScript.
+- Creó los componentes frontend `LeaveTournamentDialog.tsx` y `LeaveTournamentButton.tsx` con confirmación via checkbox obligatorio, warning extra para 2 equipos, y los integró en `TournamentRegistrationForm.tsx` y `[id].astro`.
+- Verificó typecheck (`turbo typecheck --force`) con 0 errores, documentó 28 casos de testing en `docs/TESTING-abandonar-torneo.md`, e identificó que la migración DB (columnas `status`, `withdrawnAt`, `withdrawalReason` en `tournamentTeams`) requiere autenticación de Supabase MCP para aplicarse.

--- a/docs/prompts/p5n8k2wq-prompt-log.md
+++ b/docs/prompts/p5n8k2wq-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-05-30 11:30:00
+- Task ID: p5n8k2wq
+
+## User Prompt
+
+> listo (x2) — confirmación de que el token de Supabase MCP fue regenerado y el servidor reconectado, para aplicar la migración de DB pendiente de la feature abandonar-torneo (issue #47).
+
+## Agent Main Actions
+
+- Actualizó el token de acceso de Supabase MCP en `.mcp.json` con el nuevo token generado (`sbp_****...57af`) reemplazando el anterior que estaba expirado.
+- Aplicó la migración `add_tournament_team_withdrawal_fields` via Supabase MCP: agregó columnas `status` (TEXT NOT NULL DEFAULT 'active' con CHECK), `withdrawnAt` (TIMESTAMPTZ nullable) y `withdrawalReason` (TEXT nullable con CHECK max 500 chars) a la tabla `tournamentTeams`, más índice `(tournamentId, status)`.
+- Verificó la migración con `execute_sql` (3 columnas presentes y correctas) y corrió `turbo typecheck --force` obteniendo 0 errores.


### PR DESCRIPTION
Agrega la mutación leaveTournament con 8 validaciones estrictas (auth, existencia de torneo/equipo, capitán, estado REGISTRATION, no retirado, sin fixtures jugados). Soft delete del equipo con status='withdrawn', hard delete de miembros, y cancelación automática del torneo si quedan 0 equipos. Frontend con LeaveTournamentDialog (checkbox obligatorio) integrado en la página de detalle del torneo. Migración DB: columnas status/withdrawnAt/withdrawalReason en tournamentTeams con índice (tournamentId, status).