### PR TITLE
test(e2e): cubrir carga de resultado de partido

### DIFF
--- a/apps/testing/scripts/seed.ts
+++ b/apps/testing/scripts/seed.ts
@@ -64,6 +64,14 @@ const OPEN_MATCH_FORMAT = '5v5';
 const OPEN_MATCH_DURATION_MIN = 60;
 const OPEN_MATCH_DAYS_AHEAD = 14;
 
+// Tercer partido E3: terminado y con participantes reales. Dedicado al flujo de
+// carga/votacion de resultados para que los specs no dependan de datos historicos.
+const RESULT_VOTING_MATCH_ID = 'e1000000-0000-0000-0000-000000000003';
+const RESULT_VOTING_MATCH_CAPACITY = 10;
+const RESULT_VOTING_MATCH_FORMAT = '5v5';
+const RESULT_VOTING_MATCH_DURATION_MIN = 60;
+const RESULT_VOTING_MATCH_DAYS_AGO = 2;
+
 const CLUB_DASHBOARD_FIXTURE = {
   clubId: 'b2000000-0000-0000-0000-000000000001',
   courtId: 'c2000000-0000-0000-0000-000000000001',
@@ -364,6 +372,83 @@ async function ensureTestUserNotInOpenMatch(client: SupabaseClient): Promise<voi
   if (error) {
     throw new Error(
       `[seed] No se pudo limpiar la inscripcion del usuario de prueba en E2: ${error.message}`,
+    );
+  }
+}
+
+async function ensureResultVotingMatchFixture(
+  client: SupabaseClient,
+  ricardoId: string,
+): Promise<void> {
+  const { data: club, error: clubError } = await client
+    .from('clubs')
+    .select('id')
+    .order('createdAt', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (clubError) {
+    throw new Error(`[seed] Error consultando clubs (E3): ${clubError.message}`);
+  }
+  if (!club) {
+    throw new Error('[seed] No hay clubes en la DB para crear el partido E3.');
+  }
+
+  const scheduledAt = new Date(
+    Date.now() - RESULT_VOTING_MATCH_DAYS_AGO * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  const { error: upsertError } = await client.from('matches').upsert(
+    {
+      id: RESULT_VOTING_MATCH_ID,
+      organizerId: TEST_USER_ID,
+      clubId: club.id,
+      format: RESULT_VOTING_MATCH_FORMAT,
+      capacity: RESULT_VOTING_MATCH_CAPACITY,
+      scheduledAt,
+      durationMin: RESULT_VOTING_MATCH_DURATION_MIN,
+      status: 'completed',
+      resultStatus: 'pending',
+      resultVotingClosesAt: null,
+      scoreTeamA: null,
+      scoreTeamB: null,
+      winningTeam: null,
+      description: 'Partido E3 (seed E2E) - terminado para cargar resultado.',
+    },
+    { onConflict: 'id' },
+  );
+  if (upsertError) {
+    throw new Error(`[seed] No se pudo crear/ajustar el partido E3: ${upsertError.message}`);
+  }
+
+  // Reset de propuestas/votos para que el primer resultado de la corrida sea reproducible.
+  // Los votos caen por ON DELETE CASCADE desde matchResultSubmissions.
+  const { error: deleteSubmissionsError } = await client
+    .from('matchResultSubmissions')
+    .delete()
+    .eq('matchId', RESULT_VOTING_MATCH_ID);
+  if (deleteSubmissionsError) {
+    throw new Error(
+      `[seed] No se pudieron limpiar submissions del partido E3: ${deleteSubmissionsError.message}`,
+    );
+  }
+
+  const { error: deleteParticipantsError } = await client
+    .from('matchParticipants')
+    .delete()
+    .eq('matchId', RESULT_VOTING_MATCH_ID);
+  if (deleteParticipantsError) {
+    throw new Error(
+      `[seed] No se pudieron limpiar participantes del partido E3: ${deleteParticipantsError.message}`,
+    );
+  }
+
+  const { error: insertParticipantsError } = await client.from('matchParticipants').insert([
+    { matchId: RESULT_VOTING_MATCH_ID, playerId: TEST_USER_ID, team: 'a' },
+    { matchId: RESULT_VOTING_MATCH_ID, playerId: ricardoId, team: 'b' },
+  ]);
+  if (insertParticipantsError) {
+    throw new Error(
+      `[seed] No se pudieron crear participantes del partido E3: ${insertParticipantsError.message}`,
     );
   }
 }
@@ -742,7 +827,7 @@ async function ensureProfileDisplayName(
   }
 }
 
-async function seedPermanentTeams(client: SupabaseClient): Promise<void> {
+async function seedPermanentTeams(client: SupabaseClient, ricardoId: string): Promise<void> {
   /*
    * Permanent teams for issue #137 E2E coverage.
    *
@@ -750,7 +835,6 @@ async function seedPermanentTeams(client: SupabaseClient): Promise<void> {
    * availability, tournament enrollment, config, navbar and non-captain gates.
    * T2: Mateo is a member but captainId=null. Used to verify claimCaptain.
    */
-  const { userId: ricardoId } = await signInTestPlayerRicardo();
   await ensureProfileDisplayName(client, TEST_USER_ID, 'Mateo Duran E2E');
   await ensureProfileDisplayName(client, ricardoId, 'Ricardo E2E');
 
@@ -1212,16 +1296,20 @@ async function ensureFixtureTournament(
 
 async function seed(): Promise<void> {
   const client = buildAdminClient();
+  const { userId: ricardoId } = await signInTestPlayerRicardo();
+  await ensureProfileDisplayName(client, TEST_USER_ID, 'Mateo Duran E2E');
+  await ensureProfileDisplayName(client, ricardoId, 'Ricardo E2E');
   await ensureMatchExists(client);
   await ensureMatchFullWithTestUser(client);
   await ensureOpenMatchExists(client);
   await ensureTestUserNotInOpenMatch(client);
+  await ensureResultVotingMatchFixture(client, ricardoId);
   await seedClubDashboard(client);
   await seedTournaments(client);
-  await seedPermanentTeams(client);
+  await seedPermanentTeams(client, ricardoId);
   // eslint-disable-next-line no-console
   console.log(
-    '[seed] Fixtures listas: E1 lleno, E2 abierto, dashboard club, T1 torneo abierto, T2 torneo con capitan, T3 torneo con fixture, equipos permanentes.',
+    '[seed] Fixtures listas: E1 lleno, E2 abierto, E3 resultado, dashboard club, T1 torneo abierto, T2 torneo con capitan, T3 torneo con fixture, equipos permanentes.',
   );
 }
 

--- a/apps/testing/tests/confirmar-resultado-54.spec.ts
+++ b/apps/testing/tests/confirmar-resultado-54.spec.ts
@@ -1,14 +1,25 @@
-import type { APIRequestContext } from '@playwright/test';
+import path from 'node:path';
+import { createClient } from '@supabase/supabase-js';
+import type { APIRequestContext, Browser } from '@playwright/test';
+import dotenv from 'dotenv';
 import {
+  ACCESS_TOKEN_COOKIE,
   BACKEND_GRAPHQL_URL,
   buildMockSubmission,
   buildMockVoter,
   expect,
+  FRONTEND_URL,
+  gqlPost,
   gqlPostOrThrow,
   loginAndReadToken,
+  SEED_MATCHES,
   test,
   TEST_USERS,
 } from './support';
+import type { MockMatchResultSubmission } from './support';
+
+const BACKEND_ENV_PATH = path.resolve(__dirname, '..', '..', 'backend', '.env');
+dotenv.config({ path: BACKEND_ENV_PATH });
 
 /**
  * Tests E2E — US #54 "Confirmar resultado y actualizar stats" (PR #125).
@@ -93,6 +104,23 @@ async function findEligibleMatch(
   request: APIRequestContext,
   accessToken: string,
 ): Promise<MatchSummary | null> {
+  const seededResultMatch = await gqlPostOrThrow<{ match: MatchSummary | null }>(
+    request,
+    /* GraphQL */ `
+      query GetSeedResultVotingMatch($id: ID!) {
+        match(id: $id) {
+          id status startTime durationMin isCurrentUserJoined
+        }
+      }
+    `,
+    { id: SEED_MATCHES.resultVoting },
+    accessToken,
+  ).then((d) => d.match);
+
+  if (seededResultMatch && isEligibleForResultSection(seededResultMatch)) {
+    return seededResultMatch;
+  }
+
   const ids = await gqlPostOrThrow<{ matches: Array<{ id: string }> }>(
     request,
     /* GraphQL */ `
@@ -116,20 +144,21 @@ async function findEligibleMatch(
       accessToken,
     ).then((d) => d.match);
 
-    if (!detail) continue;
-    if (detail.status === 'CANCELLED') continue;
-    if (detail.isCurrentUserJoined !== true) continue;
-
-    // Aligned with the SSR gate in [id].astro: the result section renders once the match has
-    // ENDED (startTime + durationMin), not merely started. Picking a started-but-not-ended
-    // match would make goto() fail because the section never mounts.
-    const endMs =
-      new Date(detail.startTime).getTime() + (detail.durationMin ?? 60) * 60_000;
-    const ended =
-      detail.status === 'COMPLETED' || Date.now() >= endMs;
-    if (ended) return detail;
+    if (detail && isEligibleForResultSection(detail)) return detail;
   }
   return null;
+}
+
+function isEligibleForResultSection(detail: MatchSummary): boolean {
+  if (detail.status === 'CANCELLED') return false;
+  if (detail.isCurrentUserJoined !== true) return false;
+
+  // Aligned with the SSR gate in [id].astro: the result section renders once the match has
+  // ENDED (startTime + durationMin), not merely started. Picking a started-but-not-ended
+  // match would make goto() fail because the section never mounts.
+  const endMs =
+    new Date(detail.startTime).getTime() + (detail.durationMin ?? 60) * 60_000;
+  return detail.status === 'COMPLETED' || Date.now() >= endMs;
 }
 
 test.describe('US #54 — Confirmar resultado y actualizar stats', () => {
@@ -264,11 +293,265 @@ test.describe('US #54 — Confirmar resultado y actualizar stats', () => {
       await expect(matchResultsSectionPage.loadResultButton).toHaveCount(0);
       await expect(matchResultsSectionPage.proposeAnotherButton).toHaveCount(0);
     });
+
+    test('participante carga el primer resultado: marcador + ganador Equipo A via ProposeMatchResult', async ({
+      matchResultsSectionPage,
+      request,
+      page,
+    }) => {
+      const token = await readTokenFromCookies(page);
+      const match = await findEligibleMatch(request, token);
+      test.skip(!match);
+      if (!match) return;
+
+      await matchResultsSectionPage.mockGetSubmissions({
+        data: { matchResultSubmissions: [] },
+      });
+
+      const proposed = buildMockSubmission({
+        id: 'sub-first-result-a',
+        matchId: match.id,
+        submitter: buildMockVoter({ id: 'mateo', displayName: 'Mateo Duran E2E' }),
+        scoreA: 3,
+        scoreB: 2,
+        winnerTeam: 'A',
+        status: 'PENDING',
+        approveCount: 0,
+        rejectCount: 0,
+        hasUserVoted: false,
+        userVote: null,
+        votes: [],
+      });
+      const { payloads } = await matchResultsSectionPage.mockProposeMatchResult({
+        data: { proposeMatchResult: proposed },
+      });
+
+      await matchResultsSectionPage.goto(match.id);
+      await matchResultsSectionPage.loadResultButton.click();
+      await matchResultsSectionPage.fillResult(3, 2);
+
+      await expect(matchResultsSectionPage.resultSummary).toContainText(/Gana Equipo A/i);
+      await expect(matchResultsSectionPage.submitResultButton).toBeEnabled();
+
+      await matchResultsSectionPage.submitResultButton.click();
+
+      await expect.poll(() => payloads.length, { timeout: 10_000 }).toBe(1);
+      expect(payloads[0]).toMatchObject({
+        variables: {
+          input: {
+            matchId: match.id,
+            scoreA: 3,
+            scoreB: 2,
+            winnerTeam: 'A',
+          },
+        },
+      });
+
+      await matchResultsSectionPage.expectPendingBadge(3, 2);
+      await expect(
+        matchResultsSectionPage.section.getByText(/0 aprobaciones/i),
+      ).toBeVisible();
+      await expect(
+        matchResultsSectionPage.section.getByText(/0 rechazos/i),
+      ).toBeVisible();
+      await expect(matchResultsSectionPage.proposeAnotherButton).toBeVisible();
+    });
+
+    test('deriva empate desde el marcador y envia winnerTeam=DRAW', async ({
+      matchResultsSectionPage,
+      request,
+      page,
+    }) => {
+      const token = await readTokenFromCookies(page);
+      const match = await findEligibleMatch(request, token);
+      test.skip(!match);
+      if (!match) return;
+
+      await matchResultsSectionPage.mockGetSubmissions({
+        data: { matchResultSubmissions: [] },
+      });
+
+      const proposed = buildMockSubmission({
+        id: 'sub-first-result-draw',
+        matchId: match.id,
+        scoreA: 1,
+        scoreB: 1,
+        winnerTeam: 'DRAW',
+        approveCount: 0,
+        rejectCount: 0,
+        votes: [],
+      });
+      const { payloads } = await matchResultsSectionPage.mockProposeMatchResult({
+        data: { proposeMatchResult: proposed },
+      });
+
+      await matchResultsSectionPage.goto(match.id);
+      await matchResultsSectionPage.loadResultButton.click();
+      await matchResultsSectionPage.fillResult(1, 1);
+
+      await expect(matchResultsSectionPage.resultSummary).toContainText(/Empate/i);
+      await matchResultsSectionPage.submitResultButton.click();
+
+      await expect.poll(() => payloads.length, { timeout: 10_000 }).toBe(1);
+      expect(payloads[0]).toMatchObject({
+        variables: {
+          input: {
+            matchId: match.id,
+            scoreA: 1,
+            scoreB: 1,
+            winnerTeam: 'DRAW',
+          },
+        },
+      });
+      await matchResultsSectionPage.expectPendingBadge(1, 1);
+    });
   });
 
   /* ════════════════════════════════════════════════════════════════════
      Bloque 2 — Voto APPROVE / REJECT (mutation contract)
      ════════════════════════════════════════════════════════════════════ */
+  test.describe('Contrato real de carga de resultado', () => {
+    test('proposeMatchResult inserta submission, abre voting y queda visible para otro participante', async ({
+      request,
+      page,
+      browser,
+    }) => {
+      const mateoToken = await readTokenFromCookies(page);
+
+      const created = await gqlPostOrThrow<{
+        proposeMatchResult: MockMatchResultSubmission;
+      }>(
+        request,
+        /* GraphQL */ `
+          mutation ProposeResultE2E($input: ProposeMatchResultInput!) {
+            proposeMatchResult(input: $input) {
+              id
+              matchId
+              submitter { id displayName avatarUrl }
+              scoreA
+              scoreB
+              winnerTeam
+              status
+              approveCount
+              rejectCount
+              hasUserVoted
+              userVote
+              createdAt
+              votes {
+                id
+                voter { id displayName avatarUrl }
+                vote
+                createdAt
+              }
+            }
+          }
+        `,
+        {
+          input: {
+            matchId: SEED_MATCHES.resultVoting,
+            scoreA: 4,
+            scoreB: 1,
+            winnerTeam: 'A',
+          },
+        },
+        mateoToken,
+      ).then((d) => d.proposeMatchResult);
+
+      expect(created).toMatchObject({
+        matchId: SEED_MATCHES.resultVoting,
+        scoreA: 4,
+        scoreB: 1,
+        winnerTeam: 'A',
+        status: 'PENDING',
+        approveCount: 0,
+        rejectCount: 0,
+      });
+
+      const votingState = await readMatchVotingState(SEED_MATCHES.resultVoting);
+      expect(votingState.resultStatus).toBe('voting');
+      expect(votingState.resultVotingClosesAt).toBeTruthy();
+
+      const ricardoToken = await readTokenFromStorageState(
+        browser,
+        TEST_USERS.playerRicardo.storageStatePath,
+      );
+      const visibleToRicardo = await gqlPostOrThrow<{
+        matchResultSubmissions: MockMatchResultSubmission[];
+      }>(
+        request,
+        /* GraphQL */ `
+          query GetResultSubmissionsForOtherParticipant($matchId: ID!) {
+            matchResultSubmissions(matchId: $matchId) {
+              id
+              matchId
+              submitter { id displayName avatarUrl }
+              scoreA
+              scoreB
+              winnerTeam
+              status
+              approveCount
+              rejectCount
+              hasUserVoted
+              userVote
+              createdAt
+              votes {
+                id
+                voter { id displayName avatarUrl }
+                vote
+                createdAt
+              }
+            }
+          }
+        `,
+        { matchId: SEED_MATCHES.resultVoting },
+        ricardoToken,
+      ).then((d) => d.matchResultSubmissions.find((s) => s.id === created.id));
+
+      expect(visibleToRicardo, 'El primer resultado cargado debe mostrarse al otro participante').toBeTruthy();
+      expect(visibleToRicardo).toMatchObject({
+        id: created.id,
+        scoreA: 4,
+        scoreB: 1,
+        winnerTeam: 'A',
+        status: 'PENDING',
+        hasUserVoted: false,
+      });
+    });
+
+    test('un usuario autenticado no participante no puede cargar resultado por API', async ({
+      request,
+      browser,
+    }) => {
+      const clubAdminToken = await readTokenFromStorageState(
+        browser,
+        TEST_USERS.clubAdmin.storageStatePath,
+      );
+
+      const payload = await gqlPost<{ proposeMatchResult: { id: string } }>(
+        request,
+        /* GraphQL */ `
+          mutation ProposeResultAsNonParticipant($input: ProposeMatchResultInput!) {
+            proposeMatchResult(input: $input) { id }
+          }
+        `,
+        {
+          input: {
+            matchId: SEED_MATCHES.resultVoting,
+            scoreA: 2,
+            scoreB: 0,
+            winnerTeam: 'A',
+          },
+        },
+        clubAdminToken,
+      );
+
+      expect(payload.data?.proposeMatchResult).toBeFalsy();
+      expect(payload.errors?.[0]?.message ?? '').toMatch(
+        /solo los participantes del partido pueden proponer resultados/i,
+      );
+    });
+  });
+
   test.describe('Voto APPROVE / REJECT', () => {
     test('click en "Aprobar" envía VoteMatchResult con vote=APPROVE y el submissionId correcto', async ({
       matchResultsSectionPage,
@@ -571,7 +854,7 @@ test.describe('US #54 — Confirmar resultado y actualizar stats', () => {
       const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
       const anon = await ctx.newPage();
       try {
-        await anon.goto(`http://localhost:4321/partidos/${match.id}`);
+        await anon.goto(`${FRONTEND_URL}/partidos/${match.id}`);
         await expect(
           anon.getByRole('heading', { name: /resultado del partido/i, level: 2 }),
         ).toHaveCount(0);
@@ -695,11 +978,52 @@ test.describe('Contrato GraphQL voteMatchResult', () => {
  *   no comparte storage con el browser. Reutilizar la sesión existente
  *   evita un login redundante de 1-2s por test.
  */
+function requiredBackendEnv(name: string): string {
+  const value = process.env[name];
+  expect(value, `${name} debe existir en ${BACKEND_ENV_PATH}`).toBeTruthy();
+  return value as string;
+}
+
+async function readMatchVotingState(matchId: string): Promise<{
+  resultStatus: string | null;
+  resultVotingClosesAt: string | null;
+}> {
+  const admin = createClient(
+    requiredBackendEnv('SUPABASE_URL'),
+    requiredBackendEnv('PRIVATE_SUPABASE_SECRET_KEY'),
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+  const { data, error } = await admin
+    .from('matches')
+    .select('"resultStatus", "resultVotingClosesAt"')
+    .eq('id', matchId)
+    .single();
+
+  expect(error, 'No debe fallar la lectura DB de estado de votacion').toBeNull();
+  expect(data, 'El fixture de partido E3 debe existir').toBeTruthy();
+  return data as { resultStatus: string | null; resultVotingClosesAt: string | null };
+}
+
+async function readTokenFromStorageState(
+  browser: Browser,
+  storageStatePath: string,
+): Promise<string> {
+  const context = await browser.newContext({ storageState: storageStatePath });
+  try {
+    const cookies = await context.cookies(FRONTEND_URL);
+    const token = cookies.find((c) => c.name === ACCESS_TOKEN_COOKIE)?.value;
+    expect(token, `storageState ${storageStatePath} debe tener access token`).toBeTruthy();
+    return token as string;
+  } finally {
+    await context.close();
+  }
+}
+
 async function readTokenFromCookies(
   page: import('@playwright/test').Page,
 ): Promise<string> {
-  const cookies = await page.context().cookies('http://localhost:4321');
-  const token = cookies.find((c) => c.name === 'sumateya-access-token')?.value;
+  const cookies = await page.context().cookies(FRONTEND_URL);
+  const token = cookies.find((c) => c.name === ACCESS_TOKEN_COOKIE)?.value;
   if (token) return token;
   // Fallback defensivo: si por algún motivo la cookie no está, hacemos
   // login real (cubre runs donde auth.setup.ts falló silenciosamente).

--- a/apps/testing/tests/support/constants.ts
+++ b/apps/testing/tests/support/constants.ts
@@ -70,6 +70,8 @@ export const SEED_MATCHES = {
   full: 'e1000000-0000-0000-0000-000000000001',
   /** OPEN match with 0 participants. */
   open: 'e1000000-0000-0000-0000-000000000002',
+  /** COMPLETED match with Mateo + Ricardo, reset for result-submission specs. */
+  resultVoting: 'e1000000-0000-0000-0000-000000000003',
 } as const;
 
 /**

--- a/apps/testing/tests/support/page-objects/MatchResultsSectionPage.ts
+++ b/apps/testing/tests/support/page-objects/MatchResultsSectionPage.ts
@@ -54,6 +54,11 @@ export class MatchResultsSectionPage {
   readonly changeVoteButton: Locator;
   readonly editTeamsButton: Locator;
   readonly saveTeamsButton: Locator;
+  readonly scoreAInput: Locator;
+  readonly scoreBInput: Locator;
+  readonly resultSummary: Locator;
+  readonly submitResultButton: Locator;
+  readonly cancelResultButton: Locator;
   readonly errorMessage: Locator;
 
   constructor(page: Page) {
@@ -79,6 +84,12 @@ export class MatchResultsSectionPage {
     // is CONFIRMED (the component hides the toggle once hasConfirmed).
     this.editTeamsButton = this.section.getByRole('button', { name: /editar equipos/i });
     this.saveTeamsButton = this.section.getByRole('button', { name: /guardar equipos/i });
+    const resultForm = this.section.locator('form', { hasText: /marcador final/i });
+    this.scoreAInput = resultForm.locator('input[type="number"]').nth(0);
+    this.scoreBInput = resultForm.locator('input[type="number"]').nth(1);
+    this.resultSummary = resultForm.getByText(/resultado:/i);
+    this.submitResultButton = resultForm.getByRole('button', { name: /enviar resultado/i });
+    this.cancelResultButton = resultForm.getByRole('button', { name: /cancelar/i });
     /*
      * Vote / fetch errors are rendered as <p class="text-destructive"> right
      * under the heading. We use a relaxed text-class selector because the
@@ -160,6 +171,11 @@ export class MatchResultsSectionPage {
   /** Mocks ProposeMatchResult mutation (used by ProposeResultForm sibling). */
   async mockProposeMatchResult<T>(body: T): Promise<{ payloads: Array<{ variables?: unknown }> }> {
     return this.mockOperation('ProposeMatchResult', body);
+  }
+
+  async fillResult(scoreA: number, scoreB: number): Promise<void> {
+    await this.scoreAInput.fill(String(scoreA));
+    await this.scoreBInput.fill(String(scoreB));
   }
 
   /**


### PR DESCRIPTION
test(e2e): cubrir carga de resultado de partido

- agrega un fixture deterministico de partido finalizado para votacion de resultados
- testea la carga del primer resultado desde la UI con marcador y ganador
- verifica que proposeMatchResult crea una propuesta pendiente y abre la votacion
- asegura que usuarios no participantes no puedan cargar resultados