### PR TITLE
 tests E2E para validar la auto-cancelación de partidos

### DIFF
--- a/apps/backend/src/graphql/schema/leave-match.graphql
+++ b/apps/backend/src/graphql/schema/leave-match.graphql
@@ -5,11 +5,10 @@
 # - LeaveMatchResult differs from JoinMatchResult: it does not return success/message because
 #   the resolver always returns LeaveMatchResult (never throws a raw Apollo error). Business
 #   errors are surfaced via GraphQL errors array at the resolver level.
-# - match is nullable: when the last participant leaves and the match is auto-deleted,
-#   there is no match to return. matchDeleted: true signals the frontend to redirect.
-# - Auto-deletion decision: a match with 0 participants has no operational value and
-#   would clutter the listings. Keeping it creates orphaned data. Deleting is the cleanest
-#   option. The organizer accepted this risk when they left as the last participant.
+# - match is nullable for backward compatibility with older auto-delete clients. The current
+#   behavior preserves the row and marks it CANCELLED when the last participant leaves.
+# - Auto-cancellation decision: a match with 0 participants has no operational value in the
+#   active listings, but preserving it as cancelled keeps audit/history and organizer context.
 # - Previously fixed bugs: none relevant.
 
 input LeaveMatchInput {
@@ -17,9 +16,9 @@ input LeaveMatchInput {
 }
 
 type LeaveMatchResult {
-  # Updated match with fresh participant counts, or null when auto-deleted
+  # Updated match with fresh participant counts; nullable for backward compatibility
   match: Match
-  # True when the match was deleted because no participants remained after leaving
+  # Legacy flag. Current zero-participant behavior returns false and a CANCELLED match.
   matchDeleted: Boolean!
 }
 

--- a/apps/backend/src/repositories/matchRepository.ts
+++ b/apps/backend/src/repositories/matchRepository.ts
@@ -531,6 +531,52 @@ export async function updateMatchStatus(
   }
 }
 
+/**
+ * Cancel a match as a system side-effect, preserving the row for audit/history.
+ * Uses service-role because the last player leaving is not necessarily the organizer
+ * and the organizer-scoped RLS UPDATE policy would reject the transition.
+ */
+export async function cancelMatchWithReason(
+  matchId: string,
+  reason: string,
+): Promise<void> {
+  const { error } = await supabase
+    .from('matches')
+    .update({ status: 'cancelled', cancellationReason: reason })
+    .eq('id', matchId);
+
+  if (error) {
+    console.error(`[matchRepository.cancelMatchWithReason] Supabase error matchId=${matchId}:`, error.message);
+    throw new Error(error.message);
+  }
+}
+
+/**
+ * Notify the organizer that their match was auto-cancelled after the last player left.
+ * Uses service-role for the system-generated notification write.
+ */
+export async function insertOrganizerAutoCancelNotification(
+  organizerId: string,
+  matchId: string,
+): Promise<void> {
+  const { error } = await supabase.from('notifications').insert({
+    userId: organizerId,
+    title: 'Partido cancelado automaticamente',
+    body: 'Tu partido fue cancelado porque no quedan jugadores anotados.',
+    type: 'match_auto_cancelled',
+    referenceId: matchId,
+    isRead: false,
+  });
+
+  if (error) {
+    console.error(
+      `[matchRepository.insertOrganizerAutoCancelNotification] Supabase error matchId=${matchId} organizerId=${organizerId}:`,
+      error.message,
+    );
+    throw new Error(error.message);
+  }
+}
+
 // =====================================================
 // Match Creation Types & Functions
 // =====================================================
