### PR TITLE
Filtro de Torneos

### DIFF
--- a/apps/backend/src/graphql/generated/graphql.ts
+++ b/apps/backend/src/graphql/generated/graphql.ts
@@ -769,6 +769,11 @@ export type QueryTournamentEligiblePlayersArgs = {
   tournamentId: Scalars['ID']['input'];
 };
 
+
+export type QueryTournamentsArgs = {
+  filters?: InputMaybe<TournamentFilters>;
+};
+
 export type RegisterTournamentTeamInput = {
   name: Scalars['String']['input'];
   tournamentId: Scalars['ID']['input'];
@@ -885,6 +890,15 @@ export type TournamentClub = {
   lng?: Maybe<Scalars['Float']['output']>;
   name: Scalars['String']['output'];
   zone?: Maybe<Scalars['String']['output']>;
+};
+
+export type TournamentFilters = {
+  dateFrom?: InputMaybe<Scalars['String']['input']>;
+  dateTo?: InputMaybe<Scalars['String']['input']>;
+  format?: InputMaybe<MatchFormat>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<TournamentStatus>;
+  zone?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TournamentFixtureMatch = {
@@ -1149,6 +1163,7 @@ export type ResolversTypes = ResolversObject<{
   TimeStatus: TimeStatus;
   Tournament: ResolverTypeWrapper<Tournament>;
   TournamentClub: ResolverTypeWrapper<TournamentClub>;
+  TournamentFilters: TournamentFilters;
   TournamentFixtureMatch: ResolverTypeWrapper<TournamentFixtureMatch>;
   TournamentPlayer: ResolverTypeWrapper<TournamentPlayer>;
   TournamentScheduleSlotInput: TournamentScheduleSlotInput;
@@ -1230,6 +1245,7 @@ export type ResolversParentTypes = ResolversObject<{
   TeamMember: TeamMember;
   Tournament: Tournament;
   TournamentClub: TournamentClub;
+  TournamentFilters: TournamentFilters;
   TournamentFixtureMatch: TournamentFixtureMatch;
   TournamentPlayer: TournamentPlayer;
   TournamentScheduleSlotInput: TournamentScheduleSlotInput;
@@ -1606,7 +1622,7 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   slotImpactPreview?: Resolver<ResolversTypes['SlotImpactPreview'], ParentType, ContextType, RequireFields<QuerySlotImpactPreviewArgs, 'slotIds'>>;
   tournament?: Resolver<Maybe<ResolversTypes['Tournament']>, ParentType, ContextType, RequireFields<QueryTournamentArgs, 'id'>>;
   tournamentEligiblePlayers?: Resolver<Array<ResolversTypes['TournamentPlayer']>, ParentType, ContextType, RequireFields<QueryTournamentEligiblePlayersArgs, 'tournamentId'>>;
-  tournaments?: Resolver<Array<ResolversTypes['Tournament']>, ParentType, ContextType>;
+  tournaments?: Resolver<Array<ResolversTypes['Tournament']>, ParentType, ContextType, Partial<QueryTournamentsArgs>>;
 }>;
 
 export type ScheduleSlotResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['ScheduleSlot'] = ResolversParentTypes['ScheduleSlot']> = ResolversObject<{

--- a/apps/backend/src/graphql/resolvers/domains/tournament.ts
+++ b/apps/backend/src/graphql/resolvers/domains/tournament.ts
@@ -73,7 +73,7 @@ function invalidLeaveResult(message: string) {
 }
 
 const Query: QueryResolvers = {
-  tournaments: async () => tournamentService.listRegistrationTournaments({}),
+  tournaments: async (_parent, args) => tournamentService.listTournaments({}, args.filters),
 
   tournament: async (_parent, args) => {
     const parsed = z.string().regex(UUID_REGEX, 'id invalido').safeParse(args.id);

--- a/apps/backend/src/graphql/schema/tournament.graphql
+++ b/apps/backend/src/graphql/schema/tournament.graphql
@@ -99,6 +99,15 @@ input CreateTournamentInput {
   schedule: [TournamentScheduleSlotInput!]!
 }
 
+input TournamentFilters {
+  status: TournamentStatus
+  format: MatchFormat
+  zone: String
+  dateFrom: String
+  dateTo: String
+  search: String
+}
+
 type CreateTournamentResult {
   success: Boolean!
   tournamentId: ID
@@ -131,7 +140,7 @@ input TournamentTeamMemberInput {
 }
 
 extend type Query {
-  tournaments: [Tournament!]!
+  tournaments(filters: TournamentFilters): [Tournament!]!
   tournament(id: ID!): Tournament
   tournamentEligiblePlayers(tournamentId: ID!, search: String): [TournamentPlayer!]!
 }

--- a/apps/backend/src/repositories/tournamentRepository.ts
+++ b/apps/backend/src/repositories/tournamentRepository.ts
@@ -249,6 +249,15 @@ export interface TournamentMemberPlayerRow {
   } | null;
 }
 
+export interface TournamentFilterOptions {
+  status?: string;
+  format?: string;
+  zone?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  search?: string;
+}
+
 function isMissingTournamentRpcError(message: string): boolean {
   return (
     message.includes('Could not find the function public.create_tournament_with_fixture') ||
@@ -504,22 +513,144 @@ export async function getTournamentById(
   return data as unknown as TournamentRow;
 }
 
-export async function getRegistrationTournaments(
+export async function getTournamentsWithFilters(
+  filters: TournamentFilterOptions = {},
   client: SupabaseClient = supabase,
 ): Promise<TournamentRow[]> {
-  const { data, error } = await client
+  if (filters.search) {
+    return getTournamentsWithSearch(filters, client);
+  }
+
+  const clubJoin = filters.zone ? `clubs!inner(${TOURNAMENT_CLUB_COLUMNS})` : `clubs(${TOURNAMENT_CLUB_COLUMNS})`;
+
+  let query = client
     .from('tournaments')
-    .select(`${TOURNAMENT_COLUMNS}, clubs(${TOURNAMENT_CLUB_COLUMNS}), registeredTeams:tournamentTeams(count)`)
-    .eq('status', 'registration')
-    .order('startDate', { ascending: true })
-    .order('createdAt', { ascending: false });
+    .select(`${TOURNAMENT_COLUMNS}, ${clubJoin}, registeredTeams:tournamentTeams(count)`);
+
+  query = query.eq('status', filters.status || 'registration');
+
+  if (filters.format) {
+    query = query.eq('format', filters.format);
+  }
+
+  if (filters.zone) {
+    query = query.eq('clubs.zone', filters.zone);
+  }
+
+  if (filters.dateFrom) {
+    query = query.gte('startDate', filters.dateFrom);
+  }
+
+  if (filters.dateTo) {
+    query = query.lte('startDate', filters.dateTo);
+  }
+
+  query = query.order('startDate', { ascending: true }).order('createdAt', { ascending: false });
+
+  const { data, error } = await query;
 
   if (error) {
-    console.error('[tournamentRepository.getRegistrationTournaments] Supabase error:', error.message);
+    console.error('[tournamentRepository.getTournamentsWithFilters] Supabase error:', error.message);
     throw new Error(error.message);
   }
 
   return (data as unknown as TournamentRow[]) ?? [];
+}
+
+async function getTournamentsWithSearch(
+  filters: TournamentFilterOptions,
+  client: SupabaseClient,
+): Promise<TournamentRow[]> {
+  const searchTerm = `%${filters.search}%`;
+  const baseStatus = filters.status || 'registration';
+
+  let nameQuery = client
+    .from('tournaments')
+    .select(`${TOURNAMENT_COLUMNS}, clubs(${TOURNAMENT_CLUB_COLUMNS}), registeredTeams:tournamentTeams(count)`)
+    .eq('status', baseStatus);
+
+  if (filters.format) {
+    nameQuery = nameQuery.eq('format', filters.format);
+  }
+  if (filters.dateFrom) {
+    nameQuery = nameQuery.gte('startDate', filters.dateFrom);
+  }
+  if (filters.dateTo) {
+    nameQuery = nameQuery.lte('startDate', filters.dateTo);
+  }
+
+  let clubQuery = client
+    .from('tournaments')
+    .select(`${TOURNAMENT_COLUMNS}, clubs!inner(${TOURNAMENT_CLUB_COLUMNS}), registeredTeams:tournamentTeams(count)`)
+    .eq('status', baseStatus);
+
+  if (filters.format) {
+    clubQuery = clubQuery.eq('format', filters.format);
+  }
+  if (filters.dateFrom) {
+    clubQuery = clubQuery.gte('startDate', filters.dateFrom);
+  }
+  if (filters.dateTo) {
+    clubQuery = clubQuery.lte('startDate', filters.dateTo);
+  }
+
+  let q1 = nameQuery.ilike('name', searchTerm).order('startDate', { ascending: true }).order('createdAt', { ascending: false });
+  let q2 = clubQuery.ilike('clubs.name', searchTerm).order('startDate', { ascending: true }).order('createdAt', { ascending: false });
+
+  if (filters.zone) {
+    let nameZoneQuery = client
+      .from('tournaments')
+      .select(`${TOURNAMENT_COLUMNS}, clubs!inner(${TOURNAMENT_CLUB_COLUMNS}), registeredTeams:tournamentTeams(count)`)
+      .eq('status', baseStatus);
+
+    if (filters.format) {
+      nameZoneQuery = nameZoneQuery.eq('format', filters.format);
+    }
+    if (filters.dateFrom) {
+      nameZoneQuery = nameZoneQuery.gte('startDate', filters.dateFrom);
+    }
+    if (filters.dateTo) {
+      nameZoneQuery = nameZoneQuery.lte('startDate', filters.dateTo);
+    }
+
+    q1 = nameZoneQuery
+      .ilike('name', searchTerm)
+      .eq('clubs.zone', filters.zone)
+      .order('startDate', { ascending: true })
+      .order('createdAt', { ascending: false });
+    q2 = q2.eq('clubs.zone', filters.zone);
+  }
+
+  const [nameResult, clubResult] = await Promise.all([q1, q2]);
+
+  if (nameResult.error) {
+    throw new Error(`Failed to fetch tournaments by name: ${nameResult.error.message}`);
+  }
+  if (clubResult.error) {
+    throw new Error(`Failed to fetch tournaments by club: ${clubResult.error.message}`);
+  }
+
+  const tournamentMap = new Map<string, TournamentRow>();
+  for (const tournament of (nameResult.data as unknown as TournamentRow[]) ?? []) {
+    tournamentMap.set(tournament.id, tournament);
+  }
+  for (const tournament of (clubResult.data as unknown as TournamentRow[]) ?? []) {
+    if (!tournamentMap.has(tournament.id)) {
+      tournamentMap.set(tournament.id, tournament);
+    }
+  }
+
+  return Array.from(tournamentMap.values()).sort((a, b) => {
+    const byStartDate = (a.startDate ?? '').localeCompare(b.startDate ?? '');
+    if (byStartDate !== 0) return byStartDate;
+    return (b.createdAt ?? '').localeCompare(a.createdAt ?? '');
+  });
+}
+
+export async function getRegistrationTournaments(
+  client: SupabaseClient = supabase,
+): Promise<TournamentRow[]> {
+  return getTournamentsWithFilters({ status: 'registration' }, client);
 }
 
 export async function getTournamentTeams(
@@ -880,6 +1011,7 @@ export const tournamentRepository = {
   joinTournamentRpc,
   insertFixtureMatches,
   getTournamentById,
+  getTournamentsWithFilters,
   getRegistrationTournaments,
   getTournamentTeams,
   getTournamentMemberPlayerIds,

--- a/apps/backend/src/services/tournamentService.ts
+++ b/apps/backend/src/services/tournamentService.ts
@@ -23,6 +23,7 @@ import {
   type LeaveTournamentResult,
   type RegisterTournamentTeamInput,
   type Tournament,
+  type TournamentFilters,
   type TournamentFixtureMatch,
   type TournamentPlayer,
   type TournamentTeam,
@@ -32,6 +33,7 @@ import {
 import {
   tournamentRepository,
   type FixtureMatchRow,
+  type TournamentFilterOptions,
   type TournamentPlayerRow,
   type TournamentRow,
   type TournamentSlotRow,
@@ -66,6 +68,13 @@ const DB_TO_STATUS: Record<string, TournamentStatus> = {
   cancelled: TournamentStatus.Cancelled,
 };
 
+const STATUS_TO_DB: Record<TournamentStatus, string> = {
+  [TournamentStatus.Registration]: 'registration',
+  [TournamentStatus.InProgress]: 'in_progress',
+  [TournamentStatus.Completed]: 'completed',
+  [TournamentStatus.Cancelled]: 'cancelled',
+};
+
 const DB_TO_FIXTURE_STATUS: Record<string, FixtureMatchStatus> = {
   scheduled: FixtureMatchStatus.Scheduled,
   in_progress: FixtureMatchStatus.InProgress,
@@ -87,7 +96,6 @@ const FORMAT_ORDER: Record<string, number> = {
   '11v11': 4,
 };
 
-const TOURNAMENTS_REGISTRATION_CACHE_KEY = `${CACHE_PREFIX.TOURNAMENTS_LIST}:status:registration:v2`;
 const TOURNAMENT_DETAIL_CACHE_PREFIX = `${CACHE_PREFIX.TOURNAMENTS_LIST}:detail:v2:`;
 
 // =====================================================
@@ -211,6 +219,38 @@ function toTournament(row: TournamentRow): Tournament {
     teams: activeTeamRows.map(toTournamentTeam),
     fixtureMatches: fixtureMatches.map(toFixtureMatch),
   };
+}
+
+function dateOnly(value?: string | null): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return /^\d{4}-\d{2}-\d{2}/.test(trimmed) ? trimmed.slice(0, 10) : undefined;
+}
+
+function toTournamentFilterOptions(filters?: TournamentFilters | null): TournamentFilterOptions {
+  if (!filters) return { status: 'registration' };
+
+  return {
+    status: filters.status ? STATUS_TO_DB[filters.status] : 'registration',
+    format: filters.format ? FORMAT_TO_DB[filters.format] : undefined,
+    zone: filters.zone?.trim() || undefined,
+    dateFrom: dateOnly(filters.dateFrom),
+    dateTo: dateOnly(filters.dateTo),
+    search: filters.search?.trim() || undefined,
+  };
+}
+
+function getTournamentFiltersCacheKey(filters: TournamentFilterOptions): string {
+  const parts = [
+    `status:${filters.status || 'registration'}`,
+    filters.format ? `format:${filters.format}` : '',
+    filters.zone ? `zone:${filters.zone}` : '',
+    filters.dateFrom ? `from:${filters.dateFrom}` : '',
+    filters.dateTo ? `to:${filters.dateTo}` : '',
+    filters.search ? `search:${filters.search}` : '',
+  ].filter(Boolean);
+
+  return `${CACHE_PREFIX.TOURNAMENTS_LIST}:${parts.join('|')}:v3`;
 }
 
 async function normalizeAndValidateSchedule(
@@ -382,14 +422,24 @@ async function validateJoinRoster(
 // Service Functions
 // =====================================================
 
-export async function listRegistrationTournaments(_ctx: ServiceContext): Promise<Tournament[]> {
+export async function listTournaments(
+  _ctx: ServiceContext,
+  filters?: TournamentFilters | null,
+): Promise<Tournament[]> {
+  const filterOptions = toTournamentFilterOptions(filters);
+  const cacheKey = getTournamentFiltersCacheKey(filterOptions);
+
   const tournaments = await cacheGetOrSet<TournamentRow[]>(
-    TOURNAMENTS_REGISTRATION_CACHE_KEY,
-    () => tournamentRepository.getRegistrationTournaments(),
+    cacheKey,
+    () => tournamentRepository.getTournamentsWithFilters(filterOptions),
     CACHE_TTL.DYNAMIC_DATA,
   );
 
   return tournaments.map(toTournament);
+}
+
+export async function listRegistrationTournaments(ctx: ServiceContext): Promise<Tournament[]> {
+  return listTournaments(ctx, { status: TournamentStatus.Registration });
 }
 
 export async function getTournamentById(
@@ -765,6 +815,7 @@ export async function leaveTournament(
 }
 
 export const tournamentService = {
+  listTournaments,
   listRegistrationTournaments,
   getTournamentById,
   searchTournamentEligiblePlayers,

--- a/apps/frontend/src/components/tournaments/TournamentCard.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentCard.tsx
@@ -7,6 +7,8 @@
  * - Registration stays inline because there is no tournament detail page yet; a player can
  *   find a tournament and submit the team name without losing their place in the list.
  * - Mutations go through /api/graphql-auth so the HttpOnly session cookie can be forwarded.
+ * - In-progress tournaments can appear through filters, so the CTA distinguishes closed
+ *   registration from a genuinely full registration tournament.
  */
 
 import { type SyntheticEvent, useMemo, useState } from 'react';
@@ -16,6 +18,7 @@ import { Button } from '@/components/ui/button';
 import {
   JOIN_TOURNAMENT,
   type TournamentListItem,
+  type TournamentStatus,
   type TournamentTeamRegistrationResult,
 } from '@/graphql/operations/tournaments';
 import type { MatchFormat } from '@/graphql/operations/matches';
@@ -25,6 +28,13 @@ const FORMAT_LABELS: Record<MatchFormat, string> = {
   SEVEN_VS_SEVEN: '7v7',
   TEN_VS_TEN: '10v10',
   ELEVEN_VS_ELEVEN: '11v11',
+};
+
+const STATUS_LABELS: Record<TournamentStatus, string> = {
+  REGISTRATION: 'Inscripcion abierta',
+  IN_PROGRESS: 'En curso',
+  COMPLETED: 'Finalizado',
+  CANCELLED: 'Cancelado',
 };
 
 interface TournamentCardProps {
@@ -59,7 +69,16 @@ export function TournamentCard({
   const [success, setSuccess] = useState<string | null>(null);
 
   const registeredTeams = Math.min(tournament.registeredTeamsCount, tournament.teamCount);
-  const isFull = registeredTeams >= tournament.teamCount || tournament.status !== 'REGISTRATION';
+  const isRegistration = tournament.status === 'REGISTRATION';
+  const isAtCapacity = registeredTeams >= tournament.teamCount;
+  const registrationClosed = !isRegistration || isAtCapacity;
+  const actionLabel = !isRegistration
+    ? 'Inscripcion cerrada'
+    : isAtCapacity
+      ? 'Completo'
+      : isAuthenticated
+        ? 'Anotar equipo'
+        : 'Iniciar sesion para anotar';
   const progress = useMemo(
     () => (tournament.teamCount > 0 ? Math.round((registeredTeams / tournament.teamCount) * 100) : 0),
     [registeredTeams, tournament.teamCount],
@@ -74,7 +93,7 @@ export function TournamentCard({
 
     const name = teamName.trim();
     if (name.length < 2) {
-      setError('Ingresá al menos 2 caracteres para el equipo.');
+      setError('Ingresa al menos 2 caracteres para el equipo.');
       return;
     }
 
@@ -128,6 +147,9 @@ export function TournamentCard({
         <div className="mb-3 flex flex-wrap items-center gap-1.5">
           <Badge>{FORMAT_LABELS[tournament.format]}</Badge>
           <Badge variant="secondary">{tournament.playersPerTeam} por equipo</Badge>
+          <Badge variant={isRegistration ? 'default' : 'secondary'}>
+            {STATUS_LABELS[tournament.status]}
+          </Badge>
         </div>
 
         <div className="flex items-start gap-3">
@@ -145,7 +167,7 @@ export function TournamentCard({
                 <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
                 <span className="truncate">
                   {tournament.club.name}
-                  {tournament.club.zone && <span> · {tournament.club.zone}</span>}
+                  {tournament.club.zone && <span> - {tournament.club.zone}</span>}
                 </span>
               </p>
             )}
@@ -161,7 +183,7 @@ export function TournamentCard({
           </div>
           <div className="flex items-center gap-2">
             <Users className="h-4 w-4" aria-hidden="true" />
-            <span className={isFull ? 'text-muted-foreground' : 'font-medium text-foreground'}>
+            <span className={registrationClosed ? 'text-muted-foreground' : 'font-medium text-foreground'}>
               {registeredTeams}/{tournament.teamCount} equipos
             </span>
           </div>
@@ -174,7 +196,7 @@ export function TournamentCard({
           />
         </div>
 
-        {formOpen && !isFull ? (
+        {formOpen && !registrationClosed ? (
           <form onSubmit={handleSubmit} className="flex flex-col gap-2">
             <input
               value={teamName}
@@ -197,8 +219,8 @@ export function TournamentCard({
           <Button
             type="button"
             size="sm"
-            variant={isFull ? 'secondary' : 'default'}
-            disabled={isFull}
+            variant={registrationClosed ? 'secondary' : 'default'}
+            disabled={registrationClosed}
             onClick={() => {
               if (!isAuthenticated) {
                 window.location.href = '/login';
@@ -208,7 +230,7 @@ export function TournamentCard({
             }}
             className="w-full"
           >
-            {isFull ? 'Completo' : isAuthenticated ? 'Anotar equipo' : 'Iniciar sesión para anotar'}
+            {actionLabel}
           </Button>
         )}
 

--- a/apps/frontend/src/components/tournaments/TournamentFilters.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentFilters.tsx
@@ -1,0 +1,141 @@
+/**
+ * TournamentFilters - filter controls for tournament listing.
+ *
+ * Decision Context:
+ * - Adapted from MatchFilters with the tournament surface: search by name, status,
+ *   format, zone, and date range. Tournaments do not have a time-of-day filter.
+ * - Controlled by TournamentsView so list and map share the same state and URL params.
+ */
+
+import { useCallback } from 'react';
+import { Search, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { DatePicker } from '@/components/ui/date-picker';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import type { MatchFormat } from '@/graphql/operations/matches';
+import type { TournamentStatus } from '@/graphql/operations/tournaments';
+import {
+  DEFAULT_TOURNAMENT_FILTERS,
+  normalizeTournamentFilters,
+  toDateFilter,
+  toDateInputValue,
+  type ClientTournamentFilters,
+} from '@/lib/tournament-filtering';
+
+interface TournamentFiltersProps {
+  filters: ClientTournamentFilters;
+  onFiltersChange: (filters: ClientTournamentFilters) => void;
+}
+
+const STATUS_OPTIONS: { value: TournamentStatus; label: string }[] = [
+  { value: 'REGISTRATION', label: 'Inscripcion abierta' },
+  { value: 'IN_PROGRESS', label: 'En curso' },
+];
+
+const FORMAT_OPTIONS: { value: MatchFormat; label: string }[] = [
+  { value: 'FIVE_VS_FIVE', label: 'Futbol 5' },
+  { value: 'SEVEN_VS_SEVEN', label: 'Futbol 7' },
+  { value: 'TEN_VS_TEN', label: 'Futbol 10' },
+  { value: 'ELEVEN_VS_ELEVEN', label: 'Futbol 11' },
+];
+
+const ZONE_OPTIONS = ['Norte', 'Sur', 'Este', 'Oeste', 'Centro'].map((zone) => ({
+  value: zone,
+  label: zone,
+}));
+
+export function TournamentFilters({ filters, onFiltersChange }: TournamentFiltersProps) {
+  const updateFilters = useCallback(
+    (updates: Partial<ClientTournamentFilters>) => {
+      onFiltersChange(normalizeTournamentFilters({ ...filters, ...updates }));
+    },
+    [filters, onFiltersChange],
+  );
+
+  const clearFilters = useCallback(() => {
+    onFiltersChange(DEFAULT_TOURNAMENT_FILTERS);
+  }, [onFiltersChange]);
+
+  const hasActiveFilters =
+    filters.status !== DEFAULT_TOURNAMENT_FILTERS.status ||
+    filters.format ||
+    filters.zone ||
+    filters.dateFrom ||
+    filters.dateTo ||
+    filters.search;
+
+  return (
+    <div className="mb-6 rounded-lg border border-border bg-card/70 p-4 shadow-sm">
+      <div className="grid gap-3 md:grid-cols-[minmax(220px,1.4fr)_repeat(3,minmax(140px,1fr))]">
+        <div className="relative min-w-0">
+          <Search
+            aria-hidden="true"
+            className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            type="text"
+            aria-label="Buscar torneos"
+            placeholder="Buscar torneo o club"
+            value={filters.search || ''}
+            onChange={(event) => updateFilters({ search: event.target.value || undefined })}
+            className="pl-10"
+          />
+        </div>
+
+        <Select
+          aria-label="Estado"
+          value={filters.status || DEFAULT_TOURNAMENT_FILTERS.status}
+          placeholder="Estado"
+          options={STATUS_OPTIONS}
+          onValueChange={(value) =>
+            updateFilters({ status: (value as TournamentStatus) || undefined })
+          }
+        />
+
+        <Select
+          aria-label="Formato"
+          value={filters.format || ''}
+          placeholder="Formato"
+          options={FORMAT_OPTIONS}
+          onValueChange={(value) =>
+            updateFilters({ format: (value as MatchFormat) || undefined })
+          }
+        />
+
+        <Select
+          aria-label="Zona"
+          value={filters.zone || ''}
+          placeholder="Zona"
+          options={ZONE_OPTIONS}
+          onValueChange={(value) => updateFilters({ zone: value || undefined })}
+        />
+      </div>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(150px,1fr)_minmax(150px,1fr)_auto]">
+        <DatePicker
+          aria-label="Fecha desde"
+          value={toDateInputValue(filters.dateFrom)}
+          onValueChange={(value) => updateFilters({ dateFrom: toDateFilter(value) })}
+        />
+
+        <DatePicker
+          aria-label="Fecha hasta"
+          value={toDateInputValue(filters.dateTo)}
+          onValueChange={(value) => updateFilters({ dateTo: toDateFilter(value) })}
+        />
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={clearFilters}
+          disabled={!hasActiveFilters}
+          className="gap-2"
+        >
+          <X className="h-4 w-4" />
+          Limpiar
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/tournaments/TournamentList.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentList.tsx
@@ -3,34 +3,43 @@
  *
  * Decision Context:
  * - Public listing shells fetch tournaments from the GraphQL proxy after hydration.
- * - The backend already returns registration-only tournaments, but the client filters
- *   defensively after a successful registration because a full tournament can transition
- *   to IN_PROGRESS immediately.
+ * - Server-side filters are forwarded through tournaments(filters), while a small
+ *   client-side mirror keeps mocked responses and post-registration status transitions
+ *   aligned with the visible filter state.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AlertCircle, RefreshCw, Trophy } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { GET_TOURNAMENTS, type TournamentListItem } from '@/graphql/operations/tournaments';
+import {
+  DEFAULT_TOURNAMENT_FILTERS,
+  filterTournaments,
+  toServerTournamentFilters,
+  type ClientTournamentFilters,
+} from '@/lib/tournament-filtering';
 import { TournamentCard } from './TournamentCard';
 
 interface GetTournamentsPayload {
   tournaments: TournamentListItem[];
 }
 
-function keepRegistrationOnly(tournaments: TournamentListItem[]): TournamentListItem[] {
-  return tournaments.filter((tournament) => tournament.status === 'REGISTRATION');
-}
-
 interface TournamentListProps {
   isAuthenticated?: boolean;
+  filters?: ClientTournamentFilters;
 }
 
-export function TournamentList({ isAuthenticated = false }: TournamentListProps) {
+export function TournamentList({
+  isAuthenticated = false,
+  filters = DEFAULT_TOURNAMENT_FILTERS,
+}: TournamentListProps) {
   const [tournaments, setTournaments] = useState<TournamentListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
+
+  const serverFilters = useMemo(() => toServerTournamentFilters(filters), [filters]);
+  const serverFiltersKey = useMemo(() => JSON.stringify(serverFilters), [serverFilters]);
 
   useEffect(() => {
     let cancelled = false;
@@ -40,14 +49,14 @@ export function TournamentList({ isAuthenticated = false }: TournamentListProps)
     fetch('/api/graphql', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: GET_TOURNAMENTS }),
+      body: JSON.stringify({ query: GET_TOURNAMENTS, variables: { filters: serverFilters } }),
     })
       .then((response) => response.json())
       .then((payload: { data?: GetTournamentsPayload; errors?: Array<{ message: string }> }) => {
         if (cancelled) return;
         const graphQLError = payload.errors?.[0]?.message;
         if (graphQLError) throw new Error(graphQLError);
-        setTournaments(keepRegistrationOnly(payload.data?.tournaments ?? []));
+        setTournaments(filterTournaments(payload.data?.tournaments ?? [], filters));
       })
       .catch((err: unknown) => {
         if (!cancelled) {
@@ -62,15 +71,18 @@ export function TournamentList({ isAuthenticated = false }: TournamentListProps)
     return () => {
       cancelled = true;
     };
-  }, [reloadKey]);
+    // serverFiltersKey carries all values that should refetch the server-side query.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reloadKey, serverFiltersKey]);
 
   const handleRegistered = useCallback((updated: TournamentListItem) => {
     setTournaments((current) =>
-      keepRegistrationOnly(
+      filterTournaments(
         current.map((tournament) => (tournament.id === updated.id ? updated : tournament)),
+        filters,
       ),
     );
-  }, []);
+  }, [filters]);
 
   if (loading) {
     return (
@@ -88,7 +100,12 @@ export function TournamentList({ isAuthenticated = false }: TournamentListProps)
         <AlertCircle className="mx-auto mb-3 h-7 w-7 text-destructive" aria-hidden="true" />
         <p className="font-medium text-foreground">No pudimos cargar los torneos</p>
         <p className="mt-1 text-sm text-muted-foreground">{error}</p>
-        <Button type="button" variant="secondary" className="mt-4" onClick={() => setReloadKey((key) => key + 1)}>
+        <Button
+          type="button"
+          variant="secondary"
+          className="mt-4"
+          onClick={() => setReloadKey((key) => key + 1)}
+        >
           <RefreshCw className="h-4 w-4" aria-hidden="true" />
           Reintentar
         </Button>
@@ -97,11 +114,18 @@ export function TournamentList({ isAuthenticated = false }: TournamentListProps)
   }
 
   if (tournaments.length === 0) {
+    const isInProgress = filters.status === 'IN_PROGRESS';
     return (
       <div className="rounded-xl border border-border bg-card p-8 text-center">
         <Trophy className="mx-auto mb-3 h-8 w-8 text-primary" aria-hidden="true" />
-        <p className="text-xl font-medium">No hay torneos en inscripción</p>
-        <p className="mt-2 text-muted-foreground">Cuando un club o jugador abra un torneo va a aparecer acá.</p>
+        <p className="text-xl font-medium">
+          {isInProgress ? 'No hay torneos en curso' : 'No hay torneos en inscripcion'}
+        </p>
+        <p className="mt-2 text-muted-foreground">
+          {isInProgress
+            ? 'Proba cambiando el estado o ajustando los filtros.'
+            : 'Cuando un club o jugador abra un torneo va a aparecer aca.'}
+        </p>
       </div>
     );
   }

--- a/apps/frontend/src/components/tournaments/TournamentMap.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentMap.tsx
@@ -7,6 +7,7 @@
  *   TournamentsView after hydration.
  * - Tournament pins come from the associated club coordinates: clubs.lat / clubs.lng.
  *   Clubs without coordinates are omitted from the marker layer without breaking the list.
+ * - Receives the same controlled filters as TournamentList and forwards them to GraphQL.
  */
 
 import 'leaflet/dist/leaflet.css';
@@ -19,6 +20,12 @@ import {
   type TournamentListItem,
 } from '@/graphql/operations/tournaments';
 import type { MatchFormat } from '@/graphql/operations/matches';
+import {
+  DEFAULT_TOURNAMENT_FILTERS,
+  filterTournaments,
+  toServerTournamentFilters,
+  type ClientTournamentFilters,
+} from '@/lib/tournament-filtering';
 
 delete (L.Icon.Default.prototype as unknown as { _getIconUrl?: unknown })._getIconUrl;
 L.Icon.Default.mergeOptions({
@@ -43,10 +50,6 @@ const FORMAT_LABELS: Record<MatchFormat, string> = {
 
 interface GetTournamentsPayload {
   tournaments: TournamentListItem[];
-}
-
-function keepRegistrationOnly(tournaments: TournamentListItem[]): TournamentListItem[] {
-  return tournaments.filter((tournament) => tournament.status === 'REGISTRATION');
 }
 
 function LocationButton() {
@@ -162,7 +165,11 @@ function EmptyMap({ message, mapStyle }: { message: string; mapStyle: CSSPropert
   );
 }
 
-export function TournamentMap() {
+interface TournamentMapProps {
+  filters?: ClientTournamentFilters;
+}
+
+export function TournamentMap({ filters = DEFAULT_TOURNAMENT_FILTERS }: TournamentMapProps) {
   const [tournaments, setTournaments] = useState<TournamentListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -172,6 +179,8 @@ export function TournamentMap() {
     [],
   );
   const mapStyle = useMemo(() => ({ height: mapHeight, width: '100%' }), [mapHeight]);
+  const serverFilters = useMemo(() => toServerTournamentFilters(filters), [filters]);
+  const serverFiltersKey = useMemo(() => JSON.stringify(serverFilters), [serverFilters]);
 
   useEffect(() => {
     let cancelled = false;
@@ -181,14 +190,14 @@ export function TournamentMap() {
     fetch('/api/graphql', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: GET_TOURNAMENTS }),
+      body: JSON.stringify({ query: GET_TOURNAMENTS, variables: { filters: serverFilters } }),
     })
       .then((response) => response.json())
       .then((payload: { data?: GetTournamentsPayload; errors?: Array<{ message: string }> }) => {
         if (cancelled) return;
         const graphQLError = payload.errors?.[0]?.message;
         if (graphQLError) throw new Error(graphQLError);
-        setTournaments(keepRegistrationOnly(payload.data?.tournaments ?? []));
+        setTournaments(filterTournaments(payload.data?.tournaments ?? [], filters));
       })
       .catch((err: unknown) => {
         if (!cancelled) {
@@ -203,7 +212,8 @@ export function TournamentMap() {
     return () => {
       cancelled = true;
     };
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serverFiltersKey]);
 
   const geoTournaments = tournaments.filter((tournament) => {
     if (tournament.club?.lat == null || tournament.club?.lng == null) {
@@ -234,7 +244,7 @@ export function TournamentMap() {
   }
 
   if (tournaments.length === 0) {
-    return <EmptyMap message="No hay torneos en inscripcion" mapStyle={mapStyle} />;
+    return <EmptyMap message="No hay torneos para esos filtros" mapStyle={mapStyle} />;
   }
 
   if (geoTournaments.length === 0) {

--- a/apps/frontend/src/components/tournaments/TournamentsView.tsx
+++ b/apps/frontend/src/components/tournaments/TournamentsView.tsx
@@ -6,11 +6,20 @@
  *   and lazy-load Leaflet only when the user opens the map.
  * - TournamentList and TournamentMap fetch independently, matching the existing matches
  *   architecture and keeping registration updates scoped to the list card flow.
+ * - Filters are controlled here so list/map share one state and URL params stay in sync.
  */
 
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { List, Map as MapIcon } from 'lucide-react';
 import { TournamentList } from './TournamentList';
+import { TournamentFilters } from './TournamentFilters';
+import {
+  DEFAULT_TOURNAMENT_FILTERS,
+  normalizeTournamentFilters,
+  parseTournamentFiltersFromSearch,
+  writeTournamentFiltersToUrl,
+  type ClientTournamentFilters,
+} from '@/lib/tournament-filtering';
 
 const TournamentMap = lazy(() =>
   import('./TournamentMap').then((module) => ({ default: module.TournamentMap })),
@@ -24,9 +33,35 @@ interface TournamentsViewProps {
 
 export function TournamentsView({ isAuthenticated = false }: TournamentsViewProps) {
   const [view, setView] = useState<View>('list');
+  const [filters, setFilters] = useState<ClientTournamentFilters>(DEFAULT_TOURNAMENT_FILTERS);
+  const [urlReady, setUrlReady] = useState(false);
+
+  useEffect(() => {
+    const filtersFromUrl = parseTournamentFiltersFromSearch(window.location.search);
+    setFilters(filtersFromUrl);
+    setUrlReady(true);
+  }, []);
+
+  const handleFiltersChange = useCallback(
+    (newFilters: ClientTournamentFilters) => {
+      const normalized = normalizeTournamentFilters(newFilters);
+      setFilters(normalized);
+
+      if (urlReady) {
+        window.history.replaceState(
+          null,
+          '',
+          writeTournamentFiltersToUrl(normalized, window.location.href),
+        );
+      }
+    },
+    [urlReady],
+  );
 
   return (
     <div>
+      <TournamentFilters filters={filters} onFiltersChange={handleFiltersChange} />
+
       <div className="tournament-view-toggle" role="group" aria-label="Seleccionar vista de torneos">
         <button
           type="button"
@@ -53,7 +88,10 @@ export function TournamentsView({ isAuthenticated = false }: TournamentsViewProp
       </div>
 
       {view === 'list' ? (
-        <TournamentList isAuthenticated={isAuthenticated} />
+        <TournamentList
+          isAuthenticated={isAuthenticated}
+          filters={filters}
+        />
       ) : (
         <Suspense
           fallback={
@@ -62,7 +100,7 @@ export function TournamentsView({ isAuthenticated = false }: TournamentsViewProp
             </div>
           }
         >
-          <TournamentMap />
+          <TournamentMap filters={filters} />
         </Suspense>
       )}
 

--- a/apps/frontend/src/graphql/operations/tournaments.graphql
+++ b/apps/frontend/src/graphql/operations/tournaments.graphql
@@ -1,7 +1,7 @@
 # Tournament creation
 
-query GetTournaments {
-  tournaments {
+query GetTournaments($filters: TournamentFilters) {
+  tournaments(filters: $filters) {
     id
     name
     format

--- a/apps/frontend/src/graphql/operations/tournaments.ts
+++ b/apps/frontend/src/graphql/operations/tournaments.ts
@@ -13,6 +13,15 @@ import type { MatchFormat } from './matches';
 export type TournamentStatus = 'REGISTRATION' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
 export type FixtureMatchStatus = 'SCHEDULED' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
 
+export interface TournamentFilters {
+  status?: TournamentStatus;
+  format?: MatchFormat;
+  zone?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  search?: string;
+}
+
 export interface TournamentScheduleSlotInput {
   slotId: string;
   date: string;
@@ -145,8 +154,8 @@ export interface TournamentTeamRegistrationResult {
 }
 
 export const GET_TOURNAMENTS = /* GraphQL */ `
-  query GetTournaments {
-    tournaments {
+  query GetTournaments($filters: TournamentFilters) {
+    tournaments(filters: $filters) {
       id
       name
       format

--- a/apps/frontend/src/lib/tournament-filtering.ts
+++ b/apps/frontend/src/lib/tournament-filtering.ts
@@ -1,0 +1,163 @@
+/**
+ * Tournament filtering utilities for the /torneos listing.
+ *
+ * Decision Context:
+ * - Mirrors the /partidos filter flow: controlled filter state lives in TournamentsView,
+ *   URL persistence stays outside the UI-only filter bar, and list/map receive the same
+ *   normalized filters.
+ * - Unlike matches, tournament filters are forwarded to the GraphQL query because the
+ *   tournament dataset can include registration and in-progress rows. The small local
+ *   filter mirror remains as a defensive fallback for mocked tests and registration
+ *   updates that change a card's status without a full refetch.
+ */
+
+import type { MatchFormat } from '@/graphql/operations/matches';
+import type {
+  TournamentFilters,
+  TournamentListItem,
+  TournamentStatus,
+} from '@/graphql/operations/tournaments';
+
+export type ClientTournamentFilters = TournamentFilters;
+
+export const DEFAULT_TOURNAMENT_FILTERS: ClientTournamentFilters = {
+  status: 'REGISTRATION',
+};
+
+const URL_FILTER_KEYS = ['status', 'format', 'zone', 'dateFrom', 'dateTo', 'search'] as const;
+
+const VALID_FORMATS = new Set<MatchFormat>([
+  'FIVE_VS_FIVE',
+  'SEVEN_VS_SEVEN',
+  'TEN_VS_TEN',
+  'ELEVEN_VS_ELEVEN',
+]);
+
+const VALID_STATUSES = new Set<TournamentStatus>(['REGISTRATION', 'IN_PROGRESS']);
+
+function compactFilters(filters: ClientTournamentFilters): ClientTournamentFilters {
+  const next: ClientTournamentFilters = {};
+
+  for (const [key, value] of Object.entries(filters)) {
+    if (value == null || value === '') continue;
+    next[key as keyof ClientTournamentFilters] = value as never;
+  }
+
+  return { ...DEFAULT_TOURNAMENT_FILTERS, ...next };
+}
+
+function dateOnly(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  return value.includes('T') ? value.split('T')[0] : value;
+}
+
+function toLocalDate(value?: string | null, endOfDay = false): Date | null {
+  const date = dateOnly(value);
+  if (!date) return null;
+  return new Date(`${date}T${endOfDay ? '23:59:59.999' : '00:00:00'}`);
+}
+
+export function normalizeTournamentFilters(
+  filters: ClientTournamentFilters,
+): ClientTournamentFilters {
+  return compactFilters(filters);
+}
+
+export function filterTournaments(
+  tournaments: TournamentListItem[],
+  filters: ClientTournamentFilters,
+): TournamentListItem[] {
+  const normalized = normalizeTournamentFilters(filters);
+  const fromDate = toLocalDate(normalized.dateFrom);
+  const toDate = toLocalDate(normalized.dateTo, true);
+
+  return tournaments.filter((tournament) => {
+    if (normalized.status && tournament.status !== normalized.status) return false;
+    if (normalized.format && tournament.format !== normalized.format) return false;
+    if (normalized.zone && tournament.club?.zone !== normalized.zone) return false;
+
+    const search = normalized.search?.trim().toLowerCase();
+    if (search) {
+      const haystack = [
+        tournament.name,
+        tournament.description,
+        tournament.club?.name,
+        tournament.club?.zone,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+
+      if (!haystack.includes(search)) return false;
+    }
+
+    if (fromDate || toDate) {
+      if (!tournament.startDate) return false;
+      const tournamentDate = toLocalDate(tournament.startDate);
+      if (!tournamentDate) return false;
+      if (fromDate && tournamentDate < fromDate) return false;
+      if (toDate && tournamentDate > toDate) return false;
+    }
+
+    return true;
+  });
+}
+
+export function parseTournamentFiltersFromSearch(search: string): ClientTournamentFilters {
+  const params = new URLSearchParams(search);
+  const status = params.get('status') as TournamentStatus | null;
+  const format = params.get('format') as MatchFormat | null;
+
+  return normalizeTournamentFilters({
+    status: status && VALID_STATUSES.has(status) ? status : undefined,
+    format: format && VALID_FORMATS.has(format) ? format : undefined,
+    zone: params.get('zone') || undefined,
+    dateFrom: params.get('dateFrom') || undefined,
+    dateTo: params.get('dateTo') || undefined,
+    search: params.get('search') || undefined,
+  });
+}
+
+export function writeTournamentFiltersToUrl(
+  filters: ClientTournamentFilters,
+  href: string,
+): string {
+  const url = new URL(href);
+  const normalized = normalizeTournamentFilters(filters);
+
+  for (const key of URL_FILTER_KEYS) {
+    url.searchParams.delete(key);
+  }
+
+  for (const key of URL_FILTER_KEYS) {
+    const value = normalized[key];
+    if (!value) continue;
+    if (key === 'status' && value === DEFAULT_TOURNAMENT_FILTERS.status) continue;
+    url.searchParams.set(key, key.startsWith('date') ? dateOnly(value) ?? value : value);
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function toServerTournamentFilters(
+  filters: ClientTournamentFilters,
+): TournamentFilters {
+  const normalized = normalizeTournamentFilters(filters);
+
+  return {
+    status: normalized.status,
+    format: normalized.format,
+    zone: normalized.zone,
+    dateFrom: dateOnly(normalized.dateFrom),
+    dateTo: dateOnly(normalized.dateTo),
+    search: normalized.search?.trim() || undefined,
+  };
+}
+
+export function toDateInputValue(value?: string): string {
+  return dateOnly(value) ?? '';
+}
+
+export function toDateFilter(value: string): string | undefined {
+  return value || undefined;
+}

--- a/apps/testing/tests/support/page-objects/TournamentsListPage.ts
+++ b/apps/testing/tests/support/page-objects/TournamentsListPage.ts
@@ -7,17 +7,18 @@ import { TORNEOS_URL } from '../constants';
  * Decision Context:
  * - The page shell is SSR (prerender = false), but TournamentList hydrates
  *   client-side with client:visible. Tournament data is fetched via useEffect
- *   through /api/graphql — interceptable with mockGraphQLAll(GRAPHQL_PROXY_ROUTE)
+ *   through /api/graphql, interceptable with mockGraphQLAll(GRAPHQL_PROXY_ROUTE)
  *   before goto().
  * - isAuthenticated is injected server-side from Astro.locals.user. The CTA
- *   shown in each card ("Anotar equipo" vs "Iniciar sesión para anotar") depends
+ *   shown in each card ("Anotar equipo" vs "Iniciar sesion para anotar") depends
  *   on the session at SSR time. Auth state must be controlled via
  *   test.use({ storageState }) at the describe level.
- * - The client-side keepRegistrationOnly() filter runs after the fetch, so
- *   tournaments with status !== REGISTRATION sent in mocks do not render as cards.
+ * - Tournament filters are controlled in TournamentsView and persisted in URL params.
+ *   The list forwards them to tournaments(filters) and mirrors them client-side so
+ *   mocks that return mixed statuses still behave like the real API.
  * - Loading skeletons are plain <div> elements; cards are <article> elements.
  *   expectListSettled() waits for the first <article>, empty state, or error panel
- *   — all reliable hydration proxies.
+ *   - all reliable hydration proxies.
  * - joinTournament mutations go to /api/graphql-auth. Specs that test form
  *   submission mock that route via mockGraphQLAll(GRAPHQL_AUTH_ROUTE, ...).
  * - Previously fixed bugs: none relevant.
@@ -31,20 +32,34 @@ export class TournamentsListPage {
   readonly retryButton: Locator;
   readonly teamNameInput: Locator;
   readonly cancelButton: Locator;
+  readonly statusSelect: Locator;
+  readonly searchInput: Locator;
+  readonly formatSelect: Locator;
+  readonly zoneSelect: Locator;
+  readonly dateFromInput: Locator;
+  readonly dateToInput: Locator;
+  readonly clearButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.heading = page.getByRole('heading', { name: /Torneos Disponibles/i });
-    this.subtitle = page.getByText(/Encontrá una copa abierta/i);
-    this.emptyState = page.getByText('No hay torneos en inscripción');
+    this.subtitle = page.getByText(/Encontr.*copa abierta/i);
+    this.emptyState = page.getByText(/No hay torneos en (inscripcion|curso)/i);
     this.errorPanel = page.getByText('No pudimos cargar los torneos');
     this.retryButton = page.getByRole('button', { name: /Reintentar/i });
     this.teamNameInput = page.getByPlaceholder('Nombre del equipo');
     this.cancelButton = page.getByRole('button', { name: 'Cancelar' });
+    this.statusSelect = page.getByLabel('Estado');
+    this.searchInput = page.getByLabel(/Buscar torneos/i);
+    this.formatSelect = page.getByLabel('Formato');
+    this.zoneSelect = page.getByLabel('Zona');
+    this.dateFromInput = page.getByLabel('Fecha desde');
+    this.dateToInput = page.getByLabel('Fecha hasta');
+    this.clearButton = page.getByRole('button', { name: /Limpiar/i });
   }
 
-  async goto(): Promise<void> {
-    await this.page.goto(TORNEOS_URL);
+  async goto(url: string = TORNEOS_URL): Promise<void> {
+    await this.page.goto(url);
     await this.page.locator('.tournaments-section').scrollIntoViewIfNeeded();
   }
 
@@ -70,14 +85,19 @@ export class TournamentsListPage {
     return this.page.getByRole('button', { name: 'Anotar equipo' });
   }
 
-  /** "Iniciar sesión para anotar" CTA button (anonymous user). */
+  /** "Iniciar sesion para anotar" CTA button (anonymous user). */
   loginToRegisterButton(): Locator {
-    return this.page.getByRole('button', { name: /Iniciar sesión para anotar/i });
+    return this.page.getByRole('button', { name: /Iniciar sesi/i });
   }
 
   /** "Completo" disabled button (tournament at full capacity). */
   completoButton(): Locator {
     return this.page.getByRole('button', { name: /Completo/i });
+  }
+
+  /** "Inscripcion cerrada" disabled button (non-registration tournament). */
+  registrationClosedButton(): Locator {
+    return this.page.getByRole('button', { name: /Inscripcion cerrada/i });
   }
 
   /** Submit button inside the inline registration form (text "Anotar"). */

--- a/apps/testing/tests/tournament-filters.spec.ts
+++ b/apps/testing/tests/tournament-filters.spec.ts
@@ -1,0 +1,200 @@
+import {
+  buildTournament,
+  expect,
+  GRAPHQL_PROXY_ROUTE,
+  mockGraphQLAll,
+  test,
+  TORNEOS_URL,
+} from './support';
+
+/**
+ * Tests E2E - Filtrar Torneos (/torneos).
+ *
+ * Decision Context:
+ * - Mirrors match-filters.spec.ts at a tournament scope: search by name, status, format,
+ *   zone, and date range.
+ * - The mocked GraphQL handler intentionally returns mixed tournaments even when variables
+ *   request a subset. This verifies the UI forwards filters to tournaments(filters) and
+ *   also keeps its defensive client-side mirror aligned.
+ */
+
+test.describe('Filtrar Torneos (/torneos)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('muestra filtros y carga la query inicial con estado REGISTRATION', async ({
+    tournamentsPage,
+    page,
+  }) => {
+    const tracker = await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, {
+      data: { tournaments: [buildTournament({ name: 'Copa Inicial' })] },
+    });
+
+    await tournamentsPage.goto();
+    await tournamentsPage.expectListSettled();
+
+    await expect(tournamentsPage.searchInput).toBeVisible();
+    await expect(tournamentsPage.statusSelect).toBeVisible();
+    await expect(tournamentsPage.formatSelect).toBeVisible();
+    await expect(tournamentsPage.zoneSelect).toBeVisible();
+    await expect(tournamentsPage.dateFromInput).toBeVisible();
+    await expect(tournamentsPage.dateToInput).toBeVisible();
+    await expect(tournamentsPage.clearButton).toBeDisabled();
+
+    expect(tracker.requests[0]?.variables).toMatchObject({
+      filters: { status: 'REGISTRATION' },
+    });
+  });
+
+  test('filtra por nombre y persiste search en la URL', async ({ tournamentsPage, page }) => {
+    const tracker = await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, {
+      data: {
+        tournaments: [
+          buildTournament({ id: 'search-1', name: 'Copa Primavera' }),
+          buildTournament({ id: 'search-2', name: 'Liga Otono' }),
+          buildTournament({ id: 'search-3', name: 'Desafio Nocturno' }),
+        ],
+      },
+    });
+
+    await tournamentsPage.goto();
+    await tournamentsPage.expectListSettled();
+
+    await tournamentsPage.searchInput.fill('primavera');
+
+    await expect(tournamentsPage.card('Copa Primavera')).toBeVisible();
+    await expect(tournamentsPage.card('Liga Otono')).toHaveCount(0);
+    await expect(tournamentsPage.card('Desafio Nocturno')).toHaveCount(0);
+    await expect(page).toHaveURL(/search=primavera/);
+    expect(tracker.requests.at(-1)?.variables).toMatchObject({
+      filters: { status: 'REGISTRATION', search: 'primavera' },
+    });
+  });
+
+  test('filtra por estado en curso y persiste el filtro en la URL', async ({
+    tournamentsPage,
+    page,
+  }) => {
+    const tracker = await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, {
+      data: {
+        tournaments: [
+          buildTournament({ id: 'state-1', name: 'Copa Abierta', status: 'REGISTRATION' }),
+          buildTournament({ id: 'state-2', name: 'Liga En Curso', status: 'IN_PROGRESS' }),
+        ],
+      },
+    });
+
+    await tournamentsPage.goto();
+    await tournamentsPage.expectListSettled();
+
+    await expect(tournamentsPage.card('Copa Abierta')).toBeVisible();
+    await expect(tournamentsPage.card('Liga En Curso')).toHaveCount(0);
+
+    await tournamentsPage.statusSelect.selectOption('IN_PROGRESS');
+
+    await expect(tournamentsPage.card('Liga En Curso')).toBeVisible({ timeout: 10_000 });
+    await expect(tournamentsPage.card('Copa Abierta')).toHaveCount(0);
+    await expect(page).toHaveURL(/status=IN_PROGRESS/);
+    await expect(tournamentsPage.registrationClosedButton()).toBeDisabled();
+    expect(tracker.requests.at(-1)?.variables).toMatchObject({
+      filters: { status: 'IN_PROGRESS' },
+    });
+  });
+
+  test('combina zona, formato y rango de fecha', async ({ tournamentsPage, page }) => {
+    await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, {
+      data: {
+        tournaments: [
+          buildTournament({
+            id: 'combo-1',
+            name: 'Liga Sur 7',
+            format: 'SEVEN_VS_SEVEN',
+            startDate: '2027-06-15',
+            club: { id: 'club-sur', name: 'Club Sur', zone: 'Sur', address: null, imageUrl: null },
+          }),
+          buildTournament({
+            id: 'combo-2',
+            name: 'Copa Norte 7',
+            format: 'SEVEN_VS_SEVEN',
+            startDate: '2027-06-16',
+            club: { id: 'club-norte', name: 'Club Norte', zone: 'Norte', address: null, imageUrl: null },
+          }),
+          buildTournament({
+            id: 'combo-3',
+            name: 'Copa Sur 5',
+            format: 'FIVE_VS_FIVE',
+            startDate: '2027-06-17',
+            club: { id: 'club-sur-5', name: 'Club Sur 5', zone: 'Sur', address: null, imageUrl: null },
+          }),
+          buildTournament({
+            id: 'combo-4',
+            name: 'Liga Sur Fuera De Fecha',
+            format: 'SEVEN_VS_SEVEN',
+            startDate: '2027-07-01',
+            club: { id: 'club-sur-2', name: 'Club Sur 2', zone: 'Sur', address: null, imageUrl: null },
+          }),
+        ],
+      },
+    });
+
+    await tournamentsPage.goto();
+    await tournamentsPage.expectListSettled();
+
+    await tournamentsPage.formatSelect.selectOption('SEVEN_VS_SEVEN');
+    await tournamentsPage.zoneSelect.selectOption('Sur');
+    await tournamentsPage.dateFromInput.fill('2027-06-10');
+    await tournamentsPage.dateToInput.fill('2027-06-20');
+
+    await expect(tournamentsPage.card('Liga Sur 7')).toBeVisible();
+    await expect(tournamentsPage.card('Copa Norte 7')).toHaveCount(0);
+    await expect(tournamentsPage.card('Copa Sur 5')).toHaveCount(0);
+    await expect(tournamentsPage.card('Liga Sur Fuera De Fecha')).toHaveCount(0);
+    await expect(page).toHaveURL(/format=SEVEN_VS_SEVEN/);
+    await expect(page).toHaveURL(/zone=Sur/);
+    await expect(page).toHaveURL(/dateFrom=2027-06-10/);
+    await expect(page).toHaveURL(/dateTo=2027-06-20/);
+  });
+
+  test('hidrata filtros desde URL y limpiar resetea controles y params', async ({
+    tournamentsPage,
+    page,
+  }) => {
+    await mockGraphQLAll(page, GRAPHQL_PROXY_ROUTE, {
+      data: {
+        tournaments: [
+          buildTournament({
+            id: 'url-1',
+            name: 'Liga URL',
+            status: 'IN_PROGRESS',
+            format: 'FIVE_VS_FIVE',
+            startDate: '2027-08-12',
+            club: { id: 'club-url', name: 'Club URL', zone: 'Norte', address: null, imageUrl: null },
+          }),
+        ],
+      },
+    });
+
+    await tournamentsPage.goto(
+      `${TORNEOS_URL}?status=IN_PROGRESS&format=FIVE_VS_FIVE&zone=Norte&dateFrom=2027-08-01&dateTo=2027-08-31&search=liga`,
+    );
+    await tournamentsPage.expectListSettled();
+
+    await expect(tournamentsPage.card('Liga URL')).toBeVisible();
+    await expect(tournamentsPage.statusSelect).toHaveValue('IN_PROGRESS');
+    await expect(tournamentsPage.searchInput).toHaveValue('liga');
+    await expect(tournamentsPage.formatSelect).toHaveValue('FIVE_VS_FIVE');
+    await expect(tournamentsPage.zoneSelect).toHaveValue('Norte');
+    await expect(tournamentsPage.dateFromInput).toHaveValue('2027-08-01');
+    await expect(tournamentsPage.dateToInput).toHaveValue('2027-08-31');
+
+    await tournamentsPage.clearButton.click();
+
+    await expect(tournamentsPage.statusSelect).toHaveValue('REGISTRATION');
+    await expect(tournamentsPage.searchInput).toHaveValue('');
+    await expect(tournamentsPage.formatSelect).toHaveValue('');
+    await expect(tournamentsPage.zoneSelect).toHaveValue('');
+    await expect(tournamentsPage.dateFromInput).toHaveValue('');
+    await expect(tournamentsPage.dateToInput).toHaveValue('');
+    await expect(tournamentsPage.clearButton).toBeDisabled();
+    await expect(page).toHaveURL(TORNEOS_URL);
+  });
+});


### PR DESCRIPTION
Se implementó el filtrado de torneos reutilizando el patrón existente de partidos.

Ahora el listado permite filtrar por nombre, zona, formato, estado y rango de fecha. Los filtros se sincronizan con la URL para poder compartir o recargar la búsqueda sin perder el estado.

También se actualizó la query de torneos para recibir filtros desde GraphQL, se aplicó la lógica en backend y se agregaron los tests E2E correspondientes para cubrir los casos principales.