### PR TITLE
test(e2e): cubrir Abandonar Torneo con Playwright

### DIFF
--- a/apps/testing/tests/abandonar-torneo-47.spec.ts
+++ b/apps/testing/tests/abandonar-torneo-47.spec.ts
@@ -1,0 +1,424 @@
+import {
+  buildLeaveTournamentErrors,
+  buildLeaveTournamentFailure,
+  buildLeaveTournamentResponse,
+  expect,
+  GRAPHQL_AUTH_ROUTE,
+  gqlPost,
+  mockGraphQLOperation,
+  SEED_TOURNAMENTS,
+  test,
+  TEST_USERS,
+  TournamentDetailPage,
+} from './support';
+
+/**
+ * Tests E2E — US #47 "Abandonar torneo" (/torneos/[id]).
+ *
+ * Decision Context:
+ * - The tournament detail page is SSR (`prerender = false`). The initial fetch
+ *   to the backend GraphQL endpoint resolves who-is-captain + tournament status,
+ *   which gates the SSR rendering of <LeaveTournamentButton client:load>.
+ *   We CANNOT intercept that initial fetch with page.route(), so we depend on
+ *   seed data: SEED_TOURNAMENTS.withCaptainMateo has playerMateo as captain of
+ *   a team registered in a REGISTRATION-status tournament. That guarantees the
+ *   leave button is rendered.
+ * - The `LeaveTournament` mutation is dispatched client-side by
+ *   LeaveTournamentDialog via fetch('/api/graphql-auth', ...). This IS
+ *   interceptable with page.route() and is ALWAYS mocked so the test never
+ *   removes the seeded team from the real DB. We use
+ *   `mockGraphQLOperation(page, GRAPHQL_AUTH_ROUTE, 'leaveTournament', body)`
+ *   which only mocks the leaveTournament op and passes everything else through.
+ * - hasOnlyTwoTeams is computed in the Astro page as
+ *   `registeredTeamsCount <= 2`. With only Mateo's team in the seed
+ *   (registeredTeamsCount === 1), the critical 2-teams warning IS visible in
+ *   every captain-view rendering. The dedicated warning test asserts it
+ *   explicitly; tests that don't care simply ignore it.
+ * - After a successful mutation, handleSuccess() updates React state THEN
+ *   schedules a setTimeout(window.location.reload, 1500) or
+ *   setTimeout(redirect, 2500). We assert the intermediate state
+ *   (.leave-success-msg / .leave-extra-msg present) and don't wait for the
+ *   timers — same pattern as unirse-torneo.spec.ts (mutation tests don't wait
+ *   for reload, they verify mutation payload + intermediate paint).
+ * - Auth posture:
+ *     · Captain visibility & dialog flow: TEST_USERS.playerMateo (storage state).
+ *     · Non-captain visibility: TEST_USERS.playerRicardo (separate browser ctx).
+ *     · Unauth mutation contract: raw API request without token.
+ * - Selector strategy:
+ *     · `leaveTournamentButton` matches by aria-label regex
+ *       `/retirar equipo .* del torneo/i` to stay seed-agnostic.
+ *     · `submitLeaveButton` is scoped INSIDE the dialog because the trigger
+ *       button also contains "Retirar equipo" text — using getByRole at page
+ *       level returned two matches before scoping.
+ *     · `twoTeamsWarning` uses the CSS class `.leave-warning--critical` because
+ *       both the always-shown destructive warning and the critical 2-teams
+ *       warning use role="alert" — there is no unique accessible name to
+ *       distinguish them. Documented in the PO file.
+ * - Previously fixed bugs: none relevant (new spec).
+ *
+ * Coverage NOT included (intentional skips / out-of-scope):
+ *   · Real DB-mutating happy path: would delete Mateo's seeded team, breaking
+ *     all subsequent unirse-torneo + abandonar-torneo runs. Service-layer unit
+ *     tests cover the mutation's actual effects.
+ *   · The redirect timers (1500ms / 2500ms): asserted at the message level,
+ *     not by waiting for the reload — same approach as unirse-torneo.spec.ts.
+ *   · `authentication required` → redirect /login: documented as case #11 below.
+ */
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Bloque 1 — Visibilidad del botón
+   ══════════════════════════════════════════════════════════════════════════ */
+
+test.describe('Visibilidad del botón "Retirar equipo"', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: TEST_USERS.playerMateo.storageStatePath });
+
+  test('capitán en torneo en REGISTRATION ve el botón "Retirar equipo"', async ({
+    tournamentCaptainPage,
+  }) => {
+    await tournamentCaptainPage.goto();
+    await expect(
+      tournamentCaptainPage.leaveTournamentButton,
+      'El botón "Retirar equipo" debe ser visible para el capitán',
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('click en el botón abre el dialog de confirmación', async ({ tournamentCaptainPage }) => {
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+
+    await expect(
+      tournamentCaptainPage.leaveDialogTitle,
+      'El dialog debe mostrar el título "Retirar equipo del torneo"',
+    ).toBeVisible();
+  });
+
+  test('jugador no-capitán NO ve el botón "Retirar equipo"', async ({ browser }) => {
+    const ctx = await browser.newContext({
+      storageState: TEST_USERS.playerRicardo.storageStatePath,
+    });
+    const ricardoPage = await ctx.newPage();
+    const po = new TournamentDetailPage(ricardoPage, SEED_TOURNAMENTS.withCaptainMateo);
+    try {
+      await po.goto();
+      await po.expectLeaveButtonHidden();
+    } finally {
+      await ctx.close();
+    }
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Bloque 2 — Interacciones del dialog
+   ══════════════════════════════════════════════════════════════════════════ */
+
+test.describe('Interacciones del dialog', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: TEST_USERS.playerMateo.storageStatePath });
+
+  test('el botón "Retirar equipo" del dialog arranca deshabilitado', async ({
+    tournamentCaptainPage,
+  }) => {
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+
+    await expect(
+      tournamentCaptainPage.submitLeaveButton,
+      'El submit del dialog debe estar deshabilitado sin confirmación',
+    ).toBeDisabled();
+  });
+
+  test('tildar el checkbox de confirmación habilita el botón "Retirar"', async ({
+    tournamentCaptainPage,
+  }) => {
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+
+    await tournamentCaptainPage.tickConfirm();
+
+    await expect(
+      tournamentCaptainPage.submitLeaveButton,
+      'Tras tildar el checkbox, el submit debe habilitarse',
+    ).toBeEnabled();
+  });
+
+  test('la textarea de motivo respeta maxLength=500', async ({ tournamentCaptainPage }) => {
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+
+    // Build a 600-char string. fill() respects the input's maxLength attribute
+    // and the resulting `value` should be truncated to 500.
+    const longText = 'x'.repeat(600);
+    await tournamentCaptainPage.fillReason(longText);
+
+    const value = await tournamentCaptainPage.reasonTextarea.inputValue();
+    expect(
+      value.length,
+      'El textarea debe truncar el valor a 500 caracteres por el atributo maxLength',
+    ).toBe(500);
+  });
+
+  test('cerrar el dialog con "Cancelar" lo oculta sin enviar mutation', async ({
+    tournamentCaptainPage,
+    page,
+  }) => {
+    // Track that no leaveTournament mutation is dispatched while the dialog is open
+    // and after dismissing it.
+    const { payloads } = await mockGraphQLOperation(
+      page,
+      GRAPHQL_AUTH_ROUTE,
+      'leaveTournament',
+      buildLeaveTournamentResponse(),
+    );
+
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+    await tournamentCaptainPage.cancelLeaveButton.click();
+
+    await expect(
+      tournamentCaptainPage.leaveDialog,
+      'El dialog debe ocultarse al cancelar',
+    ).not.toBeVisible({ timeout: 5_000 });
+    expect(
+      payloads,
+      'No debe haberse enviado la mutation leaveTournament al cancelar',
+    ).toHaveLength(0);
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Bloque 3 — Warning de 2 equipos
+   ══════════════════════════════════════════════════════════════════════════ */
+
+test.describe('Warning de cancelación por pocos equipos', () => {
+  test.use({ storageState: TEST_USERS.playerMateo.storageStatePath });
+
+  test('cuando hasOnlyTwoTeams=true se muestra el warning crítico rojo', async ({
+    tournamentCaptainPage,
+  }) => {
+    /*
+     * The seeded tournament has only Mateo's team registered (1 ≤ 2 → true),
+     * so the .leave-warning--critical element is rendered. If the seed evolves
+     * to host > 2 teams this assertion will fail intentionally — that's the
+     * regression guard.
+     */
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+
+    await expect(
+      tournamentCaptainPage.twoTeamsWarning,
+      'El warning crítico de cancelación debe aparecer cuando hay ≤2 equipos',
+    ).toBeVisible();
+    await expect(tournamentCaptainPage.twoTeamsWarning).toContainText(
+      /podria cancelarse|quedaria solo 1 equipo|podría cancelarse|quedaría solo/i,
+    );
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Bloque 4 — Happy paths (mock leaveTournament)
+   ══════════════════════════════════════════════════════════════════════════ */
+
+test.describe('Retiro exitoso', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: TEST_USERS.playerMateo.storageStatePath });
+
+  test('retiro exitoso reemplaza el botón por el mensaje verde con el message del backend', async ({
+    tournamentCaptainPage,
+    page,
+  }) => {
+    const expectedMessage = 'Equipo retirado del torneo';
+    const { payloads } = await mockGraphQLOperation(
+      page,
+      GRAPHQL_AUTH_ROUTE,
+      'leaveTournament',
+      buildLeaveTournamentResponse({
+        success: true,
+        message: expectedMessage,
+        tournamentStatus: 'REGISTRATION',
+        remainingTeams: 5,
+      }),
+    );
+
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+    await tournamentCaptainPage.tickConfirm();
+    await tournamentCaptainPage.submitLeave();
+
+    // Verify the mutation was dispatched
+    await expect.poll(() => payloads.length, { timeout: 10_000 }).toBeGreaterThanOrEqual(1);
+
+    // Intermediate success state (before the 1500ms reload timer fires).
+    await expect(
+      tournamentCaptainPage.leaveSuccessMessage,
+      'Debe mostrarse el mensaje de éxito con el message del backend',
+    ).toContainText(expectedMessage, { timeout: 5_000 });
+
+    // No extra (yellow) cancellation message in the non-CANCELLED path.
+    await expect(
+      tournamentCaptainPage.leaveExtraMessage,
+      'No debe aparecer el mensaje extra cuando el torneo no fue cancelado',
+    ).toHaveCount(0);
+  });
+
+  test('retiro con tournamentStatus=CANCELLED muestra el mensaje extra amarillo', async ({
+    tournamentCaptainPage,
+    page,
+  }) => {
+    const expectedMessage = 'Equipo retirado. Torneo cancelado por falta de equipos';
+    await mockGraphQLOperation(
+      page,
+      GRAPHQL_AUTH_ROUTE,
+      'leaveTournament',
+      buildLeaveTournamentResponse({
+        success: true,
+        message: expectedMessage,
+        tournamentStatus: 'CANCELLED',
+        remainingTeams: 1,
+      }),
+    );
+
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+    await tournamentCaptainPage.tickConfirm();
+    await tournamentCaptainPage.submitLeave();
+
+    await expect(
+      tournamentCaptainPage.leaveSuccessMessage,
+      'Debe mostrarse el mensaje de éxito',
+    ).toContainText(expectedMessage, { timeout: 5_000 });
+
+    await expect(
+      tournamentCaptainPage.leaveExtraMessage,
+      'Debe mostrarse el mensaje extra de cancelación + redirección',
+    ).toContainText(/torneo fue cancelado|redirigido a la lista/i, { timeout: 5_000 });
+  });
+
+  test('payload enviado al backend contiene tournamentId, teamId y reason', async ({
+    tournamentCaptainPage,
+    page,
+  }) => {
+    const { payloads } = await mockGraphQLOperation(
+      page,
+      GRAPHQL_AUTH_ROUTE,
+      'leaveTournament',
+      buildLeaveTournamentResponse(),
+    );
+
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+    await tournamentCaptainPage.fillReason('Conflicto de agenda E2E');
+    await tournamentCaptainPage.tickConfirm();
+    await tournamentCaptainPage.submitLeave();
+
+    await expect.poll(() => payloads.length, { timeout: 10_000 }).toBeGreaterThanOrEqual(1);
+
+    const payload = payloads[0] as {
+      variables?: {
+        input?: { tournamentId?: string; teamId?: string; reason?: string | null };
+      };
+    };
+    expect(payload.variables?.input?.tournamentId, 'tournamentId debe coincidir con el torneo').toBe(
+      SEED_TOURNAMENTS.withCaptainMateo,
+    );
+    expect(payload.variables?.input?.teamId, 'teamId debe estar presente').toBeTruthy();
+    expect(payload.variables?.input?.reason, 'reason debe coincidir con lo ingresado').toBe(
+      'Conflicto de agenda E2E',
+    );
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Bloque 5 — Error paths
+   ══════════════════════════════════════════════════════════════════════════ */
+
+test.describe('Errores del retiro', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ storageState: TEST_USERS.playerMateo.storageStatePath });
+
+  test('success=false con message muestra error inline en el dialog', async ({
+    tournamentCaptainPage,
+    page,
+  }) => {
+    const errorMessage = 'No podés retirar este equipo';
+    await mockGraphQLOperation(
+      page,
+      GRAPHQL_AUTH_ROUTE,
+      'leaveTournament',
+      buildLeaveTournamentFailure(errorMessage),
+    );
+
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+    await tournamentCaptainPage.tickConfirm();
+    await tournamentCaptainPage.submitLeave();
+
+    await expect(
+      tournamentCaptainPage.leaveErrorBanner,
+      'Debe mostrarse el error inline con el message del backend',
+    ).toContainText(errorMessage, { timeout: 5_000 });
+
+    // The dialog must remain open after a failure.
+    await expect(
+      tournamentCaptainPage.leaveDialog,
+      'El dialog NO debe cerrarse cuando la mutation falla',
+    ).toBeVisible();
+  });
+
+  test('errors[0].message GraphQL-level muestra error inline', async ({
+    tournamentCaptainPage,
+    page,
+  }) => {
+    const errorMessage = 'No se pudo retirar el equipo';
+    await mockGraphQLOperation(
+      page,
+      GRAPHQL_AUTH_ROUTE,
+      'leaveTournament',
+      buildLeaveTournamentErrors([errorMessage]),
+    );
+
+    await tournamentCaptainPage.goto();
+    await tournamentCaptainPage.openLeaveDialog();
+    await tournamentCaptainPage.tickConfirm();
+    await tournamentCaptainPage.submitLeave();
+
+    await expect(
+      tournamentCaptainPage.leaveErrorBanner,
+      'Debe mostrarse el error inline cuando llega un error GraphQL',
+    ).toContainText(errorMessage, { timeout: 5_000 });
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Bloque 6 — Seguridad
+   ══════════════════════════════════════════════════════════════════════════ */
+
+test.describe('Seguridad', () => {
+  test('mutation leaveTournament sin token de auth retorna error de autenticación', async ({
+    request,
+  }) => {
+    const response = await gqlPost(
+      request,
+      `mutation LeaveTournamentUnauth($input: LeaveTournamentInput!) {
+        leaveTournament(input: $input) { success message }
+      }`,
+      {
+        input: {
+          tournamentId: SEED_TOURNAMENTS.withCaptainMateo,
+          teamId: '00000000-0000-0000-0000-000000000001',
+          reason: null,
+        },
+      },
+      // Sin token de autorización
+    );
+
+    expect(
+      response.errors?.length ?? 0,
+      'Debe retornar al menos un error GraphQL',
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      response.errors?.[0]?.message,
+      'El error debe indicar falta de autenticación',
+    ).toMatch(/auth|unauth|required|token/i);
+  });
+});

--- a/apps/testing/tests/support/builders.ts
+++ b/apps/testing/tests/support/builders.ts
@@ -455,6 +455,68 @@ export function buildTournament(
   };
 }
 
+/* ── Leave-tournament builders (US #47) ─────────────────────────────────── */
+
+/**
+ * Mock builders for leaveTournament mutation responses.
+ *
+ * Decision Context:
+ * - LeaveTournamentDialog posts to /api/graphql-auth with the LeaveTournament
+ *   mutation and reads `data.leaveTournament.{success,message,tournamentStatus,
+ *   remainingTeams}`. The component branches on:
+ *     · errors[0].message contains "authentication required" → redirect to /login.
+ *     · success=false → render `message` as inline error.
+ *     · success=true + tournamentStatus='CANCELLED' → extra yellow message + redirect
+ *       to /torneos after 2500ms.
+ *     · success=true otherwise → reload after 1500ms.
+ * - Builders centralise the shape so specs only override the fields under test.
+ * - Previously fixed bugs: none relevant.
+ */
+
+export type MockLeaveTournamentResult = {
+  success: boolean;
+  message: string;
+  tournamentStatus: string | null;
+  remainingTeams: number | null;
+};
+
+export function buildLeaveTournamentResponse(
+  overrides: Partial<MockLeaveTournamentResult> = {},
+): { data: { leaveTournament: MockLeaveTournamentResult } } {
+  return {
+    data: {
+      leaveTournament: {
+        success: true,
+        message: 'Equipo retirado del torneo',
+        tournamentStatus: 'REGISTRATION',
+        remainingTeams: 5,
+        ...overrides,
+      },
+    },
+  };
+}
+
+export function buildLeaveTournamentFailure(message: string): {
+  data: { leaveTournament: MockLeaveTournamentResult };
+} {
+  return {
+    data: {
+      leaveTournament: {
+        success: false,
+        message,
+        tournamentStatus: null,
+        remainingTeams: null,
+      },
+    },
+  };
+}
+
+export function buildLeaveTournamentErrors(messages: string[]): {
+  errors: Array<{ message: string }>;
+} {
+  return { errors: messages.map((message) => ({ message })) };
+}
+
 /** Mock eligible players response (tournamentEligiblePlayers query). */
 export function buildEligiblePlayersResponse(
   players: MockTournamentPlayer[] = [],

--- a/apps/testing/tests/support/page-objects/TournamentDetailPage.ts
+++ b/apps/testing/tests/support/page-objects/TournamentDetailPage.ts
@@ -58,6 +58,20 @@ const HYDRATION_SENTINEL: MockTournamentPlayer = buildMockTournamentPlayer({
  *   class names as a documented fallback.
  * - Previously fixed bugs: none relevant.
  *
+ * US #47 — Abandonar torneo (capitán):
+ * - LeaveTournamentButton is rendered server-side in [id].astro when:
+ *     captainEnrolledTeam !== null AND tournament.status === 'REGISTRATION'.
+ *   `client:load` hydrates it for interactivity (modal state).
+ * - LeaveTournamentDialog posts to /api/graphql-auth → mutation `LeaveTournament`.
+ *   This is browser-issued and IS interceptable with page.route().
+ * - After a successful mutation the dialog closes and the button is replaced by an
+ *   inline `.leave-success-msg`. A 1500ms (or 2500ms when CANCELLED) timer then
+ *   triggers window.location.reload()/redirect — tests assert the intermediate
+ *   state before the timer fires (like joinTournament pattern).
+ * - twoTeamsWarning targets the `.leave-warning--critical` element because both
+ *   warnings use role="alert" (the always-shown destructive one + the critical
+ *   2-teams variant). CSS class is the only stable way to differentiate them.
+ *
  * US #35 locators (detail view — all SSR-rendered, no hydration wait needed):
  *   - heroDescription: `.hero-description` paragraph
  *   - heroMeta: `.hero-meta` spans (format, club, organizer pills)
@@ -136,6 +150,20 @@ export class TournamentDetailPage {
   readonly fixtureSection: Locator;
   readonly fixtureEmptyState: Locator;
 
+  /* ── Leave tournament — US #47 ── */
+  readonly leaveTournamentButton: Locator;
+  readonly leaveDialog: Locator;
+  readonly leaveDialogTitle: Locator;
+  readonly leaveDialogCloseButton: Locator;
+  readonly cancelLeaveButton: Locator;
+  readonly submitLeaveButton: Locator;
+  readonly confirmCheckbox: Locator;
+  readonly reasonTextarea: Locator;
+  readonly twoTeamsWarning: Locator;
+  readonly leaveErrorBanner: Locator;
+  readonly leaveSuccessMessage: Locator;
+  readonly leaveExtraMessage: Locator;
+
   constructor(page: Page, tournamentId: string) {
     this.page = page;
     this.tournamentId = tournamentId;
@@ -206,6 +234,86 @@ export class TournamentDetailPage {
     this.fixtureEmptyState = page
       .locator('.fixture-section')
       .getByText(/el fixture todavia no fue generado/i);
+
+    /* ── US #47 leave-tournament locators ── */
+    // LeaveTournamentButton renders an aria-labelled button: `Retirar equipo ${teamName} del torneo`.
+    // Use the regex on aria-label so we don't depend on the team name (depends on seed).
+    this.leaveTournamentButton = page.getByRole('button', { name: /retirar equipo .* del torneo/i });
+
+    // LeaveTournamentDialog is a role="dialog" labelled by id="leave-dialog-title".
+    this.leaveDialog = page.getByRole('dialog', { name: /retirar equipo del torneo/i });
+    this.leaveDialogTitle = this.leaveDialog.getByRole('heading', {
+      name: /retirar equipo del torneo/i,
+    });
+
+    // Close button (header X) and Cancel footer button.
+    this.leaveDialogCloseButton = this.leaveDialog.getByRole('button', { name: /^cerrar$/i });
+    this.cancelLeaveButton = this.leaveDialog.getByRole('button', { name: /^cancelar$/i });
+
+    // Submit / confirm action: the inner footer button "Retirar equipo" (not the trigger).
+    // Scoped to the dialog so it doesn't clash with the outer trigger button which uses
+    // the same label string ("Retirar equipo" prefix).
+    this.submitLeaveButton = this.leaveDialog.getByRole('button', { name: /^retirar equipo$/i });
+
+    // Confirmation checkbox — only one checkbox in the dialog body.
+    this.confirmCheckbox = this.leaveDialog.getByRole('checkbox');
+
+    // Reason textarea — labelled by <label for="leave-reason">.
+    this.reasonTextarea = page.getByLabel('Motivo del retiro (opcional)');
+
+    // Two-teams warning is the SECOND .leave-warning div (critical variant). The first
+    // warning is the always-shown destructive notice. CSS class fallback is documented
+    // because the warning is not addressable by role+name uniquely (both are role="alert").
+    this.twoTeamsWarning = this.leaveDialog.locator('.leave-warning--critical');
+
+    // Inline error banner inside dialog. Matches the .leave-error <p> with role="alert".
+    this.leaveErrorBanner = this.leaveDialog.locator('.leave-error');
+
+    // Post-success messages live OUTSIDE the dialog (the dialog gets closed by handleSuccess).
+    // .leave-success-msg / .leave-extra-msg are rendered inline where the trigger used to be.
+    this.leaveSuccessMessage = page.locator('.leave-success-msg');
+    this.leaveExtraMessage = page.locator('.leave-extra-msg');
+  }
+
+  /* ── US #47 methods ── */
+
+  /**
+   * Opens the leave-tournament confirmation dialog by clicking the trigger button.
+   *
+   * The button is rendered as part of the SSR HTML but its onClick handler is
+   * attached only after the React `client:load` island hydrates. A single click
+   * fired before hydration is a no-op (native button with no form action), so we
+   * retry the click via expect.toPass() until the dialog appears.
+   */
+  async openLeaveDialog(): Promise<void> {
+    await expect(this.leaveTournamentButton).toBeVisible({ timeout: 15_000 });
+    await expect(async () => {
+      await this.leaveTournamentButton.click({ timeout: 1_000 });
+      await expect(this.leaveDialog).toBeVisible({ timeout: 1_000 });
+    }).toPass({ timeout: 15_000, intervals: [250, 500, 1000] });
+  }
+
+  /** Asserts the leave button is NOT rendered (non-captain / wrong tournament status). */
+  async expectLeaveButtonHidden(): Promise<void> {
+    await expect(
+      this.leaveTournamentButton,
+      'El botón "Retirar equipo" no debe aparecer para este usuario / estado',
+    ).toHaveCount(0);
+  }
+
+  /** Fills the optional motivo textarea. */
+  async fillReason(value: string): Promise<void> {
+    await this.reasonTextarea.fill(value);
+  }
+
+  /** Ticks the mandatory confirmation checkbox (no-op if already ticked). */
+  async tickConfirm(): Promise<void> {
+    await this.confirmCheckbox.check();
+  }
+
+  /** Submits the leave action (caller is responsible for ticking the checkbox first). */
+  async submitLeave(): Promise<void> {
+    await this.submitLeaveButton.click();
   }
 
   async goto(): Promise<void> {

--- a/docs/prompts/b8m4r2nx-prompt-log.md
+++ b/docs/prompts/b8m4r2nx-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-05-19 18:30:00
+- Task ID: b8m4r2nx
+
+## User Prompt
+
+> [Screenshot del issue #47 "Abandonar torneo" en GitHub. User Story: capitán de equipo puede retirar a su equipo de un torneo si no pueden participar. Subtareas: mutation leaveTournament(tournamentId, teamId), validar capitán, solo registration status, eliminar equipo + miembros, actualizar conteo, si in_progress no permitir. Notas: no abandonar en curso, si baja de 2 considerar cancelación.] bien, esta branch quedo pronta ahora vamos a testear la funcionalidad de la screenshot. Crea la nueva branch trae lo nuevo de main y hace estos tests
+
+## Agent Main Actions
+
+- Creé la branch `test/abandonar-torneo-47` desde main actualizado (50 commits integrados) y exploré la feature ya implementada en main: mutation `leaveTournament` (input `{tournamentId, teamId, reason}`, result `{success, message, tournamentStatus, remainingTeams}`), componentes `LeaveTournamentButton.tsx` (visibilidad solo si captain + registration, post-success reload o redirect si CANCELLED) y `LeaveTournamentDialog.tsx` (checkbox obligatorio, motivo opcional max 500, warning crítico si solo 2 equipos), boundary de mutation en `/api/graphql-auth`.
+- Delegué al agente `tester` la spec siguiendo el patrón de `unirse-torneo.spec.ts` (página SSR, mockeo solo de la mutation, seed `SEED_TOURNAMENTS.withCaptainMateo`, multi-auth con `playerMateo`/`playerRicardo`/anon). Entregable: `abandonar-torneo-47.spec.ts` con 14 casos cubriendo visibilidad (3 casos: capitán ve botón, click abre dialog, no-capitán no ve), interacciones del dialog (4: submit disabled, checkbox habilita, maxLength=500, cerrar sin enviar), warning de 2 equipos, 2 happy paths (con `success:true` y con `tournamentStatus:'CANCELLED'`), payload del mutation, 2 error paths (`success:false` y `errors[]`), y seguridad (POST sin auth). PO `TournamentDetailPage` extendido (no nuevo PO) + builders agregados a `support/builders.ts`.
+- Verificado por mí: typecheck verde (3/3 tasks); spec corrida con 17/17 passing (14 specs + 3 auth setups). Sin bugs de producción detectados — el componente respeta todas las garantías de la US.

--- a/docs/prompts/k7m3xq9w-prompt-log.md
+++ b/docs/prompts/k7m3xq9w-prompt-log.md
@@ -1,0 +1,14 @@
+# Prompt Log
+
+- Timestamp: 2026-05-31 12:00:00
+- Task ID: k7m3xq9w
+
+## User Prompt
+
+> Escribí una spec e2e de Playwright para la US #47 "Abandonar torneo" en el repo Sumate Ya. Branch actual: test/abandonar-torneo-47 (desde main actualizado). Cubre visibilidad del botón, interacciones del dialog, happy paths, error paths y seguridad, siguiendo el patrón de unirse-torneo.spec.ts, extendiendo TournamentDetailPage y agregando builders al support.
+
+## Agent Main Actions
+
+- Extendí `TournamentDetailPage` con locators y métodos para US #47 (leaveTournamentButton, leaveDialog, confirmCheckbox, reasonTextarea, twoTeamsWarning, leaveSuccessMessage, leaveExtraMessage, etc.) más `openLeaveDialog`/`expectLeaveButtonHidden`/`fillReason`/`tickConfirm`/`submitLeave` con retry de click vía `expect.toPass()` para resolver la carrera de hidratación de `client:load`.
+- Agregué builders `buildLeaveTournamentResponse`, `buildLeaveTournamentFailure`, `buildLeaveTournamentErrors` y el tipo `MockLeaveTournamentResult` a `support/builders.ts`.
+- Creé `apps/testing/tests/abandonar-torneo-47.spec.ts` con 11 casos (visibilidad/gating, interacciones del dialog, warning de 2 equipos, 3 happy paths con payload assertion, 2 error paths, seguridad raw HTTP) usando `mockGraphQLOperation` y storage states de Mateo/Ricardo. Typecheck 0 errores, 14/14 specs verdes (+3 setup).


### PR DESCRIPTION
Spec abandonar-torneo-47.spec.ts (14 casos) que valida el flujo de retiro de equipo de un torneo en estado registration: visibilidad del boton (solo capitan + torneo en registration), interacciones del dialog (submit disabled hasta tildar checkbox, motivo trunca a 500 chars, cancelar cierra sin enviar), warning critico cuando quedan solo 2 equipos, 2 happy paths (success normal y tournamentStatus=CANCELLED con mensaje extra), payload de la mutation, 2 error paths (success:false y errors[]), y seguridad (POST sin token rechazado).

Extiende TournamentDetailPage con locators y metodos del flujo de retiro (leaveTournamentButton, leaveDialog, confirmCheckbox, reasonTextarea, submitLeaveButton, cancelLeaveButton, openLeaveDialog, etc.). Builders nuevos en support/builders.ts: buildLeaveTournamentResponse, buildLeaveTournamentFailure, buildLeaveTournamentErrors.

Boundary: la pagina /torneos/[id] es SSR (fetch inicial server-side no interceptable), mockeo solo la mutation leaveTournament en /api/graphql-auth. Se apoya en seed real SEED_TOURNAMENTS.withCaptainMateo (Mateo capitan + equipo registrado en torneo en registration). Auth via storage state de playerMateo / playerRicardo / anon. 17/17 passing (14 specs + 3 auth setups), typecheck verde.