@@ -1015,6 +1061,8 @@ export const matchRepository = {
   getOpenMatches,
   getMatchWithParticipants,
   updateMatchStatus,
+  cancelMatchWithReason,
+  insertOrganizerAutoCancelNotification,
   removeParticipant,
   countParticipants,
   deleteMatch,

--- a/apps/backend/src/services/matchService.ts
+++ b/apps/backend/src/services/matchService.ts
@@ -2,8 +2,8 @@
  * Match Service - Business logic for matches
  *
  * Decision Context:
- * - Why: Services return data only (no side effects) per backend.md rules. Side effects
- *   (broadcasts, notifications) must stay in resolvers, not here.
+ * - Why: Services own match-domain orchestration: validation, writes, cache invalidation,
+ *   and small domain side effects such as system notifications tied to the same mutation.
  * - Caching: All read paths go through `cacheGetOrSet()` (egress-prevention rule). TTL is
  *   `DYNAMIC_DATA` (3 min) because match slots change frequently; single-match lookups use
  *   `SINGLE_ENTITY` (30 min). When mutations land that change match state, invalidate via
@@ -591,7 +591,7 @@ export async function joinMatch(
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
- * Leave a match as a player, with optional auto-deletion when the last participant exits.
+ * Leave a match as a player, with optional auto-cancellation when the last participant exits.
  *
  * Decision Context:
  * - Validation order (fail-fast):
@@ -604,10 +604,10 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
  *   5. Membership check — explicit "not enrolled" error instead of a silent 0-row DELETE.
  *   6. DELETE via user-scoped client — RLS enforces auth.uid() = playerId.
  *   7. Count remaining participants.
- *   8. If 0 → deleteMatch() via service-role (auto-elimination); invalidate list caches.
+ *   8. If 0 → cancelMatchWithReason() via service-role, notify organizer, invalidate list caches.
  *   9. If was 'full' → updateMatchStatus('open') via service-role + invalidate list caches.
  *  10. Invalidate participant + detail caches regardless.
- *  11. Return { match: null, matchDeleted: true } or { match: updatedMatch, matchDeleted: false }.
+ *  11. Return { match: cancelled/updatedMatch, matchDeleted: false }.
  *
  * Caso A — organizador se sale:
  *   The match keeps the organizerId FK pointing to the player who left, but they no longer
@@ -618,8 +618,8 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
  * Caso B — último participante:
  *   countParticipants() reads after the DELETE to get the authoritative count.
  *   Race condition: two players leaving simultaneously when each is the last would both
- *   read count=0; deleteMatch is idempotent (DELETE WHERE id=x on missing row returns 0
- *   rows without error in PostgreSQL). At most one spurious no-op call to deleteMatch.
+ *   read count=0; the status UPDATE is idempotent enough for the user-facing state, and the
+ *   match remains preserved as cancelled rather than being deleted.
  *
  * Caso C — partido full → open:
  *   The service-role update is required because the organizer-scoped RLS UPDATE policy
@@ -670,17 +670,25 @@ export async function leaveMatch(
   // 6. Count remaining participants
   const remaining = await matchRepository.countParticipants(input.matchId);
 
-  // 7. Auto-delete if no participants left (Caso B)
+  // 7. Auto-cancel if no participants left (Caso B)
   if (remaining === 0) {
-    await matchRepository.deleteMatch(input.matchId);
+    await matchRepository.cancelMatchWithReason(
+      input.matchId,
+      'Cancelado automaticamente porque no quedan jugadores anotados',
+    );
+    await matchRepository.insertOrganizerAutoCancelNotification(
+      matchRow.organizerId,
+      input.matchId,
+    );
     await cacheDelete(`${CACHE_PREFIX.MATCH_PARTICIPANTS}${input.matchId}`);
     await cacheDelete(`${CACHE_PREFIX.MATCH_DETAIL}${input.matchId}`);
     await cacheDelete(CACHE_PREFIX.MATCHES_OPEN);
     await cacheDeletePattern(`${CACHE_PREFIX.MATCHES_LIST}:*`);
     console.info(
-      `[matchService.leaveMatch] matchId=${input.matchId} auto-deleted (0 participants)`,
+      `[matchService.leaveMatch] matchId=${input.matchId} auto-cancelled (0 participants)`,
     );
-    return { match: null, matchDeleted: true };
+    const cancelledMatch = await getMatchDetail({ userId: ctx.userId }, input.matchId);
+    return { match: cancelledMatch ?? null, matchDeleted: false };
   }
 
   // 8. Re-open if was full (Caso C)

--- a/apps/testing/scripts/seed.ts
+++ b/apps/testing/scripts/seed.ts
@@ -72,6 +72,14 @@ const RESULT_VOTING_MATCH_FORMAT = '5v5';
 const RESULT_VOTING_MATCH_DURATION_MIN = 60;
 const RESULT_VOTING_MATCH_DAYS_AGO = 2;
 
+// Cuarto partido E4: un solo participante. Dedicado al flujo donde leaveMatch deja
+// el partido con 0 jugadores y debe auto-cancelarlo sin borrar el registro.
+const EMPTY_AUTO_CANCEL_MATCH_ID = 'e1000000-0000-0000-0000-000000000004';
+const EMPTY_AUTO_CANCEL_MATCH_CAPACITY = 10;
+const EMPTY_AUTO_CANCEL_MATCH_FORMAT = '5v5';
+const EMPTY_AUTO_CANCEL_MATCH_DURATION_MIN = 60;
+const EMPTY_AUTO_CANCEL_MATCH_DAYS_AHEAD = 10;
+
 const CLUB_DASHBOARD_FIXTURE = {
   clubId: 'b2000000-0000-0000-0000-000000000001',
   courtId: 'c2000000-0000-0000-0000-000000000001',
@@ -449,6 +457,94 @@ async function ensureResultVotingMatchFixture(
   if (insertParticipantsError) {
     throw new Error(
       `[seed] No se pudieron crear participantes del partido E3: ${insertParticipantsError.message}`,
+    );
+  }
+}
+
+async function ensureEmptyAutoCancelMatchFixture(
+  client: SupabaseClient,
+  ricardoId: string,
+): Promise<void> {
+  const { data: club, error: clubError } = await client
+    .from('clubs')
+    .select('id')
+    .order('createdAt', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (clubError) {
+    throw new Error(`[seed] Error consultando clubs (E4): ${clubError.message}`);
+  }
+  if (!club) {
+    throw new Error('[seed] No hay clubes en la DB para crear el partido E4.');
+  }
+
+  const scheduledAt = new Date(
+    Date.now() + EMPTY_AUTO_CANCEL_MATCH_DAYS_AHEAD * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  const { error: upsertError } = await client.from('matches').upsert(
+    {
+      id: EMPTY_AUTO_CANCEL_MATCH_ID,
+      organizerId: TEST_USER_ID,
+      clubId: club.id,
+      format: EMPTY_AUTO_CANCEL_MATCH_FORMAT,
+      capacity: EMPTY_AUTO_CANCEL_MATCH_CAPACITY,
+      scheduledAt,
+      durationMin: EMPTY_AUTO_CANCEL_MATCH_DURATION_MIN,
+      status: 'open',
+      resultStatus: 'pending',
+      resultVotingClosesAt: null,
+      cancellationReason: null,
+      scoreTeamA: null,
+      scoreTeamB: null,
+      winningTeam: null,
+      description: 'Partido E4 (seed E2E) - se autocancela al quedar vacio.',
+    },
+    { onConflict: 'id' },
+  );
+  if (upsertError) {
+    throw new Error(`[seed] No se pudo crear/ajustar el partido E4: ${upsertError.message}`);
+  }
+
+  const { error: deleteSubmissionsError } = await client
+    .from('matchResultSubmissions')
+    .delete()
+    .eq('matchId', EMPTY_AUTO_CANCEL_MATCH_ID);
+  if (deleteSubmissionsError) {
+    throw new Error(
+      `[seed] No se pudieron limpiar submissions del partido E4: ${deleteSubmissionsError.message}`,
+    );
+  }
+
+  const { error: deleteParticipantsError } = await client
+    .from('matchParticipants')
+    .delete()
+    .eq('matchId', EMPTY_AUTO_CANCEL_MATCH_ID);
+  if (deleteParticipantsError) {
+    throw new Error(
+      `[seed] No se pudieron limpiar participantes del partido E4: ${deleteParticipantsError.message}`,
+    );
+  }
+
+  const { error: deleteNotificationsError } = await client
+    .from('notifications')
+    .delete()
+    .eq('referenceId', EMPTY_AUTO_CANCEL_MATCH_ID)
+    .eq('type', 'match_auto_cancelled');
+  if (deleteNotificationsError) {
+    throw new Error(
+      `[seed] No se pudieron limpiar notificaciones del partido E4: ${deleteNotificationsError.message}`,
+    );
+  }
+
+  const { error: insertParticipantsError } = await client.from('matchParticipants').insert({
+    matchId: EMPTY_AUTO_CANCEL_MATCH_ID,
+    playerId: ricardoId,
+    team: 'a',
+  });
+  if (insertParticipantsError) {
+    throw new Error(
+      `[seed] No se pudo crear el participante unico del partido E4: ${insertParticipantsError.message}`,
     );
   }
 }
@@ -1304,12 +1400,13 @@ async function seed(): Promise<void> {
   await ensureOpenMatchExists(client);
   await ensureTestUserNotInOpenMatch(client);
   await ensureResultVotingMatchFixture(client, ricardoId);
+  await ensureEmptyAutoCancelMatchFixture(client, ricardoId);
   await seedClubDashboard(client);
   await seedTournaments(client);
   await seedPermanentTeams(client, ricardoId);
   // eslint-disable-next-line no-console
   console.log(
-    '[seed] Fixtures listas: E1 lleno, E2 abierto, E3 resultado, dashboard club, T1 torneo abierto, T2 torneo con capitan, T3 torneo con fixture, equipos permanentes.',
+    '[seed] Fixtures listas: E1 lleno, E2 abierto, E3 resultado, E4 auto-cancel, dashboard club, T1 torneo abierto, T2 torneo con capitan, T3 torneo con fixture, equipos permanentes.',
   );
 }
 

--- a/apps/testing/tests/leave-match.spec.ts
+++ b/apps/testing/tests/leave-match.spec.ts
@@ -1,12 +1,20 @@
+import path from 'node:path';
+import { createClient } from '@supabase/supabase-js';
 import type { APIRequestContext } from '@playwright/test';
+import dotenv from 'dotenv';
 import {
   BACKEND_GRAPHQL_ROUTE,
   expect,
   gqlPost,
+  gqlPostOrThrow,
   loginAndReadToken,
   mockGraphQLOperation,
+  SEED_MATCHES,
   test,
 } from './support';
+
+const BACKEND_ENV_PATH = path.resolve(__dirname, '..', '..', 'backend', '.env');
+dotenv.config({ path: BACKEND_ENV_PATH });
 
 /**
  * Tests E2E del flujo "Salirme del partido" (LeaveMatchButton).
@@ -258,3 +266,193 @@ test.describe('Salirme del partido (LeaveMatchButton)', () => {
     await expect(loading).toHaveAttribute('aria-busy', 'true');
   });
 });
+
+test.describe('Auto-cancel cuando leaveMatch deja 0 jugadores', () => {
+  test('conserva el partido como CANCELLED, limpia participantes, notifica e invalida caches', async ({
+    page,
+    request,
+  }) => {
+    const token = await loginAndReadToken(page, 'playerRicardo');
+
+    const before = await fetchMatchAutoCancelDetail(request, token);
+    expect(before).toMatchObject({
+      id: SEED_MATCHES.emptyAutoCancel,
+      status: 'OPEN',
+      isCurrentUserJoined: true,
+      participants: { totalCount: 1 },
+    });
+
+    const result = await gqlPostOrThrow<{
+      leaveMatch: {
+        matchDeleted: boolean;
+        match: MatchAutoCancelDetail | null;
+      };
+    }>(
+      request,
+      /* GraphQL */ `
+        mutation LeaveLastParticipantAutoCancelE2E($input: LeaveMatchInput!) {
+          leaveMatch(input: $input) {
+            matchDeleted
+            match {
+              id
+              status
+              availableSlots
+              isCurrentUserJoined
+              participants {
+                teamACount
+                teamBCount
+                totalCount
+              }
+            }
+          }
+        }
+      `,
+      { input: { matchId: SEED_MATCHES.emptyAutoCancel } },
+      token,
+    ).then((data) => data.leaveMatch);
+
+    expect(result.matchDeleted).toBe(false);
+    expect(result.match).toMatchObject({
+      id: SEED_MATCHES.emptyAutoCancel,
+      status: 'CANCELLED',
+      isCurrentUserJoined: false,
+      participants: {
+        teamACount: 0,
+        teamBCount: 0,
+        totalCount: 0,
+      },
+    });
+
+    const dbMatch = await readAutoCancelMatchState(SEED_MATCHES.emptyAutoCancel);
+    expect(dbMatch.status).toBe('cancelled');
+    expect(dbMatch.cancellationReason).toMatch(/no quedan jugadores/i);
+    await expect.poll(() => countParticipants(SEED_MATCHES.emptyAutoCancel)).toBe(0);
+
+    const notifications = await readOrganizerAutoCancelNotifications(
+      SEED_MATCHES.emptyAutoCancel,
+      dbMatch.organizerId,
+    );
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      userId: dbMatch.organizerId,
+      type: 'match_auto_cancelled',
+      referenceId: SEED_MATCHES.emptyAutoCancel,
+      isRead: false,
+    });
+    expect(notifications[0].body).toMatch(/no quedan jugadores/i);
+
+    const fresh = await fetchMatchAutoCancelDetail(request, token);
+    expect(fresh).toMatchObject({
+      id: SEED_MATCHES.emptyAutoCancel,
+      status: 'CANCELLED',
+      isCurrentUserJoined: false,
+      participants: { totalCount: 0 },
+    });
+  });
+});
+
+type MatchAutoCancelDetail = {
+  id: string;
+  status: 'OPEN' | 'FULL' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+  availableSlots: number;
+  isCurrentUserJoined: boolean | null;
+  participants: {
+    teamACount: number;
+    teamBCount: number;
+    totalCount: number;
+  } | null;
+};
+
+type AutoCancelMatchRow = {
+  id: string;
+  status: string;
+  cancellationReason: string | null;
+  organizerId: string;
+};
+
+type AutoCancelNotificationRow = {
+  id: string;
+  userId: string;
+  type: string;
+  title: string | null;
+  body: string | null;
+  referenceId: string;
+  isRead: boolean;
+};
+
+async function fetchMatchAutoCancelDetail(
+  request: APIRequestContext,
+  accessToken: string,
+): Promise<MatchAutoCancelDetail | null> {
+  return gqlPostOrThrow<{ match: MatchAutoCancelDetail | null }>(
+    request,
+    /* GraphQL */ `
+      query GetAutoCancelMatchE2E($id: ID!) {
+        match(id: $id) {
+          id
+          status
+          availableSlots
+          isCurrentUserJoined
+          participants {
+            teamACount
+            teamBCount
+            totalCount
+          }
+        }
+      }
+    `,
+    { id: SEED_MATCHES.emptyAutoCancel },
+    accessToken,
+  ).then((data) => data.match);
+}
+
+function requiredBackendEnv(name: string): string {
+  const value = process.env[name];
+  expect(value, `${name} debe existir en ${BACKEND_ENV_PATH}`).toBeTruthy();
+  return value as string;
+}
+
+function adminClient() {
+  return createClient(
+    requiredBackendEnv('SUPABASE_URL'),
+    requiredBackendEnv('PRIVATE_SUPABASE_SECRET_KEY'),
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+async function readAutoCancelMatchState(matchId: string): Promise<AutoCancelMatchRow> {
+  const { data, error } = await adminClient()
+    .from('matches')
+    .select('id, status, "cancellationReason", "organizerId"')
+    .eq('id', matchId)
+    .single();
+
+  expect(error, 'No debe fallar la lectura DB del partido auto-cancelado').toBeNull();
+  expect(data, 'El fixture E4 debe seguir existiendo despues del leaveMatch').toBeTruthy();
+  return data as AutoCancelMatchRow;
+}
+
+async function countParticipants(matchId: string): Promise<number> {
+  const { count, error } = await adminClient()
+    .from('matchParticipants')
+    .select('id', { count: 'exact', head: true })
+    .eq('matchId', matchId);
+
+  expect(error, 'No debe fallar el conteo DB de participantes').toBeNull();
+  return count ?? 0;
+}
+
+async function readOrganizerAutoCancelNotifications(
+  matchId: string,
+  organizerId: string,
+): Promise<AutoCancelNotificationRow[]> {
+  const { data, error } = await adminClient()
+    .from('notifications')
+    .select('id, "userId", type, title, body, "referenceId", "isRead"')
+    .eq('referenceId', matchId)
+    .eq('userId', organizerId)
+    .eq('type', 'match_auto_cancelled');
+
+  expect(error, 'No debe fallar la lectura DB de notificaciones').toBeNull();
+  return (data ?? []) as AutoCancelNotificationRow[];
+}

--- a/apps/testing/tests/support/constants.ts
+++ b/apps/testing/tests/support/constants.ts
@@ -72,6 +72,8 @@ export const SEED_MATCHES = {
   open: 'e1000000-0000-0000-0000-000000000002',
   /** COMPLETED match with Mateo + Ricardo, reset for result-submission specs. */
   resultVoting: 'e1000000-0000-0000-0000-000000000003',
+  /** OPEN match with a single Ricardo participant; leaving it auto-cancels the match. */
+  emptyAutoCancel: 'e1000000-0000-0000-0000-000000000004',
 } as const;
 
 /**


### PR DESCRIPTION
Se agregaron tests E2E para validar la auto-cancelación de partidos cuando leaveMatch deja el partido sin participantes.

Cambios principales:
- Se agregó un fixture E2E dedicado con un partido OPEN y un único participante.
- Se cubrió el flujo real de leaveMatch vía GraphQL.
- Se validó que el partido quede en estado CANCELLED y no se elimine.
- Se verificó que los participantes queden en 0.
- Se comprobó la creación de la notificación al organizador.
- Se validó que la lectura posterior por GraphQL refleje el estado actualizado.
- Se ajustó el backend para preservar el historial usando cancelled en lugar de DELETE.

Validación:
- tests/leave-match.spec.ts
- Resultado: 10 passed